### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/scripts/update-licenses.js
+++ b/scripts/update-licenses.js
@@ -213,9 +213,17 @@ async function updateNoticeFile(runtimePackages, devPackages) {
   const formatPackages = (packages) => {
     return packages
       .map((pkg) => {
-        const url = pkg.repository.includes('npmjs.com')
-          ? pkg.repository
-          : `https://www.npmjs.com/package/${pkg.name}`;
+        let url;
+        try {
+          const parsedUrl = new URL(pkg.repository);
+          if (parsedUrl.host === 'npmjs.com' || parsedUrl.host.endsWith('.npmjs.com')) {
+            url = pkg.repository;
+          } else {
+            url = `https://www.npmjs.com/package/${pkg.name}`;
+          }
+        } catch (err) {
+          url = `https://www.npmjs.com/package/${pkg.name}`;
+        }
 
         return `${pkg.name}
     License: ${pkg.license}


### PR DESCRIPTION
Potential fix for [https://github.com/contentful/contentful-mcp-server/security/code-scanning/5](https://github.com/contentful/contentful-mcp-server/security/code-scanning/5)

To address the issue, we should parse the URL and perform domain validation using the `host` component of the parsed URL. This ensures that we are explicitly comparing the host of the URL against a whitelist of allowed domains, rather than relying on substring matching. The `new URL()` constructor in JavaScript can be used for robust URL parsing.

Steps to fix:
1. Parse the repository URL using the `new URL()` constructor.
2. Extract the `host` component of the parsed URL.
3. Compare the `host` against the allowed domain `npmjs.com` or its subdomains.

This fix ensures that only URLs with a host of `npmjs.com` or its subdomains (e.g., `www.npmjs.com`) are accepted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
