### PR TITLE
chore: implement taxonomy support in content type tools [DX-364]

### DIFF
--- a/src/tools/content-types/createContentType.test.ts
+++ b/src/tools/content-types/createContentType.test.ts
@@ -268,6 +268,78 @@ describe('createContentType', () => {
     });
   });
 
+  it('should create a content type with taxonomy metadata', async () => {
+    const taxonomyMetadata = {
+      taxonomy: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConceptScheme' as const,
+            id: 'test-concept-scheme',
+          },
+          required: false,
+        },
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'test-concept',
+          },
+          required: true,
+        },
+      ],
+    };
+
+    const testArgs = {
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      name: 'Content Type with Taxonomy',
+      displayField: 'title',
+      description: 'A content type with taxonomy concepts',
+      fields: [mockField],
+      metadata: taxonomyMetadata,
+    };
+
+    const mockContentTypeWithTaxonomy = {
+      ...mockContentType,
+      name: 'Content Type with Taxonomy',
+      metadata: taxonomyMetadata,
+    };
+
+    mockContentTypeCreate.mockResolvedValue(mockContentTypeWithTaxonomy);
+
+    const result = await createContentTypeTool(testArgs);
+
+    expect(mockContentTypeCreate).toHaveBeenCalledWith(
+      {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      {
+        name: 'Content Type with Taxonomy',
+        displayField: 'title',
+        description: 'A content type with taxonomy concepts',
+        fields: [mockField],
+        metadata: taxonomyMetadata,
+      },
+    );
+
+    const expectedResponse = formatResponse(
+      'Content type created successfully',
+      {
+        contentType: mockContentTypeWithTaxonomy,
+      },
+    );
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
   it('should handle errors when content type creation fails', async () => {
     const testArgs = {
       spaceId: mockArgs.spaceId,

--- a/src/tools/content-types/createContentType.ts
+++ b/src/tools/content-types/createContentType.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { FieldSchema } from '../../types/fieldSchema.js';
+import { ContentTypeMetadataSchema } from '../../types/taxonomySchema.js';
 
 export const CreateContentTypeToolParams = BaseToolSchema.extend({
   name: z.string().describe('The name of the content type'),
@@ -22,6 +23,7 @@ export const CreateContentTypeToolParams = BaseToolSchema.extend({
   fields: z
     .array(FieldSchema)
     .describe('Array of field definitions for the content type'),
+  metadata: ContentTypeMetadataSchema,
 });
 
 type Params = z.infer<typeof CreateContentTypeToolParams>;
@@ -39,6 +41,7 @@ async function tool(args: Params) {
     displayField: args.displayField,
     description: args.description,
     fields: args.fields,
+    metadata: args.metadata,
   };
 
   // Create the content type with or without ID

--- a/src/tools/content-types/updateContentType.test.ts
+++ b/src/tools/content-types/updateContentType.test.ts
@@ -230,6 +230,73 @@ describe('updateContentType', () => {
     });
   });
 
+  it('should update a content type with taxonomy metadata', async () => {
+    const currentContentType = { ...mockContentType };
+
+    const taxonomyMetadata = {
+      taxonomy: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConceptScheme' as const,
+            id: 'updated-concept-scheme',
+          },
+          required: true,
+        },
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'updated-concept',
+          },
+          required: false,
+        },
+      ],
+    };
+
+    const testArgs = {
+      ...mockArgs,
+      metadata: taxonomyMetadata,
+    };
+
+    const updatedContentType = {
+      ...mockContentType,
+      sys: { ...mockContentType.sys, version: 2 },
+      metadata: taxonomyMetadata,
+    };
+
+    mockContentTypeGet.mockResolvedValue(currentContentType);
+    mockContentTypeUpdate.mockResolvedValue(updatedContentType);
+
+    const result = await updateContentTypeTool(testArgs);
+
+    expect(mockContentTypeUpdate).toHaveBeenCalledWith(
+      {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+        contentTypeId: mockArgs.contentTypeId,
+      },
+      expect.objectContaining({
+        metadata: taxonomyMetadata,
+      }),
+    );
+
+    const expectedResponse = formatResponse(
+      'Content type updated successfully',
+      {
+        contentType: updatedContentType,
+      },
+    );
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
   it('should handle update with no changes (empty args)', async () => {
     const currentContentType = { ...mockContentType };
     const updatedContentType = {

--- a/src/tools/content-types/updateContentType.ts
+++ b/src/tools/content-types/updateContentType.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { FieldSchema } from '../../types/fieldSchema.js';
+import { ContentTypeMetadataSchema } from '../../types/taxonomySchema.js';
 import { ContentFields } from 'contentful-management';
 
 export const UpdateContentTypeToolParams = BaseToolSchema.extend({
@@ -24,6 +25,7 @@ export const UpdateContentTypeToolParams = BaseToolSchema.extend({
     .describe(
       'Array of field definitions for the content type. Will be merged with existing fields.',
     ),
+  metadata: ContentTypeMetadataSchema,
 });
 
 type Params = z.infer<typeof UpdateContentTypeToolParams>;
@@ -93,6 +95,7 @@ async function tool(args: Params) {
     description: args.description || currentContentType.description,
     displayField: args.displayField || currentContentType.displayField,
     fields: fields as typeof currentContentType.fields,
+    metadata: args.metadata || currentContentType.metadata,
   });
 
   return createSuccessResponse('Content type updated successfully', {

--- a/src/types/taxonomySchema.ts
+++ b/src/types/taxonomySchema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+/**
+ * Schema for taxonomy concept validation links
+ * Matches Contentful's TaxonomyConceptValidationLink type
+ */
+export const TaxonomyConceptValidationLinkSchema = z.object({
+  sys: z.object({
+    type: z.literal('Link'),
+    linkType: z.literal('TaxonomyConcept'),
+    id: z.string().describe('The ID of the taxonomy concept'),
+  }),
+  required: z.boolean().optional(),
+});
+
+/**
+ * Schema for taxonomy concept scheme validation links
+ * Matches Contentful's TaxonomyConceptSchemeValidationLink type
+ */
+export const TaxonomyConceptSchemeValidationLinkSchema = z.object({
+  sys: z.object({
+    type: z.literal('Link'),
+    linkType: z.literal('TaxonomyConceptScheme'),
+    id: z.string().describe('The ID of the taxonomy concept scheme'),
+  }),
+  required: z.boolean().optional(),
+});
+
+/**
+ * Union schema for taxonomy validation links
+ * Matches the array type expected by Contentful's ContentTypeMetadata.taxonomy
+ */
+export const TaxonomyValidationLinkSchema = z.union([
+  TaxonomyConceptValidationLinkSchema,
+  TaxonomyConceptSchemeValidationLinkSchema,
+]);
+
+/**
+ * Schema for content type metadata
+ * Matches Contentful's ContentTypeMetadata type structure
+ */
+export const ContentTypeMetadataSchema = z
+  .object({
+    taxonomy: z.array(TaxonomyValidationLinkSchema).optional(),
+  })
+  .optional();


### PR DESCRIPTION
https://contentful.atlassian.net/browse/DX-364

## Summary

This PR introduces taxonomy support in the create_content_type and the update_content_type tools.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
