### PR TITLE
feat: add start tool for space to space migration workflow [DX-328]

### DIFF
--- a/src/tools/context/instructions.ts
+++ b/src/tools/context/instructions.ts
@@ -55,6 +55,9 @@ export const MCP_INSTRUCTIONS = `You are a helpful assistant integrated with Con
 - Use transform_image for AI-powered image operations
 - Always verify entry existence before attempting to modify it
 
+# Migration Strategies
+- Use the space_to_space migration workflow to help a user when they want to migrate content from one space to another. Start this workflow by calling the start_space_to_space_migration tool.
+- You do not need to fetch content types (ex. list_content_types tool) or entries (ex. search_entries tool) prior to starting the migration workflow. Once the user states they want to start the migration workflow, you simply need to call the start_space_to_space_migration tool.
 
 # Error Handling and Debugging
 

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -8,6 +8,7 @@ import { registerSpaceTools } from './spaces/register.js';
 import { registerTagsTools } from './tags/register.js';
 import { registerAiActionsTools } from './ai-actions/register.js';
 import { registerLocaleTools } from './locales/register.js';
+import { registerWorkflows } from './workflows/register.js';
 
 export function registerAllTools(server: McpServer) {
   registerContextTools(server);
@@ -19,4 +20,6 @@ export function registerAllTools(server: McpServer) {
   registerTagsTools(server);
   registerAiActionsTools(server);
   registerLocaleTools(server);
+
+  registerWorkflows(server);
 }

--- a/src/tools/workflows/register.ts
+++ b/src/tools/workflows/register.ts
@@ -1,0 +1,7 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { registerSpaceToSpaceMigrationTools } from './space-to-space-migration/register.js';
+
+export function registerWorkflows(server: McpServer) {
+  registerSpaceToSpaceMigrationTools(server);
+}

--- a/src/tools/workflows/space-to-space-migration/instructions.ts
+++ b/src/tools/workflows/space-to-space-migration/instructions.ts
@@ -1,0 +1,13 @@
+export const S2S_MIGRATION_INSTRUCTIONS = `
+You are a helpful assistant that can help with space to space migration.
+
+You will be given a list of tools that can be used to migrate a space to another space.
+
+Once the space to space migration workflow is started, you will need to call the tools in the following order:
+
+1. start_space_to_space_migration (already confirmed by the user)
+2. space_to_space_param_collection
+2. export_space 
+3. import_space
+
+`;

--- a/src/tools/workflows/space-to-space-migration/instructions.ts
+++ b/src/tools/workflows/space-to-space-migration/instructions.ts
@@ -7,7 +7,7 @@ Once the space to space migration workflow is started, you will need to call the
 
 1. start_space_to_space_migration (already confirmed by the user)
 2. space_to_space_param_collection
-2. export_space 
-3. import_space
+3. export_space 
+4. import_space
 
 `;

--- a/src/tools/workflows/space-to-space-migration/register.ts
+++ b/src/tools/workflows/space-to-space-migration/register.ts
@@ -1,0 +1,71 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  makeSpaceToSpaceMigrationTool,
+  StartSpaceToSpaceMigrationToolParams,
+} from './startMigration.js';
+import z from 'zod';
+
+export function registerSpaceToSpaceMigrationTools(server: McpServer) {
+  // Placeholder param collection tool
+  const paramCollectionTool = server.tool(
+    'space_to_space_param_collection',
+    'Collect parameters for the space to space migration workflow',
+    z.object({}).shape,
+    () => ({
+      content: [
+        {
+          type: 'text',
+          text: 'param collection tool',
+        },
+      ],
+    }),
+  );
+
+  // Placeholder export space tool
+  const exportSpaceTool = server.tool(
+    'export_space',
+    'Export a space to a file',
+    z.object({}).shape,
+    () => ({
+      content: [
+        {
+          type: 'text',
+          text: 'export tool',
+        },
+      ],
+    }),
+  );
+
+  // Placeholder import space tool
+  const importSpaceTool = server.tool(
+    'import_space',
+    'Import a space from a file',
+    z.object({}).shape,
+    () => ({
+      content: [
+        {
+          type: 'text',
+          text: 'import tool',
+        },
+      ],
+    }),
+  );
+
+  // Disable all tools except the start_space_to_space_migration tool by default
+  paramCollectionTool.disable();
+  importSpaceTool.disable();
+  exportSpaceTool.disable();
+
+  const StartSpaceToSpaceMigrationTool = makeSpaceToSpaceMigrationTool([
+    paramCollectionTool,
+    exportSpaceTool,
+    importSpaceTool,
+  ]);
+
+  server.tool(
+    'start_space_to_space_migration',
+    'Confirmation if the user wants to start the space to space migration workflow',
+    StartSpaceToSpaceMigrationToolParams.shape,
+    StartSpaceToSpaceMigrationTool,
+  );
+}

--- a/src/tools/workflows/space-to-space-migration/startMigration.ts
+++ b/src/tools/workflows/space-to-space-migration/startMigration.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema } from '../../../utils/tools.js';
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { S2S_MIGRATION_INSTRUCTIONS } from './instructions.js';
+
+export const StartSpaceToSpaceMigrationToolParams = BaseToolSchema.extend({
+  startWorkflow: z
+    .boolean()
+    .describe(
+      'Confirmation if the user wants to start the space to space migration workflow',
+    ),
+});
+
+type Params = z.infer<typeof StartSpaceToSpaceMigrationToolParams>;
+
+export const makeSpaceToSpaceMigrationTool = (tools: RegisteredTool[]) => {
+  async function tool(args: Params) {
+    const { startWorkflow } = args;
+
+    tools.forEach((tool) => {
+      tool.enable();
+    });
+
+    return createSuccessResponse('Space to space migration workflow started.', {
+      startWorkflow,
+      instructions: S2S_MIGRATION_INSTRUCTIONS,
+    });
+  }
+
+  return withErrorHandling(
+    tool,
+    'Error starting space to space migration workflow',
+  );
+};


### PR DESCRIPTION
## Summary

Creates the technical foundation for the new space to space migration workflow. Includes placeholder tools to showcase how tools can be enabled/disabled during runtime.

## Description

For a "workflow" we want to have only one tool enabled on initialization of the server. This tool `start_space_to_space_migration` will then enable it's subset of workflow tools when called.