### PR TITLE
feat(entry): add taxonomy concepts to entries [DX-365]

### DIFF
--- a/src/tools/entries/createEntry.test.ts
+++ b/src/tools/entries/createEntry.test.ts
@@ -86,6 +86,15 @@ describe('createEntry', () => {
           },
         },
       ],
+      concepts: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'test-concept-id',
+          },
+        },
+      ],
     };
 
     const testArgs = {

--- a/src/tools/entries/createEntry.ts
+++ b/src/tools/entries/createEntry.ts
@@ -4,6 +4,7 @@ import {
   withErrorHandling,
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import { EntryMetadataSchema } from '../../types/taxonomySchema.js';
 
 export const CreateEntryToolParams = BaseToolSchema.extend({
   contentTypeId: z
@@ -14,19 +15,7 @@ export const CreateEntryToolParams = BaseToolSchema.extend({
     .describe(
       'The field values for the new entry. Keys should be field IDs and values should be the field content.',
     ),
-  metadata: z
-    .object({
-      tags: z.array(
-        z.object({
-          sys: z.object({
-            type: z.literal('Link'),
-            linkType: z.literal('Tag'),
-            id: z.string(),
-          }),
-        }),
-      ),
-    })
-    .optional(),
+  metadata: EntryMetadataSchema,
 });
 
 type Params = z.infer<typeof CreateEntryToolParams>;
@@ -45,7 +34,7 @@ async function tool(args: Params) {
     },
     {
       fields: args.fields,
-      metadata: args.metadata,
+      ...(args.metadata ? { metadata: args.metadata } : {}),
     },
   );
 

--- a/src/tools/entries/updateEntry.test.ts
+++ b/src/tools/entries/updateEntry.test.ts
@@ -84,6 +84,15 @@ describe('updateEntry', () => {
             },
           },
         ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept-id-123',
+            },
+          },
+        ],
       },
     };
 
@@ -99,6 +108,15 @@ describe('updateEntry', () => {
               type: 'Link' as const,
               linkType: 'Tag' as const,
               id: 'existing-tag-id',
+            },
+          },
+        ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'existing-concept-id',
             },
           },
         ],
@@ -126,6 +144,22 @@ describe('updateEntry', () => {
             },
           },
         ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'existing-concept-id',
+            },
+          },
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept-id-123',
+            },
+          },
+        ],
       },
     };
 
@@ -145,6 +179,51 @@ describe('updateEntry', () => {
         },
       ],
     });
+
+    // Verify that the entry.update was called with the correct merged concepts
+    expect(mockEntryUpdate).toHaveBeenCalledWith(
+      {
+        spaceId: 'test-space-id',
+        environmentId: 'test-environment',
+        entryId: 'test-entry-id',
+      },
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          tags: [
+            {
+              sys: {
+                id: 'existing-tag-id',
+                linkType: 'Tag',
+                type: 'Link',
+              },
+            },
+            {
+              sys: {
+                id: 'new-tag-id',
+                linkType: 'Tag',
+                type: 'Link',
+              },
+            },
+          ],
+          concepts: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'existing-concept-id',
+              },
+            },
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'concept-id-123',
+              },
+            },
+          ],
+        }),
+      }),
+    );
   });
 
   it('should update an entry with empty fields', async () => {

--- a/src/types/taxonomySchema.ts
+++ b/src/types/taxonomySchema.ts
@@ -44,3 +44,32 @@ export const ContentTypeMetadataSchema = z
     taxonomy: z.array(TaxonomyValidationLinkSchema).optional(),
   })
   .optional();
+
+/**
+ * Schema for entry type metadata
+ * Matches Contentful's MetadataProps type structure
+ */
+export const EntryMetadataSchema = z
+  .object({
+    tags: z.array(
+      z.object({
+        sys: z.object({
+          type: z.literal('Link'),
+          linkType: z.literal('Tag'),
+          id: z.string(),
+        }),
+      }),
+    ),
+    concepts: z
+      .array(
+        z.object({
+          sys: z.object({
+            type: z.literal('Link'),
+            linkType: z.literal('TaxonomyConcept'),
+            id: z.string(),
+          }),
+        }),
+      )
+      .optional(),
+  })
+  .optional();


### PR DESCRIPTION
## Summary
[Add ability to add Taxonomy concepts to an entry](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/taxonomy/concepts-on-entries/add-a-concept-to-an-entry/console/js-plain), via create/update methods.


**From API Reference docs: how to add a concept to an entry**

```js
const updatedEntry = await client.entry.update({
    /* space, env, content type, entryID etc */
  },
  {
    sys: entry.sys,
    fields: { /*...*/ },
    metadata: {
      concepts: [{
        sys: {
          type: 'Link',
          linkType: 'TaxonomyConcept',
          id: '<concept_id>'
        }
      }]
    }
  }
);
```


## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
