### PR TITLE
chore: taxonomy concept support for assets [DX-410]

### DIFF
--- a/src/tools/assets/mockClient.ts
+++ b/src/tools/assets/mockClient.ts
@@ -100,6 +100,10 @@ export const mockAsset = {
       },
     },
   },
+  metadata: {
+    tags: [],
+    concepts: [],
+  },
 };
 
 /**
@@ -167,6 +171,60 @@ export const mockProcessedAsset = {
         ...mockAsset.fields.file['en-US'],
         url: 'https://images.ctfassets.net/processed/test-image.jpg',
       },
+    },
+  },
+};
+
+/**
+ * Mock taxonomy concepts for testing
+ */
+export const mockTaxonomyConcepts = {
+  concept1: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'TaxonomyConcept' as const,
+      id: 'concept-1',
+    },
+  },
+  concept2: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'TaxonomyConcept' as const,
+      id: 'concept-2',
+    },
+  },
+  existingConcept: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'TaxonomyConcept' as const,
+      id: 'existing-concept',
+    },
+  },
+};
+
+/**
+ * Mock tags for testing
+ */
+export const mockTags = {
+  tag1: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'Tag' as const,
+      id: 'tag-1',
+    },
+  },
+  tag2: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'Tag' as const,
+      id: 'tag-2',
+    },
+  },
+  existingTag: {
+    sys: {
+      type: 'Link' as const,
+      linkType: 'Tag' as const,
+      id: 'existing-tag',
     },
   },
 };

--- a/src/tools/assets/updateAsset.test.ts
+++ b/src/tools/assets/updateAsset.test.ts
@@ -73,6 +73,7 @@ describe('updateAsset', () => {
         },
         metadata: {
           tags: [],
+          concepts: [],
         },
       },
     );
@@ -94,6 +95,7 @@ describe('updateAsset', () => {
             },
           },
         ],
+        concepts: [],
       },
     };
 
@@ -109,6 +111,7 @@ describe('updateAsset', () => {
             },
           },
         ],
+        concepts: [],
       },
     };
 
@@ -135,6 +138,7 @@ describe('updateAsset', () => {
             },
           },
         ],
+        concepts: [],
       },
     };
 
@@ -163,6 +167,7 @@ describe('updateAsset', () => {
               },
             },
           ],
+          concepts: [],
         },
       }),
     );
@@ -278,6 +283,205 @@ describe('updateAsset', () => {
       expect.objectContaining({
         metadata: {
           tags: [],
+          concepts: [],
+        },
+      }),
+    );
+  });
+
+  it('should update an asset with new taxonomy concepts', async () => {
+    const testArgs = {
+      ...mockArgs,
+      fields: {
+        title: { 'en-US': 'Asset with Concepts' },
+      },
+      metadata: {
+        tags: [],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept-1',
+            },
+          },
+        ],
+      },
+    };
+
+    const assetWithExistingConcepts = {
+      ...mockAsset,
+      metadata: {
+        tags: [],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'existing-concept',
+            },
+          },
+        ],
+      },
+    };
+
+    const updatedAsset = {
+      ...assetWithExistingConcepts,
+      fields: {
+        ...assetWithExistingConcepts.fields,
+        title: { 'en-US': 'Asset with Concepts' },
+      },
+      metadata: {
+        tags: [],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'existing-concept',
+            },
+          },
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept-1',
+            },
+          },
+        ],
+      },
+    };
+
+    mockAssetGet.mockResolvedValue(assetWithExistingConcepts);
+    mockAssetUpdate.mockResolvedValue(updatedAsset);
+
+    await updateAssetTool(testArgs);
+
+    expect(mockAssetUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        metadata: {
+          tags: [],
+          concepts: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'existing-concept',
+              },
+            },
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'concept-1',
+              },
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it('should update an asset with both tags and concepts', async () => {
+    const testArgs = {
+      ...mockArgs,
+      fields: {
+        title: { 'en-US': 'Asset with Tags and Concepts' },
+      },
+      metadata: {
+        tags: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'Tag' as const,
+              id: 'new-tag',
+            },
+          },
+        ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'new-concept',
+            },
+          },
+        ],
+      },
+    };
+
+    const assetWithExistingMetadata = {
+      ...mockAsset,
+      metadata: {
+        tags: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'Tag' as const,
+              id: 'existing-tag',
+            },
+          },
+        ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'existing-concept',
+            },
+          },
+        ],
+      },
+    };
+
+    mockAssetGet.mockResolvedValue(assetWithExistingMetadata);
+    mockAssetUpdate.mockResolvedValue({
+      ...assetWithExistingMetadata,
+      fields: {
+        ...assetWithExistingMetadata.fields,
+        title: { 'en-US': 'Asset with Tags and Concepts' },
+      },
+    });
+
+    await updateAssetTool(testArgs);
+
+    expect(mockAssetUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        metadata: {
+          tags: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'Tag',
+                id: 'existing-tag',
+              },
+            },
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'Tag',
+                id: 'new-tag',
+              },
+            },
+          ],
+          concepts: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'existing-concept',
+              },
+            },
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'new-concept',
+              },
+            },
+          ],
         },
       }),
     );

