### PR TITLE
fix: node_env check to import mcps_logger now opt in [DX-300]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { registerAllResources } from './resources/register.js';
 import { registerAllTools } from './tools/register.js';
 import { VERSION } from './config/version.js';
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV === 'development') {
   import('mcps-logger/console');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,11 @@ import { registerAllTools } from './tools/register.js';
 import { VERSION } from './config/version.js';
 
 if (process.env.NODE_ENV === 'development') {
-  import('mcps-logger/console');
+  try {
+    await import('mcps-logger/console');
+  } catch {
+    console.warn('mcps-logger not available in production environment');
+  }
 }
 
 const MCP_SERVER_NAME = '@contentful/mcp-server';


### PR DESCRIPTION
https://contentful.atlassian.net/browse/DX-300

## Summary

This PR introduces a small change to fix an initialization bug that the server would experience when attempting to spin up through the npm package when NODE_ENV was not set to 'production'.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
