### PR TITLE
fix: update zod arrays with actual schema objects for VSCode compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@contentful/mcp-server",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@contentful/mcp-server",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",
@@ -33,7 +33,7 @@
         "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
         "mcps-logger": "^1.0.0",
-        "nodemon": "^3.1.0",
+        "nodemon": "^3.1.10",
         "nx": "^21.3.5",
         "prettier": "^3.6.2",
         "pretty-quick": "^4.2.2",
@@ -5788,6 +5788,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -5985,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -6255,6 +6257,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -6279,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8337,7 +8341,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -8412,6 +8417,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -9230,6 +9236,7 @@
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
       "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
@@ -9269,6 +9276,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -9278,6 +9286,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9290,6 +9299,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -9302,6 +9312,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10036,7 +10047,8 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10238,6 +10250,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -10823,6 +10836,7 @@
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -11246,6 +11260,7 @@
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
       "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
@@ -11404,7 +11419,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -12041,9 +12057,10 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && tsc",
-    "dev": "nodemon --ext ts --ignore build/ --watch src/ --exec 'npm run build && npm start'",
+    "dev": "npm run clean && tsc --watch",
     "format": "prettier --write .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -55,7 +55,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "husky": "^9.1.7",
     "mcps-logger": "^1.0.0",
-    "nodemon": "^3.1.0",
+    "nodemon": "^3.1.10",
     "nx": "^21.3.5",
     "prettier": "^3.6.2",
     "pretty-quick": "^4.2.2",

--- a/src/tools/ai-actions/createAiAction.ts
+++ b/src/tools/ai-actions/createAiAction.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { VariableType } from '../../utils/ai-actions.js';
+import { AiActionTestCaseSchema } from '../../types/aiActionTestCaseSchema.js';
 
 export const CreateAiActionToolParams = BaseToolSchema.extend({
   name: z.string().describe('The name of the AI action'),
@@ -36,7 +37,7 @@ export const CreateAiActionToolParams = BaseToolSchema.extend({
     })
     .describe('The configuration for the AI action'),
   testCases: z
-    .array(z.any())
+    .array(AiActionTestCaseSchema)
     .optional()
     .describe('Test cases for the AI action'),
 });

--- a/src/tools/ai-actions/updateAiAction.ts
+++ b/src/tools/ai-actions/updateAiAction.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { VariableType } from '../../utils/ai-actions.js';
+import { AiActionTestCaseSchema } from '../../types/aiActionTestCaseSchema.js';
 
 export const UpdateAiActionToolParams = BaseToolSchema.extend({
   aiActionId: z.string().describe('The ID of the AI action to update'),
@@ -42,7 +43,7 @@ export const UpdateAiActionToolParams = BaseToolSchema.extend({
     .optional()
     .describe('The configuration for the AI action'),
   testCases: z
-    .array(z.any())
+    .array(AiActionTestCaseSchema)
     .optional()
     .describe('Test cases for the AI action'),
 });

--- a/src/tools/content-types/updateContentType.ts
+++ b/src/tools/content-types/updateContentType.ts
@@ -5,8 +5,7 @@ import {
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { FieldSchema } from '../../types/fieldSchema.js';
-
-type FieldType = z.infer<typeof FieldSchema>;
+import { ContentFields } from 'contentful-management';
 
 export const UpdateContentTypeToolParams = BaseToolSchema.extend({
   contentTypeId: z.string().describe('The ID of the content type to update'),
@@ -47,7 +46,7 @@ async function tool(args: Params) {
   // If fields are provided, ensure we're not removing any required field metadata
   if (args.fields) {
     const existingFieldsMap = currentContentType.fields.reduce(
-      (acc: Record<string, FieldType>, field: FieldType) => {
+      (acc: Record<string, ContentFields>, field: ContentFields) => {
         acc[field.id] = field;
         return acc;
       },
@@ -55,7 +54,7 @@ async function tool(args: Params) {
     );
 
     // Ensure each field has all required metadata
-    fields.forEach((field: FieldType) => {
+    fields.forEach((field: ContentFields) => {
       const existingField = existingFieldsMap[field.id];
       if (existingField) {
         // Preserve validations if not explicitly changed

--- a/src/types/aiActionTestCaseSchema.ts
+++ b/src/types/aiActionTestCaseSchema.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+/**
+ * Zod schemas for AI Action Test Cases
+ *
+ * These schemas mirror the `AiActionTestCase` type from contentful-management
+ * (see node_modules/contentful-management/dist/typings/entities/ai-action.d.ts)
+ *
+ * AI Action Test Cases are used to provide sample inputs for testing AI Actions
+ * in Contentful. They can be either simple text inputs or references to existing
+ * content entries that serve as examples for the AI Action.
+ */
+
+/**
+ * Schema for text-based test cases
+ *
+ * Represents a simple text input that can be used to test an AI Action.
+ * This is typically used for straightforward prompts or instructions
+ * that don't require complex structured data.
+ */
+const TextTestCase = z.object({
+  type: z.literal('Text').optional(),
+  value: z.string().optional(),
+});
+
+/**
+ * Schema for reference-based test cases
+ *
+ * Represents a test case that references an existing Contentful entry.
+ * This is used when the AI Action needs to process structured content
+ * or when testing with real-world examples from the content model.
+ *
+ * The reference includes:
+ * - entityPath: The path to access specific fields within the entry
+ * - entityType: The type of entity (currently only 'Entry' is supported)
+ * - entityId: The unique identifier of the referenced entry
+ */
+const ReferenceTestCase = z.object({
+  type: z.literal('Reference').optional(),
+  value: z
+    .object({
+      entityPath: z.string().optional(),
+      entityType: z.literal('Entry').optional(),
+      entityId: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Main schema for AI Action Test Cases
+ *
+ * This union type represents all possible test case formats for AI Actions.
+ * It's used in the AI Action definition to provide sample inputs that can
+ * be used to test the AI Action's functionality directly in the Contentful UI
+ * or through the API.
+ *
+ * Test cases help content creators understand how the AI Action works and
+ * provide developers with a way to test the AI Action's behavior with
+ * representative examples.
+ */
+export const AiActionTestCaseSchema = z.union([
+  TextTestCase,
+  ReferenceTestCase,
+]);
+
+/**
+ * Type derived from the AiActionTestCaseSchema
+ *
+ * Used for typing variables and parameters throughout the application when
+ * working with AI Action test cases. This type ensures that all test cases
+ * conform to either the text or reference format required by the Contentful API.
+ */
+export type AiActionTestCase = z.infer<typeof AiActionTestCaseSchema>;

--- a/src/types/contentTypeFieldValidationSchema.ts
+++ b/src/types/contentTypeFieldValidationSchema.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+import { INLINES, BLOCKS } from '@contentful/rich-text-types';
+
+/**
+ * Zod schemas for Content Type Field Validation
+ *
+ * These schemas mirror the `ContentTypeFieldValidation` from contentful-management
+ * (see node_modules/contentful-management/dist/typings/entities/content-type-fields.d.ts)
+ *
+ * They define the validation rules that can be applied to content type fields
+ * in Contentful, such as size limits, allowed content types for references,
+ * date ranges, regular expressions, etc.
+ */
+
+/**
+ * Schema for numeric range validation
+ * Used to validate numeric fields with minimum and maximum constraints
+ */
+const NumRange = z.object({
+  min: z.number().optional(),
+  max: z.number().optional(),
+});
+
+/**
+ * Schema for date range validation
+ * Used to validate date fields with minimum and maximum date constraints
+ */
+const DateRange = z.object({
+  min: z.string().optional(),
+  max: z.string().optional(),
+});
+
+/**
+ * Schema for regular expression validation
+ * Defines a pattern and flags for validating text with regular expressions
+ */
+const RegExpSchema = z.object({
+  pattern: z.string(),
+  flags: z.string(),
+});
+
+/**
+ * Schema for validating image dimensions in assets
+ * Allows specifying width and height constraints
+ */
+const AssetImageDimensions = z.object({
+  width: NumRange.optional(),
+  height: NumRange.optional(),
+});
+
+/**
+ * Schema for external resource references
+ * Used for linking to resources outside of Contentful
+ */
+export const ExternalResource = z.object({
+  type: z.string(),
+});
+
+/**
+ * Schema for Contentful entry resources
+ * Used for linking to specific content types within Contentful
+ */
+export const ContentfulEntryResource = z.object({
+  type: z.literal('Contentful:Entry'),
+  source: z.string(),
+  contentTypes: z.array(z.string()),
+});
+
+/**
+ * Union of allowed resource types for content linking
+ * Can be either Contentful entries or external resources
+ */
+export const ContentTypeAllowedResources = z.union([
+  ContentfulEntryResource,
+  ExternalResource,
+]);
+
+/**
+ * Schema for validating nodes in rich text fields
+ * Defines validations for embedded entries, assets, and other node types
+ */
+const NodesValidation = z.record(
+  z
+    .array(
+      z.object({
+        // subset of ContentTypeFieldValidation used for node validations
+        size: NumRange.optional(),
+        linkContentType: z.array(z.string()).optional(),
+        message: z.string().nullable().optional(),
+      }),
+    )
+    .or(
+      z.object({
+        validations: z.array(
+          z.object({
+            size: NumRange.optional(),
+            message: z.string().nullable().optional(),
+          }),
+        ),
+        allowedResources: z.array(ContentTypeAllowedResources),
+      }),
+    ),
+);
+
+/**
+ * Main schema for content type field validation
+ *
+ * This comprehensive schema defines all possible validation rules that can be
+ * applied to content type fields in Contentful, including:
+ * - Link validations (content types, MIME types)
+ * - Value constraints (allowed values, size limits, ranges)
+ * - Text validations (regular expressions)
+ * - Rich text validations (allowed node types, marks)
+ * - Asset validations (file size, image dimensions)
+ * - Custom error messages
+ */
+export const ContentTypeFieldValidationSchema = z.object({
+  linkContentType: z.array(z.string()).optional(),
+  in: z.array(z.union([z.string(), z.number()])).optional(),
+  linkMimetypeGroup: z.array(z.string()).optional(),
+  enabledNodeTypes: z
+    .array(z.union([z.nativeEnum(BLOCKS), z.nativeEnum(INLINES)]))
+    .optional(),
+  enabledMarks: z.array(z.string()).optional(),
+  unique: z.boolean().optional(),
+  size: NumRange.optional(),
+  range: NumRange.optional(),
+  dateRange: DateRange.optional(),
+  regexp: RegExpSchema.optional(),
+  message: z.string().nullable().optional(),
+  prohibitRegexp: RegExpSchema.optional(),
+  assetImageDimensions: AssetImageDimensions.optional(),
+  assetFileSize: NumRange.optional(),
+  nodes: NodesValidation.optional(),
+});
+
+/**
+ * Type derived from the ContentTypeFieldValidationSchema
+ * Used for typing variables and parameters throughout the application
+ */
+export type ContentTypeFieldValidation = z.infer<
+  typeof ContentTypeFieldValidationSchema
+>;

--- a/src/types/fieldSchema.ts
+++ b/src/types/fieldSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-
+import { ContentTypeFieldValidationSchema } from './contentTypeFieldValidationSchema.js';
 export const FieldSchema = z.object({
   id: z.string().describe('The field ID'),
   name: z.string().describe('The field name'),
@@ -15,7 +15,10 @@ export const FieldSchema = z.object({
     .boolean()
     .optional()
     .describe('Whether the field is omitted from the API response'),
-  validations: z.array(z.any()).optional().describe('Field validations'),
+  validations: z
+    .array(ContentTypeFieldValidationSchema)
+    .optional()
+    .describe('Field validations'),
   settings: z.record(z.any()).optional().describe('Field-specific settings'),
   defaultValue: z.any().optional().describe('Default value for the field'),
   linkType: z
@@ -26,7 +29,7 @@ export const FieldSchema = z.object({
     .object({
       type: z.string(),
       linkType: z.string().optional(),
-      validations: z.array(z.any()).optional(),
+      validations: z.array(ContentTypeFieldValidationSchema).optional(),
     })
     .optional()
     .describe('Items configuration for Array fields'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "sourceMap": true,
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
This PR implements changes to improve VS Code compatibility.

As reported in #120, the MCP server had issues running in VSCode.

The issue turned out being that VSCode requires that, when defining schemas, that arrays have their types defined. There were a few instances where arrays where typed as `zod.any()`, which was causing the issue. I updated these arrays by adding new zode schemas that follow the types expected in these arrays and using those instead of the anys.

VSCode as an issue opened up [here](https://github.com/microsoft/vscode/issues/244467) for this problem. Its main.y a problem because other coding agents (Claude Desktop/Cursor/etc..) don't seem to care when the arrays are typed as anys and function without error.

Closes #120 