--- a/src/tools/assets/uploadAsset.test.ts
+++ b/src/tools/assets/uploadAsset.test.ts
@@ -183,4 +183,121 @@ describe('uploadAsset', () => {
       ],
     });
   });
+
+  it('should upload an asset with taxonomy concepts metadata', async () => {
+    const testArgs = {
+      ...mockArgs,
+      title: 'Asset with Concepts',
+      file: mockFile,
+      metadata: {
+        tags: [],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept1',
+            },
+          },
+        ],
+      },
+    };
+
+    mockAssetCreate.mockResolvedValue(mockAsset);
+    mockAssetProcessForAllLocales.mockResolvedValue(mockProcessedAsset);
+
+    await uploadAssetTool(testArgs);
+
+    expect(mockAssetCreate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        metadata: testArgs.metadata,
+      }),
+    );
+  });
+
+  it('should upload an asset with both tags and concepts', async () => {
+    const testArgs = {
+      ...mockArgs,
+      title: 'Asset with Tags and Concepts',
+      file: mockFile,
+      metadata: {
+        tags: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'Tag' as const,
+              id: 'tag1',
+            },
+          },
+        ],
+        concepts: [
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept1',
+            },
+          },
+          {
+            sys: {
+              type: 'Link' as const,
+              linkType: 'TaxonomyConcept' as const,
+              id: 'concept2',
+            },
+          },
+        ],
+      },
+    };
+
+    mockAssetCreate.mockResolvedValue(mockAsset);
+    mockAssetProcessForAllLocales.mockResolvedValue(mockProcessedAsset);
+
+    const result = await uploadAssetTool(testArgs);
+
+    const expectedResponse = formatResponse('Asset uploaded successfully', {
+      asset: mockProcessedAsset,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+
+    expect(mockAssetCreate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        metadata: {
+          tags: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'Tag',
+                id: 'tag1',
+              },
+            },
+          ],
+          concepts: [
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'concept1',
+              },
+            },
+            {
+              sys: {
+                type: 'Link',
+                linkType: 'TaxonomyConcept',
+                id: 'concept2',
+              },
+            },
+          ],
+        },
+      }),
+    );
+  });
 });

--- a/src/tools/assets/uploadAsset.ts
+++ b/src/tools/assets/uploadAsset.ts
@@ -4,6 +4,7 @@ import {
   withErrorHandling,
 } from '../../utils/response.js';
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import { AssetMetadataSchema } from '../../types/taxonomySchema.js';
 
 const FileSchema = z.object({
   fileName: z.string().describe('The name of the file'),
@@ -15,19 +16,7 @@ export const UploadAssetToolParams = BaseToolSchema.extend({
   title: z.string().describe('The title of the asset'),
   description: z.string().optional().describe('The description of the asset'),
   file: FileSchema.describe('The file information for the asset'),
-  metadata: z
-    .object({
-      tags: z.array(
-        z.object({
-          sys: z.object({
-            type: z.literal('Link'),
-            linkType: z.literal('Tag'),
-            id: z.string(),
-          }),
-        }),
-      ),
-    })
-    .optional(),
+  metadata: AssetMetadataSchema,
 });
 
 type Params = z.infer<typeof UploadAssetToolParams>;

--- a/src/types/taxonomySchema.ts
+++ b/src/types/taxonomySchema.ts
@@ -73,3 +73,32 @@ export const EntryMetadataSchema = z
       .optional(),
   })
   .optional();
+
+/**
+ * Schema for asset type metadata
+ * Matches Contentful's asset metadata structure with tags and taxonomy concepts
+ */
+export const AssetMetadataSchema = z
+  .object({
+    tags: z.array(
+      z.object({
+        sys: z.object({
+          type: z.literal('Link'),
+          linkType: z.literal('Tag'),
+          id: z.string(),
+        }),
+      }),
+    ),
+    concepts: z
+      .array(
+        z.object({
+          sys: z.object({
+            type: z.literal('Link'),
+            linkType: z.literal('TaxonomyConcept'),
+            id: z.string(),
+          }),
+        }),
+      )
+      .optional(),
+  })
+  .optional();


### PR DESCRIPTION
https://contentful.atlassian.net/browse/DX-410

## Summary

This PR introduces support for adding taxonomy concepts to assets through the updateAsset tool and the uploadAsset tool.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
