### PR TITLE
fix: update install to cursor link in README [DX-356]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This MCP server provides a comprehensive set of tools for content management, al
 
 #### One-Click install
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=contentful-mcp&config=eyJjb21tYW5kIjoibnB4IC15IEBjb250ZW50ZnVsL21jcC1zZXJ2ZXIiLCJlbnYiOnsiQ09OVEVOVEZVTF9NQU5BR0VNRU5UX0FDQ0VTU19UT0tFTiI6InlvdXItQ01BLXRva2VuIiwiU1BBQ0VfSUQiOiJ5b3VyLXNwYWNlLWlkIiwiRU5WSVJPTk1FTlRfSUQiOiJtYXN0ZXIiLCJDT05URU5URlVMX0hPU1QiOiJhcGkuY29udGVudGZ1bC5jb20iLCJOT0RFX0VOViI6InByb2R1Y3Rpb24ifX0%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=contentful-mcp&config=eyJjb21tYW5kIjoibnB4IC15IEBjb250ZW50ZnVsL21jcC1zZXJ2ZXIiLCJlbnYiOnsiQ09OVEVOVEZVTF9NQU5BR0VNRU5UX0FDQ0VTU19UT0tFTiI6InlvdXItQ01BLXRva2VuIiwiU1BBQ0VfSUQiOiJ5b3VyLXNwYWNlLWlkIiwiRU5WSVJPTk1FTlRfSUQiOiJtYXN0ZXIiLCJDT05URU5URlVMX0hPU1QiOiJhcGkuY29udGVudGZ1bC5jb20ifX0%3D)
 
 _Note: This requires [Cursor](https://cursor.com/) to be installed. If the link doesn't work, try the manual installation below._
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

Fixed the broken `Install to Cursor` link in the `README`.

## Description

Regenerated the link [here](https://docs.cursor.com/en/tools/developers) using this JSON config:

```
{
  "contentful-mcp": {
    "command": "npx",
    "args": [
      "-y",
      "@contentful/mcp-server"
    ],
    "env": {
      "CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "your-CMA-token",
      "SPACE_ID": "your-space-id",
      "ENVIRONMENT_ID": "master",
      "CONTENTFUL_HOST": "api.contentful.com"
    }
  }
}
```

## Motivation and Context

Fixes broken installation link for users who want to add the MCP server to Cursor and already have Cursor installed.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
