### PR TITLE
chore: attribute MCP calls to SDK [DX-197]

### DIFF
--- a/src/config/contentful.ts
+++ b/src/config/contentful.ts
@@ -1,5 +1,6 @@
 import { ClientOptions } from 'contentful-management';
 import { env } from '../config/env.js';
+import { getVersion } from '../utils/getVersion.js';
 
 /**
  * Creates a default Contentful client configuration without actually initializing it.
@@ -14,7 +15,7 @@ export function getDefaultClientConfig(): ClientOptions {
     host: env.data.CONTENTFUL_HOST,
     space: env.data.SPACE_ID,
     headers: {
-      'X-Contentful-User-Agent-Tool': 'contentful-mcp/0.0.1', //Include user agent header for telemetry tracking
+      'X-Contentful-User-Agent-Tool': `contentful-mcp/${getVersion()}`, //Include user agent header for telemetry tracking
     },
   };
 

--- a/src/utils/getVersion.ts
+++ b/src/utils/getVersion.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+export const getVersion = () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const packageJsonPath = join(__dirname, '../../package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  return packageJson.version;
+};


### PR DESCRIPTION
## Summary

https://contentful.atlassian.net/browse/DX-197
This PR introduces a new header that is passed to the client on its configuration. This header will then be included in any subsequent tool calls, allowing telemetry data to be accessed on Splunk.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
