### PR TITLE
feat: add support for default values in content type fields

### DIFF
--- a/src/tools/content-types/createContentType.test.ts
+++ b/src/tools/content-types/createContentType.test.ts
@@ -142,6 +142,81 @@ describe('createContentType', () => {
     });
   });
 
+  it('should create a content type with fields containing defaultValue', async () => {
+    const fieldsWithDefaults = [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+        required: true,
+        localized: false,
+        defaultValue: 'Untitled',
+      },
+      {
+        id: 'published',
+        name: 'Published',
+        type: 'Boolean',
+        required: false,
+        localized: false,
+        defaultValue: false,
+      },
+      {
+        id: 'priority',
+        name: 'Priority',
+        type: 'Integer',
+        required: false,
+        localized: false,
+        defaultValue: 1,
+      },
+    ];
+
+    const testArgs = {
+      ...mockArgs,
+      name: 'Content Type with Defaults',
+      displayField: 'title',
+      description: 'A content type with default values',
+      fields: fieldsWithDefaults,
+    };
+
+    const mockContentTypeWithDefaults = {
+      ...mockContentType,
+      name: 'Content Type with Defaults',
+      fields: fieldsWithDefaults,
+    };
+
+    mockContentTypeCreate.mockResolvedValue(mockContentTypeWithDefaults);
+
+    const result = await createContentTypeTool(testArgs);
+
+    expect(mockContentTypeCreate).toHaveBeenCalledWith(
+      {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      {
+        name: 'Content Type with Defaults',
+        displayField: 'title',
+        description: 'A content type with default values',
+        fields: fieldsWithDefaults,
+      },
+    );
+
+    const expectedResponse = formatResponse(
+      'Content type created successfully',
+      {
+        contentType: mockContentTypeWithDefaults,
+      },
+    );
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
   it('should handle errors when content type creation fails', async () => {
     const testArgs = {
       ...mockArgs,

--- a/src/types/fieldSchema.ts
+++ b/src/types/fieldSchema.ts
@@ -17,6 +17,7 @@ export const FieldSchema = z.object({
     .describe('Whether the field is omitted from the API response'),
   validations: z.array(z.any()).optional().describe('Field validations'),
   settings: z.record(z.any()).optional().describe('Field-specific settings'),
+  defaultValue: z.any().optional().describe('Default value for the field'),
   linkType: z
     .string()
     .optional()


### PR DESCRIPTION
## Summary

Added the ability to specify default values for fields.

## Description

Added `defaultValue` to the FieldSchema, along with a description.
Added a unit test verifying that this works for 3 data types.

## Motivation and Context

This is a capability we need, and also it's a fix for the bug [create_content_type tool fails if "defaultValue" is provided](https://github.com/contentful/contentful-mcp-server/issues/113).
This capability is supported by the SDK, but wasn't supported by the MCP yet.

## PR Checklist

- [X] I have read the `CONTRIBUTING.md` file
- [X] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Documentation is updated (if necessary)
- [X] PR doesn't contain any sensitive information
- [X] There are no breaking changes
