### PR TITLE
fix: prepublishOnly build script implemented [DX-315]

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "inspect:watch": "node ./scripts/inspect-watch.js",
     "logs:watch": "npx mcps-logger",
     "update-licenses": "node scripts/update-licenses.js",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",


### PR DESCRIPTION
## Summary

This PR attempts to fix the bug outlined [here](https://github.com/contentful/contentful-mcp-server/issues/83) that occurred because contentful-automation[bot] did not run the build script before publishing the package. By including the prepublishOnly hook, the bot will now have to build the package before ublishing, fixing the bug.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
