### PR TITLE
fix: sanitize URLs for NOTICE file

### DIFF
--- a/scripts/update-licenses.js
+++ b/scripts/update-licenses.js
@@ -213,9 +213,17 @@ async function updateNoticeFile(runtimePackages, devPackages) {
   const formatPackages = (packages) => {
     return packages
       .map((pkg) => {
-        const url = pkg.repository.includes('npmjs.com')
-          ? pkg.repository
-          : `https://www.npmjs.com/package/${pkg.name}`;
+        let url;
+        try {
+          const parsedUrl = new URL(pkg.repository);
+          if (parsedUrl.host === 'npmjs.com' || parsedUrl.host.endsWith('.npmjs.com')) {
+            url = pkg.repository;
+          } else {
+            url = `https://www.npmjs.com/package/${pkg.name}`;
+          }
+        } catch (err) {
+          url = `https://www.npmjs.com/package/${pkg.name}`;
+        }
 
         return `${pkg.name}
     License: ${pkg.license}


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
JIRA: [DX-301](https://github.com/contentful/contentful-mcp-server/pull/78)
Fix code scan alert for URL sanitization

## Description

<!-- Describe your changes in detail -->

Current implementation causes a code scan alert with high severity. This fix checks that the host is a known & safe url.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes


[DX-301]: https://contentful.atlassian.net/browse/DX-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