### PR TITLE
feat: taxonomy concept CRUD tools [DX-408]

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -96,51 +96,67 @@ Below is a sample configuration:
 
 ## 🛠️ Available Tools
 
-| Category                  | Tool Name                  | Description                                      |
-| ------------------------- | -------------------------- | ------------------------------------------------ |
-| **Context & Setup**       | `get_initial_context`      | Initialize connection and get usage instructions |
-| **Content Types**         | `list_content_types`       | List all content types                           |
-|                           | `get_content_type`         | Get detailed content type information            |
-|                           | `create_content_type`      | Create new content types                         |
-|                           | `update_content_type`      | Modify existing content types                    |
-|                           | `publish_content_type`     | Publish content type changes                     |
-|                           | `unpublish_content_type`   | Unpublish content types                          |
-|                           | `delete_content_type`      | Remove content types                             |
-| **Entries**               | `search_entries`           | Search and filter entries                        |
-|                           | `get_entry`                | Retrieve specific entries                        |
-|                           | `create_entry`             | Create new content entries                       |
-|                           | `update_entry`             | Modify existing entries                          |
-|                           | `publish_entry`            | Publish entries (single or bulk)                 |
-|                           | `unpublish_entry`          | Unpublish entries (single or bulk)               |
-|                           | `delete_entry`             | Remove entries                                   |
-| **Assets**                | `upload_asset`             | Upload new assets                                |
-|                           | `list_assets`              | List and browse assets                           |
-|                           | `get_asset`                | Retrieve specific assets                         |
-|                           | `update_asset`             | Modify asset metadata                            |
-|                           | `publish_asset`            | Publish assets (single or bulk)                  |
-|                           | `unpublish_asset`          | Unpublish assets (single or bulk)                |
-|                           | `delete_asset`             | Remove assets                                    |
-| **Spaces & Environments** | `list_spaces`              | List available spaces                            |
-|                           | `get_space`                | Get space details                                |
-|                           | `list_environments`        | List environments                                |
-|                           | `create_environment`       | Create new environments                          |
-|                           | `delete_environment`       | Remove environments                              |
-| **Locales**               | `list_locales`             | List all locales in your environment             |
-|                           | `get_locale`               | Retrieve specific locale information             |
-|                           | `create_locale`            | Create new locales for multi-language content    |
-|                           | `update_locale`            | Modify existing locale settings                  |
-|                           | `delete_locale`            | Remove locales from environment                  |
-| **Tags**                  | `list_tags`                | List all tags                                    |
-|                           | `create_tag`               | Create new tags                                  |
-| **AI Actions**            | `create_ai_action`         | Create custom AI-powered workflows               |
-|                           | `invoke_ai_action`         | Invoke an AI action with variables               |
-|                           | `get_ai_action_invocation` | Get AI action invocation details                 |
-|                           | `get_ai_action`            | Retrieve AI action details and configuration     |
-|                           | `list_ai_actions`          | List AI actions in a space                       |
-|                           | `update_ai_action`         | Update existing AI actions                       |
-|                           | `publish_ai_action`        | Publish AI actions for use                       |
-|                           | `unpublish_ai_action`      | Unpublish AI actions                             |
-|                           | `delete_ai_action`         | Remove AI actions                                |
+| Category                  | Tool Name                          | Description                                      |
+| ------------------------- | ---------------------------------- | ------------------------------------------------ |
+| **Context & Setup**       | `get_initial_context`              | Initialize connection and get usage instructions |
+| **Content Types**         | `list_content_types`               | List content types (max 10 per request)          |
+|                           | `get_content_type`                 | Get detailed content type information            |
+|                           | `create_content_type`              | Create new content types                         |
+|                           | `update_content_type`              | Modify existing content types                    |
+|                           | `publish_content_type`             | Publish content type changes                     |
+|                           | `unpublish_content_type`           | Unpublish content types                          |
+|                           | `delete_content_type`              | Remove content types                             |
+| **Entries**               | `search_entries`                   | Search and filter entries in your space          |
+|                           | `get_entry`                        | Retrieve specific entries                        |
+|                           | `create_entry`                     | Create new content entries with locale support   |
+|                           | `update_entry`                     | Modify existing entries with locale support      |
+|                           | `publish_entry`                    | Publish entries (single or bulk up to 100)       |
+|                           | `unpublish_entry`                  | Unpublish entries (single or bulk up to 100)     |
+|                           | `delete_entry`                     | Remove entries                                   |
+| **Assets**                | `upload_asset`                     | Upload new assets                                |
+|                           | `list_assets`                      | List and browse assets (max 3 per request)       |
+|                           | `get_asset`                        | Retrieve specific assets                         |
+|                           | `update_asset`                     | Modify asset metadata                            |
+|                           | `publish_asset`                    | Publish assets (single or bulk up to 100)        |
+|                           | `unpublish_asset`                  | Unpublish assets (single or bulk up to 100)      |
+|                           | `delete_asset`                     | Remove assets                                    |
+| **Spaces & Environments** | `list_spaces`                      | List available spaces (max 10 per request)       |
+|                           | `get_space`                        | Get space details                                |
+|                           | `list_environments`                | List environments in a space                     |
+|                           | `create_environment`               | Create new environments                          |
+|                           | `delete_environment`               | Remove environments                              |
+| **Locales**               | `list_locales`                     | List all locales in your environment             |
+|                           | `get_locale`                       | Retrieve specific locale information             |
+|                           | `create_locale`                    | Create new locales for multi-language content    |
+|                           | `update_locale`                    | Modify existing locale settings                  |
+|                           | `delete_locale`                    | Remove locales from environment                  |
+| **Tags**                  | `list_tags`                        | List all tags in an environment                  |
+|                           | `create_tag`                       | Create new tags with public/private visibility   |
+| **Organizations**         | `list_orgs`                        | List organizations user has access to            |
+|                           | `get_org`                          | Get details of a specific organization           |
+| **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
+|                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
+|                           | `get_ai_action_invocation`         | Get AI action invocation details                 |
+|                           | `get_ai_action`                    | Retrieve AI action details and configuration     |
+|                           | `list_ai_actions`                  | List AI actions in a space (max 3 per request)   |
+|                           | `update_ai_action`                 | Update existing AI actions                       |
+|                           | `publish_ai_action`                | Publish AI actions for use                       |
+|                           | `unpublish_ai_action`              | Unpublish AI actions                             |
+|                           | `delete_ai_action`                 | Remove AI actions                                |
+| **Taxonomy Concepts**     | `create_concept`                   | Create new taxonomy concepts with localization   |
+|                           | `get_concept`                      | Retrieve specific taxonomy concept               |
+|                           | `list_concepts`                    | List concepts with filtering and hierarchy       |
+|                           | `update_concept`                   | Update taxonomy concept properties               |
+|                           | `delete_concept`                   | Remove taxonomy concepts                         |
+| **Taxonomy Schemes**      | `create_concept_scheme`            | Create new taxonomy concept schemes              |
+|                           | `get_concept_scheme`               | Retrieve specific concept scheme                 |
+|                           | `list_concept_schemes`             | List concept schemes with pagination             |
+|                           | `update_concept_scheme`            | Update concept scheme properties                 |
+|                           | `delete_concept_scheme`            | Remove concept schemes                           |
+| **Space Migration**       | `space_to_space_migration_handler` | Enable/disable space migration workflow          |
+|                           | `space_to_space_param_collection`  | Collect parameters for migration workflow        |
+|                           | `export_space`                     | Export space to file for migration               |
+|                           | `import_space`                     | Import space from exported file                  |
 
 ## 🤝 Contributing
 

--- a/packages/mcp-tools/README.md
+++ b/packages/mcp-tools/README.md
@@ -85,30 +85,30 @@ Each tool includes semantic annotations to help MCP clients understand tool beha
 | Category                  | Tool Name                          | Description                                      |
 | ------------------------- | ---------------------------------- | ------------------------------------------------ |
 | **Context & Setup**       | `get_initial_context`              | Initialize connection and get usage instructions |
-| **Content Types**         | `list_content_types`               | List all content types                           |
+| **Content Types**         | `list_content_types`               | List content types (max 10 per request)          |
 |                           | `get_content_type`                 | Get detailed content type information            |
 |                           | `create_content_type`              | Create new content types                         |
 |                           | `update_content_type`              | Modify existing content types                    |
 |                           | `publish_content_type`             | Publish content type changes                     |
 |                           | `unpublish_content_type`           | Unpublish content types                          |
 |                           | `delete_content_type`              | Remove content types                             |
-| **Entries**               | `search_entries`                   | Search and filter entries                        |
+| **Entries**               | `search_entries`                   | Search and filter entries in your space          |
 |                           | `get_entry`                        | Retrieve specific entries                        |
-|                           | `create_entry`                     | Create new content entries                       |
-|                           | `update_entry`                     | Modify existing entries                          |
-|                           | `publish_entry`                    | Publish entries (single or bulk)                 |
-|                           | `unpublish_entry`                  | Unpublish entries (single or bulk)               |
+|                           | `create_entry`                     | Create new content entries with locale support   |
+|                           | `update_entry`                     | Modify existing entries with locale support      |
+|                           | `publish_entry`                    | Publish entries (single or bulk up to 100)       |
+|                           | `unpublish_entry`                  | Unpublish entries (single or bulk up to 100)     |
 |                           | `delete_entry`                     | Remove entries                                   |
 | **Assets**                | `upload_asset`                     | Upload new assets                                |
-|                           | `list_assets`                      | List and browse assets                           |
+|                           | `list_assets`                      | List and browse assets (max 3 per request)       |
 |                           | `get_asset`                        | Retrieve specific assets                         |
 |                           | `update_asset`                     | Modify asset metadata                            |
-|                           | `publish_asset`                    | Publish assets (single or bulk)                  |
-|                           | `unpublish_asset`                  | Unpublish assets (single or bulk)                |
+|                           | `publish_asset`                    | Publish assets (single or bulk up to 100)        |
+|                           | `unpublish_asset`                  | Unpublish assets (single or bulk up to 100)      |
 |                           | `delete_asset`                     | Remove assets                                    |
-| **Spaces & Environments** | `list_spaces`                      | List available spaces                            |
+| **Spaces & Environments** | `list_spaces`                      | List available spaces (max 10 per request)       |
 |                           | `get_space`                        | Get space details                                |
-|                           | `list_environments`                | List environments                                |
+|                           | `list_environments`                | List environments in a space                     |
 |                           | `create_environment`               | Create new environments                          |
 |                           | `delete_environment`               | Remove environments                              |
 | **Locales**               | `list_locales`                     | List all locales in your environment             |
@@ -116,25 +116,33 @@ Each tool includes semantic annotations to help MCP clients understand tool beha
 |                           | `create_locale`                    | Create new locales for multi-language content    |
 |                           | `update_locale`                    | Modify existing locale settings                  |
 |                           | `delete_locale`                    | Remove locales from environment                  |
-| **Tags**                  | `list_tags`                        | List all tags                                    |
-|                           | `create_tag`                       | Create new tags                                  |
+| **Tags**                  | `list_tags`                        | List all tags in an environment                  |
+|                           | `create_tag`                       | Create new tags with public/private visibility   |
+| **Organizations**         | `list_orgs`                        | List organizations user has access to            |
+|                           | `get_org`                          | Get details of a specific organization           |
 | **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
-|                           | `invoke_ai_action`                 | Invoke an AI action with variables               |
+|                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
 |                           | `get_ai_action_invocation`         | Get AI action invocation details                 |
 |                           | `get_ai_action`                    | Retrieve AI action details and configuration     |
-|                           | `list_ai_actions`                  | List AI actions in a space                       |
+|                           | `list_ai_actions`                  | List AI actions in a space (max 3 per request)   |
 |                           | `update_ai_action`                 | Update existing AI actions                       |
 |                           | `publish_ai_action`                | Publish AI actions for use                       |
 |                           | `unpublish_ai_action`              | Unpublish AI actions                             |
 |                           | `delete_ai_action`                 | Remove AI actions                                |
-| **Organizations**         | `list_orgs`                        | List all organizations user has access to        |
-|                           | `get_org`                          | Get details of a specific organization           |
-| **Taxonomies**            | `create_concept_scheme`            | Create new taxonomy concept schemes              |
+| **Taxonomy Concepts**     | `create_concept`                   | Create new taxonomy concepts with localization   |
+|                           | `get_concept`                      | Retrieve specific taxonomy concept               |
+|                           | `list_concepts`                    | List concepts with filtering and hierarchy       |
+|                           | `update_concept`                   | Update taxonomy concept properties               |
+|                           | `delete_concept`                   | Remove taxonomy concepts                         |
+| **Taxonomy Schemes**      | `create_concept_scheme`            | Create new taxonomy concept schemes              |
 |                           | `get_concept_scheme`               | Retrieve specific concept scheme                 |
-|                           | `list_concept_schemes`             | List taxonomy concept schemes                    |
-|                           | `update_concept_scheme`            | Update existing concept schemes                  |
+|                           | `list_concept_schemes`             | List concept schemes with pagination             |
+|                           | `update_concept_scheme`            | Update concept scheme properties                 |
 |                           | `delete_concept_scheme`            | Remove concept schemes                           |
-| **Jobs**                  | `space_to_space_migration_handler` | Enable/disable space migration workflow          |
+| **Space Migration**       | `space_to_space_migration_handler` | Enable/disable space migration workflow          |
+|                           | `space_to_space_param_collection`  | Collect parameters for migration workflow        |
+|                           | `export_space`                     | Export space to file for migration               |
+|                           | `import_space`                     | Import space from exported file                  |
 
 ## Configuration
 

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/createConceptScheme.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/createConceptScheme.test.ts
@@ -3,9 +3,10 @@ import {
   testConceptScheme,
   mockConceptSchemeCreate,
   mockConceptSchemeCreateWithId,
+  mockCreateClient,
 } from './mockClient.js';
 import { createConceptSchemeTool } from './createConceptScheme.js';
-import { createToolClient } from '../../../utils/tools.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { formatResponse } from '../../../utils/formatters.js';
 
 describe('createConceptScheme', () => {
@@ -26,9 +27,10 @@ describe('createConceptScheme', () => {
 
     const result = await createConceptSchemeTool(testArgs);
 
-    expect(createToolClient).toHaveBeenCalledWith({
-      spaceId: 'dummy',
-      environmentId: 'dummy',
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
     });
     expect(mockConceptSchemeCreate).toHaveBeenCalledWith(
       {

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/createConceptScheme.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/createConceptScheme.ts
@@ -3,7 +3,8 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { createToolClient } from '../../../utils/tools.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import {
   ConceptSchemePayload,
   TaxonomyConceptLinkSchema,
@@ -58,10 +59,11 @@ export const CreateConceptSchemeToolParams = z.object({
 type Params = z.infer<typeof CreateConceptSchemeToolParams>;
 
 async function tool(args: Params) {
-  const contentfulClient = createToolClient({
-    spaceId: 'dummy', // Not needed for concept scheme creation but required by BaseToolSchema
-    environmentId: 'dummy', // Not needed for concept scheme creation but required by BaseToolSchema
-  });
+  // Create a client without space-specific configuration for concept scheme operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
 
   // Build the concept scheme payload by filtering out undefined values
   const conceptSchemePayload: ConceptSchemePayload = {

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/deleteConceptScheme.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/deleteConceptScheme.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mockConceptSchemeDelete } from './mockClient.js';
+import { mockConceptSchemeDelete, mockCreateClient } from './mockClient.js';
 import { deleteConceptSchemeTool } from './deleteConceptScheme.js';
-import { createToolClient } from '../../../utils/tools.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { formatResponse } from '../../../utils/formatters.js';
 
 describe('deleteConceptScheme', () => {
   beforeEach(() => {
     mockConceptSchemeDelete.mockClear();
+    mockCreateClient.mockClear();
   });
 
   const testArgs = {
@@ -20,9 +21,10 @@ describe('deleteConceptScheme', () => {
 
     const result = await deleteConceptSchemeTool(testArgs);
 
-    expect(createToolClient).toHaveBeenCalledWith({
-      spaceId: 'dummy',
-      environmentId: 'dummy',
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
     });
 
     expect(mockConceptSchemeDelete).toHaveBeenCalledWith({

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/deleteConceptScheme.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/deleteConceptScheme.ts
@@ -3,7 +3,8 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { createToolClient } from '../../../utils/tools.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 
 export const DeleteConceptSchemeToolParams = z.object({
   organizationId: z.string().describe('The ID of the Contentful organization'),
@@ -16,10 +17,11 @@ export const DeleteConceptSchemeToolParams = z.object({
 type Params = z.infer<typeof DeleteConceptSchemeToolParams>;
 
 async function tool(args: Params) {
-  const contentfulClient = createToolClient({
-    spaceId: 'dummy', // Not needed for concept scheme deletion but required by BaseToolSchema
-    environmentId: 'dummy', // Not needed for concept scheme deletion but required by BaseToolSchema
-  });
+  // Create a client without space-specific configuration for concept scheme operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
 
   // Delete the concept scheme
   await contentfulClient.conceptScheme.delete({

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/getConceptScheme.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/getConceptScheme.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { testConceptScheme, mockConceptSchemeGet } from './mockClient.js';
+import {
+  testConceptScheme,
+  mockConceptSchemeGet,
+  mockCreateClient,
+} from './mockClient.js';
 import { getConceptSchemeTool } from './getConceptScheme.js';
-import { createToolClient } from '../../../utils/tools.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { formatResponse } from '../../../utils/formatters.js';
 
 describe('getConceptScheme', () => {
   beforeEach(() => {
     mockConceptSchemeGet.mockClear();
+    mockCreateClient.mockClear();
   });
 
   const testArgs = {
@@ -19,9 +24,10 @@ describe('getConceptScheme', () => {
 
     const result = await getConceptSchemeTool(testArgs);
 
-    expect(createToolClient).toHaveBeenCalledWith({
-      spaceId: 'dummy',
-      environmentId: 'dummy',
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
     });
 
     expect(mockConceptSchemeGet).toHaveBeenCalledWith({

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/getConceptScheme.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/getConceptScheme.ts
@@ -3,7 +3,8 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { createToolClient } from '../../../utils/tools.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 
 export const GetConceptSchemeToolParams = z.object({
   organizationId: z.string().describe('The ID of the Contentful organization'),
@@ -15,10 +16,11 @@ export const GetConceptSchemeToolParams = z.object({
 type Params = z.infer<typeof GetConceptSchemeToolParams>;
 
 async function tool(args: Params) {
-  const contentfulClient = createToolClient({
-    spaceId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-    environmentId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-  });
+  // Create a client without space-specific configuration for concept scheme operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
 
   const params = {
     organizationId: args.organizationId,

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/listConceptSchemes.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/listConceptSchemes.test.ts
@@ -3,9 +3,10 @@ import {
   testConceptScheme1,
   testConceptScheme2,
   mockConceptSchemeGetMany,
+  mockCreateClient,
 } from './mockClient.js';
 import { listConceptSchemesTool } from './listConceptSchemes.js';
-import { createToolClient } from '../../../utils/tools.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 
 const mockConceptSchemesResponse = {
   sys: {
@@ -20,6 +21,7 @@ const mockConceptSchemesResponse = {
 describe('listConceptSchemes', () => {
   beforeEach(() => {
     mockConceptSchemeGetMany.mockClear();
+    mockCreateClient.mockClear();
   });
 
   const testArgs = {
@@ -31,9 +33,10 @@ describe('listConceptSchemes', () => {
 
     const result = await listConceptSchemesTool(testArgs);
 
-    expect(createToolClient).toHaveBeenCalledWith({
-      spaceId: 'dummy',
-      environmentId: 'dummy',
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
     });
 
     expect(mockConceptSchemeGetMany).toHaveBeenCalledWith({

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/listConceptSchemes.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/listConceptSchemes.ts
@@ -3,7 +3,8 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { createToolClient } from '../../../utils/tools.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 
 export const ListConceptSchemesToolParams = z.object({
@@ -30,10 +31,11 @@ export const ListConceptSchemesToolParams = z.object({
 type Params = z.infer<typeof ListConceptSchemesToolParams>;
 
 async function tool(args: Params) {
-  const contentfulClient = createToolClient({
-    spaceId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-    environmentId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-  });
+  // Create a client without space-specific configuration for concept scheme operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
 
   const conceptSchemes = await contentfulClient.conceptScheme.getMany({
     organizationId: args.organizationId,

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/mockClient.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/mockClient.ts
@@ -7,35 +7,41 @@ const {
   mockConceptSchemeGetMany,
   mockConceptSchemeUpdate,
   mockConceptSchemeDelete,
-  mockCreateToolClient,
+  mockCreateClient,
 } = vi.hoisted(() => {
+  const mockConceptSchemeCreate = vi.fn();
+  const mockConceptSchemeCreateWithId = vi.fn();
+  const mockConceptSchemeGet = vi.fn();
+  const mockConceptSchemeGetMany = vi.fn();
+  const mockConceptSchemeUpdate = vi.fn();
+  const mockConceptSchemeDelete = vi.fn();
+  const mockCreateClient = vi.fn(() => ({
+    conceptScheme: {
+      create: mockConceptSchemeCreate,
+      createWithId: mockConceptSchemeCreateWithId,
+      get: mockConceptSchemeGet,
+      getMany: mockConceptSchemeGetMany,
+      update: mockConceptSchemeUpdate,
+      delete: mockConceptSchemeDelete,
+    },
+  }));
   return {
-    mockConceptSchemeCreate: vi.fn(),
-    mockConceptSchemeCreateWithId: vi.fn(),
-    mockConceptSchemeGet: vi.fn(),
-    mockConceptSchemeGetMany: vi.fn(),
-    mockConceptSchemeUpdate: vi.fn(),
-    mockConceptSchemeDelete: vi.fn(),
-    mockCreateToolClient: vi.fn(() => {
-      return {
-        conceptScheme: {
-          create: mockConceptSchemeCreate,
-          createWithId: mockConceptSchemeCreateWithId,
-          get: mockConceptSchemeGet,
-          getMany: mockConceptSchemeGetMany,
-          update: mockConceptSchemeUpdate,
-          delete: mockConceptSchemeDelete,
-        },
-      };
-    }),
+    mockConceptSchemeCreate,
+    mockConceptSchemeCreateWithId,
+    mockConceptSchemeGet,
+    mockConceptSchemeGetMany,
+    mockConceptSchemeUpdate,
+    mockConceptSchemeDelete,
+    mockCreateClient,
   };
 });
 
-vi.mock('../../../utils/tools.js', async (importOriginal) => {
-  const org = await importOriginal<typeof import('../../../utils/tools.js')>();
+vi.mock('contentful-management', () => {
   return {
-    ...org,
-    createToolClient: mockCreateToolClient,
+    default: {
+      createClient: mockCreateClient,
+    },
+    createClient: mockCreateClient,
   };
 });
 
@@ -46,7 +52,7 @@ export {
   mockConceptSchemeGetMany,
   mockConceptSchemeUpdate,
   mockConceptSchemeDelete,
-  mockCreateToolClient,
+  mockCreateClient,
 };
 
 export const testConceptScheme = {

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/register.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/register.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { taxonomyTools } from './register.js';
+import { conceptSchemeTools } from './register.js';
 import {
   createConceptSchemeTool,
   CreateConceptSchemeToolParams,
@@ -21,14 +21,14 @@ import {
   DeleteConceptSchemeToolParams,
 } from './deleteConceptScheme.js';
 
-describe('taxonomy tools collection', () => {
-  it('should export taxonomyTools collection with correct structure', () => {
-    expect(taxonomyTools).toBeDefined();
-    expect(Object.keys(taxonomyTools)).toHaveLength(5);
+describe('concept scheme tools collection', () => {
+  it('should export conceptSchemeTools collection with correct structure', () => {
+    expect(conceptSchemeTools).toBeDefined();
+    expect(Object.keys(conceptSchemeTools)).toHaveLength(5);
   });
 
   it('should have createConceptScheme tool with correct properties', () => {
-    const { createConceptScheme } = taxonomyTools;
+    const { createConceptScheme } = conceptSchemeTools;
 
     expect(createConceptScheme.title).toBe('create_concept_scheme');
     expect(createConceptScheme.description).toBe(
@@ -47,7 +47,7 @@ describe('taxonomy tools collection', () => {
   });
 
   it('should have getConceptScheme tool with correct properties', () => {
-    const { getConceptScheme } = taxonomyTools;
+    const { getConceptScheme } = conceptSchemeTools;
 
     expect(getConceptScheme.title).toBe('get_concept_scheme');
     expect(getConceptScheme.description).toBe(
@@ -64,7 +64,7 @@ describe('taxonomy tools collection', () => {
   });
 
   it('should have listConceptSchemes tool with correct properties', () => {
-    const { listConceptSchemes } = taxonomyTools;
+    const { listConceptSchemes } = conceptSchemeTools;
 
     expect(listConceptSchemes.title).toBe('list_concept_schemes');
     expect(listConceptSchemes.description).toBe(
@@ -81,7 +81,7 @@ describe('taxonomy tools collection', () => {
   });
 
   it('should have updateConceptScheme tool with correct properties', () => {
-    const { updateConceptScheme } = taxonomyTools;
+    const { updateConceptScheme } = conceptSchemeTools;
 
     expect(updateConceptScheme.title).toBe('update_concept_scheme');
     expect(updateConceptScheme.description).toBe(
@@ -100,7 +100,7 @@ describe('taxonomy tools collection', () => {
   });
 
   it('should have deleteConceptScheme tool with correct properties', () => {
-    const { deleteConceptScheme } = taxonomyTools;
+    const { deleteConceptScheme } = conceptSchemeTools;
 
     expect(deleteConceptScheme.title).toBe('delete_concept_scheme');
     expect(deleteConceptScheme.description).toBe(

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/register.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/register.ts
@@ -19,7 +19,7 @@ import {
   DeleteConceptSchemeToolParams,
 } from './deleteConceptScheme.js';
 
-export const taxonomyTools = {
+export const conceptSchemeTools = {
   createConceptScheme: {
     title: 'create_concept_scheme',
     description:

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.test.ts
@@ -3,14 +3,16 @@ import {
   testConceptScheme,
   testUpdatedConceptScheme,
   mockConceptSchemeUpdate,
+  mockCreateClient,
 } from './mockClient.js';
 import { updateConceptSchemeTool } from './updateConceptScheme.js';
-import { createToolClient } from '../../../utils/tools.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { formatResponse } from '../../../utils/formatters.js';
 
 describe('updateConceptScheme', () => {
   beforeEach(() => {
     mockConceptSchemeUpdate.mockClear();
+    mockCreateClient.mockClear();
   });
 
   const testArgs = {
@@ -27,9 +29,10 @@ describe('updateConceptScheme', () => {
 
     const result = await updateConceptSchemeTool(testArgs);
 
-    expect(createToolClient).toHaveBeenCalledWith({
-      spaceId: 'dummy',
-      environmentId: 'dummy',
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
     });
 
     expect(mockConceptSchemeUpdate).toHaveBeenCalledWith(

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.ts
@@ -50,6 +50,12 @@ export const UpdateConceptSchemeToolParams = z.object({
     .array(TaxonomyConceptLinkSchema)
     .optional()
     .describe('Links to top-level concepts in this scheme'),
+  addConcept: z
+    .string()
+    .optional()
+    .describe(
+      'ID of a concept to add to this scheme (adds to both concepts and topConcepts)',
+    ),
 });
 
 type Params = z.infer<typeof UpdateConceptSchemeToolParams>;
@@ -102,6 +108,29 @@ async function tool(args: Params) {
       op: args.uri === null ? 'remove' : 'replace',
       path: '/uri',
       ...(args.uri !== null && { value: args.uri }),
+    });
+  }
+
+  // Handle adding a concept to the scheme
+  if (args.addConcept) {
+    const conceptLink = {
+      sys: {
+        id: args.addConcept,
+        linkType: 'TaxonomyConcept',
+        type: 'Link',
+      },
+    };
+    // Add to concepts array
+    patchOperations.push({
+      op: 'add',
+      path: '/concepts/-',
+      value: conceptLink,
+    });
+    // Add to topConcepts array
+    patchOperations.push({
+      op: 'add',
+      path: '/topConcepts/-',
+      value: conceptLink,
     });
   }
 

--- a/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concept-schemes/updateConceptScheme.ts
@@ -3,7 +3,8 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { createToolClient } from '../../../utils/tools.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
 import { TaxonomyConceptLinkSchema } from '../../../types/conceptPayloadTypes.js';
 
 export const UpdateConceptSchemeToolParams = z.object({
@@ -54,10 +55,11 @@ export const UpdateConceptSchemeToolParams = z.object({
 type Params = z.infer<typeof UpdateConceptSchemeToolParams>;
 
 async function tool(args: Params) {
-  const contentfulClient = createToolClient({
-    spaceId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-    environmentId: 'dummy', // Not needed for concept scheme operations but required by BaseToolSchema
-  });
+  // Create a client without space-specific configuration for concept scheme operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
 
   const params = {
     organizationId: args.organizationId,

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/createConcept.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/createConcept.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  testConcept,
+  mockConceptCreate,
+  mockConceptCreateWithId,
+  mockCreateClient,
+} from './mockClient.js';
+import { createConceptTool } from './createConcept.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+describe('createConcept', () => {
+  beforeEach(() => {
+    mockConceptCreate.mockClear();
+    mockConceptCreateWithId.mockClear();
+  });
+
+  const testArgs = {
+    organizationId: 'test-org-id',
+    prefLabel: {
+      'en-US': 'Test Concept',
+    },
+  };
+
+  it('should create a concept successfully with minimal required fields', async () => {
+    mockConceptCreate.mockResolvedValue(testConcept);
+
+    const result = await createConceptTool(testArgs);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+    expect(mockConceptCreate).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+      },
+      {
+        prefLabel: {
+          'en-US': 'Test Concept',
+        },
+      },
+    );
+
+    const expectedResponse = formatResponse('Concept created successfully', {
+      newConcept: testConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should create a concept successfully with all optional fields', async () => {
+    const fullArgs = {
+      organizationId: 'test-org-id',
+      prefLabel: {
+        'en-US': 'Test Concept',
+        'de-DE': 'Test Konzept',
+      },
+      uri: 'https://example.com/concept/test',
+      altLabels: {
+        'en-US': ['Alternative Label 1', 'Alternative Label 2'],
+        'de-DE': ['Alternatives Label 1'],
+      },
+      hiddenLabels: {
+        'en-US': ['Hidden Label 1'],
+      },
+      definition: {
+        'en-US': 'This is a test concept definition',
+        'de-DE': 'Dies ist eine Test-Konzeptdefinition',
+      },
+      editorialNote: {
+        'en-US': 'Editorial note for test concept',
+      },
+      historyNote: {
+        'en-US': 'History note for test concept',
+      },
+      example: {
+        'en-US': 'Example usage of test concept',
+      },
+      note: {
+        'en-US': 'General note for test concept',
+      },
+      scopeNote: {
+        'en-US': 'Scope note for test concept',
+      },
+      notations: ['TC001', 'TEST-CONCEPT'],
+      broader: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'broader-concept-id',
+          },
+        },
+      ],
+      related: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'related-concept-id',
+          },
+        },
+      ],
+    };
+
+    const fullMockConcept = {
+      ...testConcept,
+      prefLabel: fullArgs.prefLabel,
+      uri: fullArgs.uri,
+      altLabels: fullArgs.altLabels,
+      hiddenLabels: fullArgs.hiddenLabels,
+      definition: fullArgs.definition,
+      editorialNote: fullArgs.editorialNote,
+      historyNote: fullArgs.historyNote,
+      example: fullArgs.example,
+      note: fullArgs.note,
+      scopeNote: fullArgs.scopeNote,
+      notations: fullArgs.notations,
+      broader: fullArgs.broader,
+      related: fullArgs.related,
+    };
+
+    mockConceptCreate.mockResolvedValue(fullMockConcept);
+
+    const result = await createConceptTool(fullArgs);
+
+    expect(mockConceptCreate).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+      },
+      {
+        prefLabel: fullArgs.prefLabel,
+        uri: fullArgs.uri,
+        altLabels: fullArgs.altLabels,
+        hiddenLabels: fullArgs.hiddenLabels,
+        definition: fullArgs.definition,
+        editorialNote: fullArgs.editorialNote,
+        historyNote: fullArgs.historyNote,
+        example: fullArgs.example,
+        note: fullArgs.note,
+        scopeNote: fullArgs.scopeNote,
+        notations: fullArgs.notations,
+        broader: fullArgs.broader,
+        related: fullArgs.related,
+      },
+    );
+
+    const expectedResponse = formatResponse('Concept created successfully', {
+      newConcept: fullMockConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should handle errors when concept creation fails', async () => {
+    const error = new Error('Failed to create concept');
+    mockConceptCreate.mockRejectedValue(error);
+
+    const result = await createConceptTool(testArgs);
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Error creating concept: Failed to create concept',
+        },
+      ],
+      isError: true,
+    });
+  });
+
+  it('should create a concept with user-defined ID successfully', async () => {
+    const argsWithId = {
+      ...testArgs,
+      conceptId: 'my-custom-concept-id',
+    };
+
+    const conceptWithCustomId = {
+      ...testConcept,
+      sys: {
+        ...testConcept.sys,
+        id: 'my-custom-concept-id',
+      },
+    };
+
+    mockConceptCreateWithId.mockResolvedValue(conceptWithCustomId);
+
+    const result = await createConceptTool(argsWithId);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+    expect(mockConceptCreateWithId).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+        conceptId: 'my-custom-concept-id',
+      },
+      {
+        prefLabel: {
+          'en-US': 'Test Concept',
+        },
+      },
+    );
+    expect(mockConceptCreate).not.toHaveBeenCalled();
+
+    const expectedResponse = formatResponse('Concept created successfully', {
+      newConcept: conceptWithCustomId,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should create a concept without ID using the standard create method', async () => {
+    mockConceptCreate.mockResolvedValue(testConcept);
+
+    const result = await createConceptTool(testArgs);
+
+    expect(mockConceptCreate).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+      },
+      {
+        prefLabel: {
+          'en-US': 'Test Concept',
+        },
+      },
+    );
+    expect(mockConceptCreateWithId).not.toHaveBeenCalled();
+
+    const expectedResponse = formatResponse('Concept created successfully', {
+      newConcept: testConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/createConcept.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/createConcept.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+import {
+  TaxonomyConceptLinkSchema,
+  type ConceptPayload,
+} from '../../../types/conceptPayloadTypes.js';
+
+export const CreateConceptToolParams = z.object({
+  organizationId: z.string().describe('The ID of the Contentful organization'),
+  conceptId: z
+    .string()
+    .optional()
+    .describe(
+      'Optional user-defined ID for the concept. If not provided, Contentful will generate one automatically.',
+    ),
+  prefLabel: z
+    .record(z.string())
+    .describe('The preferred label for the concept (localized)'),
+  uri: z.string().nullable().optional().describe('The URI for the concept'),
+  altLabels: z
+    .record(z.array(z.string()))
+    .optional()
+    .describe('Alternative labels for the concept (localized)'),
+  hiddenLabels: z
+    .record(z.array(z.string()))
+    .optional()
+    .describe('Hidden labels for the concept (localized)'),
+  definition: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Definition of the concept (localized)'),
+  editorialNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Editorial note for the concept (localized)'),
+  historyNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('History note for the concept (localized)'),
+  example: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Example for the concept (localized)'),
+  note: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('General note for the concept (localized)'),
+  scopeNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Scope note for the concept (localized)'),
+  notations: z
+    .array(z.string())
+    .optional()
+    .describe('Notations for the concept'),
+  broader: z
+    .array(TaxonomyConceptLinkSchema)
+    .optional()
+    .describe('Links to broader concepts'),
+  related: z
+    .array(TaxonomyConceptLinkSchema)
+    .optional()
+    .describe('Links to related concepts'),
+});
+
+type Params = z.infer<typeof CreateConceptToolParams>;
+
+async function tool(args: Params) {
+  // Create a client without space-specific configuration for concept operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
+
+  // Build the concept payload using the shared type
+  const conceptPayload: ConceptPayload = {
+    prefLabel: args.prefLabel,
+    ...(args.uri !== undefined && { uri: args.uri }),
+    ...(args.altLabels && { altLabels: args.altLabels }),
+    ...(args.hiddenLabels && { hiddenLabels: args.hiddenLabels }),
+    ...(args.definition && { definition: args.definition }),
+    ...(args.editorialNote && { editorialNote: args.editorialNote }),
+    ...(args.historyNote && { historyNote: args.historyNote }),
+    ...(args.example && { example: args.example }),
+    ...(args.note && { note: args.note }),
+    ...(args.scopeNote && { scopeNote: args.scopeNote }),
+    ...(args.notations && { notations: args.notations }),
+    ...(args.broader && { broader: args.broader }),
+    ...(args.related && { related: args.related }),
+  };
+
+  const newConcept = args.conceptId
+    ? await contentfulClient.concept.createWithId(
+        { organizationId: args.organizationId, conceptId: args.conceptId },
+        conceptPayload,
+      )
+    : await contentfulClient.concept.create(
+        { organizationId: args.organizationId },
+        conceptPayload,
+      );
+
+  return createSuccessResponse('Concept created successfully', { newConcept });
+}
+
+export const createConceptTool = withErrorHandling(
+  tool,
+  'Error creating concept',
+);

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/deleteConcept.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/deleteConcept.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  testConcept,
+  mockConceptGet,
+  mockConceptDelete,
+  mockCreateClient,
+} from './mockClient.js';
+import { deleteConceptTool } from './deleteConcept.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+describe('deleteConcept', () => {
+  beforeEach(() => {
+    mockConceptGet.mockClear();
+    mockConceptDelete.mockClear();
+  });
+
+  const testArgs = {
+    organizationId: 'test-org-id',
+    conceptId: 'test-concept-id',
+    version: 1,
+  };
+
+  it('should delete a concept successfully', async () => {
+    mockConceptGet.mockResolvedValue(testConcept);
+    mockConceptDelete.mockResolvedValue(undefined);
+
+    const result = await deleteConceptTool(testArgs);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+
+    expect(mockConceptDelete).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+      version: 1,
+    });
+
+    const expectedResponse = formatResponse('Concept deleted successfully', {
+      conceptId: 'test-concept-id',
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should handle errors when concept deletion fails', async () => {
+    const error = new Error('Version mismatch');
+    mockConceptGet.mockResolvedValue(testConcept);
+    mockConceptDelete.mockRejectedValue(error);
+
+    const result = await deleteConceptTool(testArgs);
+
+    expect(mockConceptDelete).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+      version: 1,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Error deleting concept: Version mismatch',
+        },
+      ],
+      isError: true,
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/deleteConcept.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/deleteConcept.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+export const DeleteConceptToolParams = z.object({
+  organizationId: z.string().describe('The ID of the Contentful organization'),
+  conceptId: z.string().describe('The ID of the concept to delete'),
+  version: z.number().describe('The version of the concept to delete'),
+});
+
+type Params = z.infer<typeof DeleteConceptToolParams>;
+
+async function tool(args: Params) {
+  // Create a client without space-specific configuration for concept operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
+
+  // Delete the concept
+  await contentfulClient.concept.delete({
+    organizationId: args.organizationId,
+    conceptId: args.conceptId,
+    version: args.version,
+  });
+
+  return createSuccessResponse('Concept deleted successfully', {
+    conceptId: args.conceptId,
+  });
+}
+
+export const deleteConceptTool = withErrorHandling(
+  tool,
+  'Error deleting concept',
+);

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/getConcept.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/getConcept.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { testConcept, mockConceptGet, mockCreateClient } from './mockClient.js';
+import { getConceptTool } from './getConcept.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+describe('getConcept', () => {
+  beforeEach(() => {
+    mockConceptGet.mockClear();
+  });
+
+  const testArgs = {
+    organizationId: 'test-org-id',
+    conceptId: 'test-concept-id',
+  };
+
+  it('should retrieve a concept successfully', async () => {
+    mockConceptGet.mockResolvedValue(testConcept);
+
+    const result = await getConceptTool(testArgs);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+    expect(mockConceptGet).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+    });
+
+    const expectedResponse = formatResponse('Concept retrieved successfully', {
+      concept: testConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should handle errors when retrieving a concept', async () => {
+    const error = new Error('Concept not found');
+    mockConceptGet.mockRejectedValue(error);
+
+    const result = await getConceptTool(testArgs);
+
+    expect(mockConceptGet).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error retrieving concept');
+    expect(result.content[0].text).toContain('Concept not found');
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/getConcept.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/getConcept.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+export const GetConceptToolParams = z.object({
+  organizationId: z.string().describe('The ID of the Contentful organization'),
+  conceptId: z.string().describe('The ID of the concept to retrieve'),
+});
+
+type Params = z.infer<typeof GetConceptToolParams>;
+
+async function tool(args: Params) {
+  // Create a client without space-specific configuration for concept operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
+
+  const concept = await contentfulClient.concept.get({
+    organizationId: args.organizationId,
+    conceptId: args.conceptId,
+  });
+
+  return createSuccessResponse('Concept retrieved successfully', { concept });
+}
+
+export const getConceptTool = withErrorHandling(
+  tool,
+  'Error retrieving concept',
+);

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/listConcepts.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/listConcepts.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  testConcept,
+  mockConceptGetMany,
+  mockConceptGetDescendants,
+  mockConceptGetAncestors,
+  mockConceptGetTotal,
+  mockCreateClient,
+} from './mockClient.js';
+import { listConceptsTool } from './listConcepts.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+describe('listConcepts', () => {
+  beforeEach(() => {
+    mockConceptGetMany.mockClear();
+    mockConceptGetDescendants.mockClear();
+    mockConceptGetAncestors.mockClear();
+    mockConceptGetTotal.mockClear();
+  });
+
+  const testArgs = {
+    organizationId: 'test-org-id',
+  };
+
+  const mockConceptsResponse = {
+    items: [testConcept],
+    total: 1,
+    skip: 0,
+    limit: 10,
+  };
+
+  it('should list concepts successfully with default parameters', async () => {
+    mockConceptGetMany.mockResolvedValue(mockConceptsResponse);
+
+    const result = await listConceptsTool(testArgs);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+    expect(mockConceptGetMany).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      query: {
+        limit: 10,
+        skip: 0,
+      },
+    });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Concepts retrieved successfully');
+    expect(result.content[0].text).toContain('test-concept-id');
+    expect(result.content[0].text).toContain('Test Concept');
+  });
+
+  it('should list concepts with all optional parameters', async () => {
+    const fullArgs = {
+      organizationId: 'test-org-id',
+      limit: 20,
+      skip: 5,
+      select: 'sys,prefLabel,uri',
+      include: 2,
+      order: 'sys.createdAt',
+    };
+
+    mockConceptGetMany.mockResolvedValue(mockConceptsResponse);
+
+    const result = await listConceptsTool(fullArgs);
+
+    expect(mockConceptGetMany).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      query: {
+        limit: 20,
+        skip: 5,
+        select: 'sys,prefLabel,uri',
+        include: 2,
+        order: 'sys.createdAt',
+      },
+    });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Concepts retrieved successfully');
+  });
+
+  it('should handle errors when listing concepts', async () => {
+    const error = new Error('Failed to fetch concepts');
+    mockConceptGetMany.mockRejectedValue(error);
+
+    const result = await listConceptsTool(testArgs);
+
+    expect(mockConceptGetMany).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      query: {
+        limit: 10,
+        skip: 0,
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error retrieving concepts');
+    expect(result.content[0].text).toContain('Failed to fetch concepts');
+  });
+
+  it('should get total count only when getTotalOnly is true', async () => {
+    const totalOnlyArgs = {
+      organizationId: 'test-org-id',
+      getTotalOnly: true,
+    };
+
+    mockConceptGetTotal.mockResolvedValue(42);
+
+    const result = await listConceptsTool(totalOnlyArgs);
+
+    expect(mockConceptGetTotal).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+    });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain(
+      'Total concepts retrieved successfully',
+    );
+    expect(result.content[0].text).toContain('42');
+  });
+
+  it('should get descendants when getDescendants is true', async () => {
+    const descendantsArgs = {
+      organizationId: 'test-org-id',
+      conceptId: 'parent-concept-id',
+      getDescendants: true,
+    };
+
+    const mockDescendantsResponse = {
+      items: [testConcept],
+      total: 1,
+      skip: 0,
+      limit: 10,
+    };
+
+    mockConceptGetDescendants.mockResolvedValue(mockDescendantsResponse);
+
+    const result = await listConceptsTool(descendantsArgs);
+
+    expect(mockConceptGetDescendants).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'parent-concept-id',
+    });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain(
+      'Concept descendants retrieved successfully',
+    );
+    expect(result.content[0].text).toContain('test-concept-id');
+  });
+
+  it('should get ancestors when getAncestors is true', async () => {
+    const ancestorsArgs = {
+      organizationId: 'test-org-id',
+      conceptId: 'child-concept-id',
+      getAncestors: true,
+    };
+
+    const mockAncestorsResponse = {
+      items: [testConcept],
+      total: 1,
+      skip: 0,
+      limit: 10,
+    };
+
+    mockConceptGetAncestors.mockResolvedValue(mockAncestorsResponse);
+
+    const result = await listConceptsTool(ancestorsArgs);
+
+    expect(mockConceptGetAncestors).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'child-concept-id',
+    });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain(
+      'Concept ancestors retrieved successfully',
+    );
+    expect(result.content[0].text).toContain('test-concept-id');
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/listConcepts.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/listConcepts.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+import { summarizeData } from '../../../utils/summarizer.js';
+
+export const ListConceptsToolParams = z.object({
+  organizationId: z.string().describe('The ID of the Contentful organization'),
+  conceptId: z
+    .string()
+    .optional()
+    .describe('The ID of the concept (required for descendants/ancestors)'),
+  limit: z.number().optional().describe('Maximum number of concepts to return'),
+  skip: z
+    .number()
+    .optional()
+    .describe('Skip this many concepts for pagination'),
+  select: z
+    .string()
+    .optional()
+    .describe('Comma-separated list of fields to return'),
+  include: z
+    .number()
+    .optional()
+    .describe('Include this many levels of linked entries'),
+  order: z.string().optional().describe('Order concepts by this field'),
+  getDescendants: z
+    .boolean()
+    .optional()
+    .describe('Get descendants of the specified concept (requires conceptId)'),
+  getAncestors: z
+    .boolean()
+    .optional()
+    .describe('Get ancestors of the specified concept (requires conceptId)'),
+  getTotalOnly: z
+    .boolean()
+    .optional()
+    .describe('Get only the total number of concepts without full data'),
+});
+
+type Params = z.infer<typeof ListConceptsToolParams>;
+
+async function tool(args: Params) {
+  // Create a client without space-specific configuration for concept operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
+
+  // Validate required parameters for specific operations
+  if ((args.getDescendants || args.getAncestors) && !args.conceptId) {
+    throw new Error(
+      'conceptId is required when getting descendants or ancestors',
+    );
+  }
+
+  // Handle getTotalOnly - return just the total count
+  if (args.getTotalOnly) {
+    const total = await contentfulClient.concept.getTotal({
+      organizationId: args.organizationId,
+    });
+    return createSuccessResponse('Total concepts retrieved successfully', {
+      total,
+    });
+  }
+
+  // Handle getDescendants
+  if (args.getDescendants) {
+    const descendants = await contentfulClient.concept.getDescendants({
+      organizationId: args.organizationId,
+      conceptId: args.conceptId!,
+      ...(args.limit && { limit: args.limit }),
+      ...(args.skip && { skip: args.skip }),
+      ...(args.select && { select: args.select }),
+      ...(args.include && { include: args.include }),
+      ...(args.order && { order: args.order }),
+    });
+
+    const summarizedDescendants = descendants.items.map((concept) => ({
+      sys: concept.sys,
+      prefLabel: concept.prefLabel,
+      uri: concept.uri,
+      broader: concept.broader,
+      related: concept.related,
+    }));
+
+    const responseData = summarizeData({
+      ...descendants,
+      items: summarizedDescendants,
+    });
+
+    return createSuccessResponse(
+      'Concept descendants retrieved successfully',
+      responseData as Record<string, unknown>,
+    );
+  }
+
+  // Handle getAncestors
+  if (args.getAncestors) {
+    const ancestors = await contentfulClient.concept.getAncestors({
+      organizationId: args.organizationId,
+      conceptId: args.conceptId!,
+      ...(args.limit && { limit: args.limit }),
+      ...(args.skip && { skip: args.skip }),
+      ...(args.select && { select: args.select }),
+      ...(args.include && { include: args.include }),
+      ...(args.order && { order: args.order }),
+    });
+
+    const summarizedAncestors = ancestors.items.map((concept) => ({
+      sys: concept.sys,
+      prefLabel: concept.prefLabel,
+      uri: concept.uri,
+      broader: concept.broader,
+      related: concept.related,
+    }));
+
+    const responseData = summarizeData({
+      ...ancestors,
+      items: summarizedAncestors,
+    });
+
+    return createSuccessResponse(
+      'Concept ancestors retrieved successfully',
+      responseData as Record<string, unknown>,
+    );
+  }
+
+  // Default behavior - get all concepts
+  const concepts = await contentfulClient.concept.getMany({
+    organizationId: args.organizationId,
+    query: {
+      limit: args.limit || 10,
+      skip: args.skip || 0,
+      ...(args.select && { select: args.select }),
+      ...(args.include && { include: args.include }),
+      ...(args.order && { order: args.order }),
+    },
+  });
+
+  const summarizedConcepts = concepts.items.map((concept) => ({
+    sys: concept.sys,
+    prefLabel: concept.prefLabel,
+    uri: concept.uri,
+    broader: concept.broader,
+    related: concept.related,
+  }));
+
+  const responseData = summarizeData({
+    ...concepts,
+    items: summarizedConcepts,
+  });
+
+  return createSuccessResponse(
+    'Concepts retrieved successfully',
+    responseData as Record<string, unknown>,
+  );
+}
+
+export const listConceptsTool = withErrorHandling(
+  tool,
+  'Error retrieving concepts',
+);

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/mockClient.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/mockClient.ts
@@ -1,0 +1,114 @@
+import { vi } from 'vitest';
+
+const {
+  mockConceptCreate,
+  mockConceptCreateWithId,
+  mockConceptGet,
+  mockConceptGetMany,
+  mockConceptGetDescendants,
+  mockConceptGetAncestors,
+  mockConceptGetTotal,
+  mockConceptDelete,
+  mockConceptUpdatePut,
+  mockCreateClient,
+} = vi.hoisted(() => {
+  const mockConceptCreate = vi.fn();
+  const mockConceptCreateWithId = vi.fn();
+  const mockConceptGet = vi.fn();
+  const mockConceptGetMany = vi.fn();
+  const mockConceptGetDescendants = vi.fn();
+  const mockConceptGetAncestors = vi.fn();
+  const mockConceptGetTotal = vi.fn();
+  const mockConceptDelete = vi.fn();
+  const mockConceptUpdatePut = vi.fn();
+  const mockCreateClient = vi.fn(() => ({
+    concept: {
+      create: mockConceptCreate,
+      createWithId: mockConceptCreateWithId,
+      get: mockConceptGet,
+      getMany: mockConceptGetMany,
+      getDescendants: mockConceptGetDescendants,
+      getAncestors: mockConceptGetAncestors,
+      getTotal: mockConceptGetTotal,
+      delete: mockConceptDelete,
+      updatePut: mockConceptUpdatePut,
+    },
+  }));
+  return {
+    mockConceptCreate,
+    mockConceptCreateWithId,
+    mockConceptGet,
+    mockConceptGetMany,
+    mockConceptGetDescendants,
+    mockConceptGetAncestors,
+    mockConceptGetTotal,
+    mockConceptDelete,
+    mockConceptUpdatePut,
+    mockCreateClient,
+  };
+});
+
+vi.mock('contentful-management', () => {
+  return {
+    default: {
+      createClient: mockCreateClient,
+    },
+    createClient: mockCreateClient,
+  };
+});
+
+export {
+  mockConceptCreate,
+  mockConceptCreateWithId,
+  mockConceptGet,
+  mockConceptGetMany,
+  mockConceptGetDescendants,
+  mockConceptGetAncestors,
+  mockConceptGetTotal,
+  mockConceptDelete,
+  mockConceptUpdatePut,
+  mockCreateClient,
+};
+
+export const testConcept = {
+  sys: {
+    type: 'TaxonomyConcept',
+    id: 'test-concept-id',
+    version: 1,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
+    createdBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'user-id',
+      },
+    },
+    updatedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'user-id',
+      },
+    },
+  },
+  prefLabel: {
+    'en-US': 'Test Concept',
+  },
+  uri: null,
+  altLabels: {},
+  hiddenLabels: {},
+  definition: null,
+  editorialNote: null,
+  historyNote: null,
+  example: null,
+  note: null,
+  scopeNote: null,
+  notations: [],
+  broader: [],
+  related: [],
+};
+
+export const mockArgs = {
+  organizationId: 'test-org-id',
+};

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/register.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/register.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { conceptTools } from './register.js';
+import { createConceptTool, CreateConceptToolParams } from './createConcept.js';
+import { getConceptTool, GetConceptToolParams } from './getConcept.js';
+import { listConceptsTool, ListConceptsToolParams } from './listConcepts.js';
+import { updateConceptTool, UpdateConceptToolParams } from './updateConcept.js';
+import { deleteConceptTool, DeleteConceptToolParams } from './deleteConcept.js';
+
+describe('concept tools collection', () => {
+  it('should export conceptTools collection with correct structure', () => {
+    expect(conceptTools).toBeDefined();
+    expect(Object.keys(conceptTools)).toHaveLength(5);
+  });
+
+  it('should have createConcept tool with correct properties', () => {
+    const { createConcept } = conceptTools;
+
+    expect(createConcept.title).toBe('create_concept');
+    expect(createConcept.description).toBe(
+      'Create a new taxonomy concept in Contentful. Concepts are used to organize and categorize content within taxonomies. The prefLabel is required and should be localized. You can optionally provide a conceptId for a user-defined ID, or let Contentful generate one automatically. You can also include definitions, notes, relationships to other concepts, and various metadata fields.',
+    );
+    expect(createConcept.inputParams).toStrictEqual(
+      CreateConceptToolParams.shape,
+    );
+    expect(createConcept.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(createConcept.tool).toBe(createConceptTool);
+  });
+
+  it('should have getConcept tool with correct properties', () => {
+    const { getConcept } = conceptTools;
+
+    expect(getConcept.title).toBe('get_concept');
+    expect(getConcept.description).toBe(
+      'Retrieve a specific taxonomy concept from Contentful. Returns the complete concept with all its properties including prefLabel, definition, relationships, and other metadata.',
+    );
+    expect(getConcept.inputParams).toStrictEqual(GetConceptToolParams.shape);
+    expect(getConcept.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+    expect(getConcept.tool).toBe(getConceptTool);
+  });
+
+  it('should have listConcepts tool with correct properties', () => {
+    const { listConcepts } = conceptTools;
+
+    expect(listConcepts.title).toBe('list_concepts');
+    expect(listConcepts.description).toBe(
+      'List taxonomy concepts in a Contentful organization. Supports multiple modes: (1) Default - list all concepts with pagination and filtering, (2) getTotalOnly - return only the total count of concepts, (3) getDescendants - get descendants of a specific concept (requires conceptId), (4) getAncestors - get ancestors of a specific concept (requires conceptId). Returns summarized view of concepts with essential information.',
+    );
+    expect(listConcepts.inputParams).toStrictEqual(
+      ListConceptsToolParams.shape,
+    );
+    expect(listConcepts.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+    expect(listConcepts.tool).toBe(listConceptsTool);
+  });
+
+  it('should have updateConcept tool with correct properties', () => {
+    const { updateConcept } = conceptTools;
+
+    expect(updateConcept.title).toBe('update_concept');
+    expect(updateConcept.description).toBe(
+      'Update a taxonomy concept in Contentful. Requires the concept ID and version number for optimistic concurrency control. You can update any combination of fields - only the fields you provide will be changed, while others remain unchanged. Use this to modify labels, definitions, relationships, and other concept properties.',
+    );
+    expect(updateConcept.inputParams).toStrictEqual(
+      UpdateConceptToolParams.shape,
+    );
+    expect(updateConcept.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(updateConcept.tool).toBe(updateConceptTool);
+  });
+
+  it('should have deleteConcept tool with correct properties', () => {
+    const { deleteConcept } = conceptTools;
+
+    expect(deleteConcept.title).toBe('delete_concept');
+    expect(deleteConcept.description).toBe(
+      'Delete a taxonomy concept from Contentful. Requires the concept ID and version number for optimistic concurrency control. This operation permanently removes the concept and cannot be undone.',
+    );
+    expect(deleteConcept.inputParams).toStrictEqual(
+      DeleteConceptToolParams.shape,
+    );
+    expect(deleteConcept.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(deleteConcept.tool).toBe(deleteConceptTool);
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/register.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/register.ts
@@ -1,0 +1,69 @@
+import { createConceptTool, CreateConceptToolParams } from './createConcept.js';
+import { deleteConceptTool, DeleteConceptToolParams } from './deleteConcept.js';
+import { updateConceptTool, UpdateConceptToolParams } from './updateConcept.js';
+import { getConceptTool, GetConceptToolParams } from './getConcept.js';
+import { listConceptsTool, ListConceptsToolParams } from './listConcepts.js';
+
+export const conceptTools = {
+  createConcept: {
+    title: 'create_concept',
+    description:
+      'Create a new taxonomy concept in Contentful. Concepts are used to organize and categorize content within taxonomies. The prefLabel is required and should be localized. You can optionally provide a conceptId for a user-defined ID, or let Contentful generate one automatically. You can also include definitions, notes, relationships to other concepts, and various metadata fields.',
+    inputParams: CreateConceptToolParams.shape,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    tool: createConceptTool,
+  },
+  getConcept: {
+    title: 'get_concept',
+    description:
+      'Retrieve a specific taxonomy concept from Contentful. Returns the complete concept with all its properties including prefLabel, definition, relationships, and other metadata.',
+    inputParams: GetConceptToolParams.shape,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    tool: getConceptTool,
+  },
+  listConcepts: {
+    title: 'list_concepts',
+    description:
+      'List taxonomy concepts in a Contentful organization. Supports multiple modes: (1) Default - list all concepts with pagination and filtering, (2) getTotalOnly - return only the total count of concepts, (3) getDescendants - get descendants of a specific concept (requires conceptId), (4) getAncestors - get ancestors of a specific concept (requires conceptId). Returns summarized view of concepts with essential information.',
+    inputParams: ListConceptsToolParams.shape,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    tool: listConceptsTool,
+  },
+  updateConcept: {
+    title: 'update_concept',
+    description:
+      'Update a taxonomy concept in Contentful. Requires the concept ID and version number for optimistic concurrency control. You can update any combination of fields - only the fields you provide will be changed, while others remain unchanged. Use this to modify labels, definitions, relationships, and other concept properties.',
+    inputParams: UpdateConceptToolParams.shape,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    tool: updateConceptTool,
+  },
+  deleteConcept: {
+    title: 'delete_concept',
+    description:
+      'Delete a taxonomy concept from Contentful. Requires the concept ID and version number for optimistic concurrency control. This operation permanently removes the concept and cannot be undone.',
+    inputParams: DeleteConceptToolParams.shape,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    tool: deleteConceptTool,
+  },
+};

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/updateConcept.test.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/updateConcept.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  testConcept,
+  mockConceptGet,
+  mockConceptUpdatePut,
+  mockCreateClient,
+} from './mockClient.js';
+import { updateConceptTool } from './updateConcept.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+
+describe('updateConcept', () => {
+  beforeEach(() => {
+    mockConceptGet.mockClear();
+    mockConceptUpdatePut.mockClear();
+  });
+
+  const testArgs = {
+    organizationId: 'test-org-id',
+    conceptId: 'test-concept-id',
+    version: 1,
+  };
+
+  const existingConcept = {
+    ...testConcept,
+    prefLabel: {
+      'en-US': 'Original Concept',
+    },
+    uri: 'https://example.com/original',
+    definition: {
+      'en-US': 'Original definition',
+    },
+    altLabels: {
+      'en-US': ['Original Alt Label'],
+    },
+    broader: [
+      {
+        sys: {
+          type: 'Link' as const,
+          linkType: 'TaxonomyConcept' as const,
+          id: 'original-broader-concept',
+        },
+      },
+    ],
+  };
+
+  it('should update a concept successfully with partial updates', async () => {
+    const updateArgs = {
+      ...testArgs,
+      prefLabel: {
+        'en-US': 'Updated Concept',
+        'de-DE': 'Aktualisiertes Konzept',
+      },
+      definition: {
+        'en-US': 'Updated definition',
+      },
+    };
+
+    const updatedConcept = {
+      ...existingConcept,
+      prefLabel: updateArgs.prefLabel,
+      definition: updateArgs.definition,
+      sys: {
+        ...existingConcept.sys,
+        version: 2,
+        updatedAt: '2023-01-02T00:00:00Z',
+      },
+    };
+
+    mockConceptGet.mockResolvedValue(existingConcept);
+    mockConceptUpdatePut.mockResolvedValue(updatedConcept);
+
+    const result = await updateConceptTool(updateArgs);
+
+    const clientConfig = getDefaultClientConfig();
+    delete clientConfig.space;
+    expect(mockCreateClient).toHaveBeenCalledWith(clientConfig, {
+      type: 'plain',
+    });
+
+    expect(mockConceptGet).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+    });
+
+    expect(mockConceptUpdatePut).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+        conceptId: 'test-concept-id',
+        version: 1,
+      },
+      {
+        prefLabel: {
+          'en-US': 'Updated Concept',
+          'de-DE': 'Aktualisiertes Konzept',
+        },
+        uri: 'https://example.com/original', // Should preserve existing
+        altLabels: {
+          'en-US': ['Original Alt Label'], // Should preserve existing
+        },
+        hiddenLabels: existingConcept.hiddenLabels,
+        definition: {
+          'en-US': 'Updated definition',
+        },
+        editorialNote: existingConcept.editorialNote,
+        historyNote: existingConcept.historyNote,
+        example: existingConcept.example,
+        note: existingConcept.note,
+        scopeNote: existingConcept.scopeNote,
+        notations: existingConcept.notations,
+        broader: existingConcept.broader, // Should preserve existing
+        related: existingConcept.related,
+      },
+    );
+
+    const expectedResponse = formatResponse('Concept updated successfully', {
+      updatedConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should update a concept with all fields', async () => {
+    const fullUpdateArgs = {
+      ...testArgs,
+      prefLabel: {
+        'en-US': 'Fully Updated Concept',
+      },
+      uri: 'https://example.com/updated',
+      altLabels: {
+        'en-US': ['Updated Alt Label 1', 'Updated Alt Label 2'],
+      },
+      hiddenLabels: {
+        'en-US': ['Updated Hidden Label'],
+      },
+      definition: {
+        'en-US': 'Fully updated definition',
+      },
+      editorialNote: {
+        'en-US': 'Updated editorial note',
+      },
+      historyNote: {
+        'en-US': 'Updated history note',
+      },
+      example: {
+        'en-US': 'Updated example',
+      },
+      note: {
+        'en-US': 'Updated general note',
+      },
+      scopeNote: {
+        'en-US': 'Updated scope note',
+      },
+      notations: ['UPN001', 'UPDATED'],
+      broader: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'updated-broader-concept',
+          },
+        },
+      ],
+      related: [
+        {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'TaxonomyConcept' as const,
+            id: 'updated-related-concept',
+          },
+        },
+      ],
+    };
+
+    const fullyUpdatedConcept = {
+      ...existingConcept,
+      ...fullUpdateArgs,
+      sys: {
+        ...existingConcept.sys,
+        version: 2,
+        updatedAt: '2023-01-02T00:00:00Z',
+      },
+    };
+
+    mockConceptGet.mockResolvedValue(existingConcept);
+    mockConceptUpdatePut.mockResolvedValue(fullyUpdatedConcept);
+
+    const result = await updateConceptTool(fullUpdateArgs);
+
+    expect(mockConceptUpdatePut).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+        conceptId: 'test-concept-id',
+        version: 1,
+      },
+      {
+        prefLabel: fullUpdateArgs.prefLabel,
+        uri: fullUpdateArgs.uri,
+        altLabels: fullUpdateArgs.altLabels,
+        hiddenLabels: fullUpdateArgs.hiddenLabels,
+        definition: fullUpdateArgs.definition,
+        editorialNote: fullUpdateArgs.editorialNote,
+        historyNote: fullUpdateArgs.historyNote,
+        example: fullUpdateArgs.example,
+        note: fullUpdateArgs.note,
+        scopeNote: fullUpdateArgs.scopeNote,
+        notations: fullUpdateArgs.notations,
+        broader: fullUpdateArgs.broader,
+        related: fullUpdateArgs.related,
+      },
+    );
+
+    const expectedResponse = formatResponse('Concept updated successfully', {
+      updatedConcept: fullyUpdatedConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+
+  it('should handle errors when concept update fails', async () => {
+    const error = new Error('Version mismatch');
+    mockConceptGet.mockResolvedValue(existingConcept);
+    mockConceptUpdatePut.mockRejectedValue(error);
+
+    const result = await updateConceptTool(testArgs);
+
+    expect(mockConceptGet).toHaveBeenCalledWith({
+      organizationId: 'test-org-id',
+      conceptId: 'test-concept-id',
+    });
+
+    expect(mockConceptUpdatePut).toHaveBeenCalled();
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Error updating concept: Version mismatch',
+        },
+      ],
+      isError: true,
+    });
+  });
+
+  it('should preserve existing fields when no updates are provided', async () => {
+    const minimalUpdateArgs = {
+      ...testArgs,
+      // Only providing required fields, no optional updates
+    };
+
+    const unchangedConcept = {
+      ...existingConcept,
+      sys: {
+        ...existingConcept.sys,
+        version: 2,
+      },
+    };
+
+    mockConceptGet.mockResolvedValue(existingConcept);
+    mockConceptUpdatePut.mockResolvedValue(unchangedConcept);
+
+    const result = await updateConceptTool(minimalUpdateArgs);
+
+    expect(mockConceptUpdatePut).toHaveBeenCalledWith(
+      {
+        organizationId: 'test-org-id',
+        conceptId: 'test-concept-id',
+        version: 1,
+      },
+      {
+        prefLabel: existingConcept.prefLabel, // Should preserve existing
+        uri: existingConcept.uri, // Should preserve existing
+        altLabels: existingConcept.altLabels, // Should preserve existing
+        hiddenLabels: existingConcept.hiddenLabels,
+        definition: existingConcept.definition,
+        editorialNote: existingConcept.editorialNote,
+        historyNote: existingConcept.historyNote,
+        example: existingConcept.example,
+        note: existingConcept.note,
+        scopeNote: existingConcept.scopeNote,
+        notations: existingConcept.notations,
+        broader: existingConcept.broader, // Should preserve existing
+        related: existingConcept.related,
+      },
+    );
+
+    const expectedResponse = formatResponse('Concept updated successfully', {
+      updatedConcept: unchangedConcept,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: expectedResponse,
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/taxonomies/concepts/updateConcept.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/concepts/updateConcept.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import ctfl from 'contentful-management';
+import { getDefaultClientConfig } from '../../../config/contentful.js';
+import {
+  TaxonomyConceptLinkSchema,
+  type ConceptPayload,
+} from '../../../types/conceptPayloadTypes.js';
+
+export const UpdateConceptToolParams = z.object({
+  organizationId: z.string().describe('The ID of the Contentful organization'),
+  conceptId: z.string().describe('The ID of the concept to update'),
+  version: z.number().describe('The current version of the concept'),
+  prefLabel: z
+    .record(z.string())
+    .optional()
+    .describe('The preferred label for the concept (localized)'),
+  uri: z.string().nullable().optional().describe('The URI for the concept'),
+  altLabels: z
+    .record(z.array(z.string()))
+    .optional()
+    .describe('Alternative labels for the concept (localized)'),
+  hiddenLabels: z
+    .record(z.array(z.string()))
+    .optional()
+    .describe('Hidden labels for the concept (localized)'),
+  definition: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Definition of the concept (localized)'),
+  editorialNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Editorial note for the concept (localized)'),
+  historyNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('History note for the concept (localized)'),
+  example: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Example for the concept (localized)'),
+  note: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('General note for the concept (localized)'),
+  scopeNote: z
+    .record(z.string().nullable())
+    .optional()
+    .describe('Scope note for the concept (localized)'),
+  notations: z
+    .array(z.string())
+    .optional()
+    .describe('Notations for the concept'),
+  broader: z
+    .array(TaxonomyConceptLinkSchema)
+    .optional()
+    .describe('Links to broader concepts'),
+  related: z
+    .array(TaxonomyConceptLinkSchema)
+    .optional()
+    .describe('Links to related concepts'),
+});
+
+type Params = z.infer<typeof UpdateConceptToolParams>;
+
+async function tool(args: Params) {
+  // Create a client without space-specific configuration for concept operations
+  const clientConfig = getDefaultClientConfig();
+  // Remove space from config since we're working at the organization level
+  delete clientConfig.space;
+  const contentfulClient = ctfl.createClient(clientConfig, { type: 'plain' });
+
+  // First, get the existing concept
+  const existingConcept = await contentfulClient.concept.get({
+    organizationId: args.organizationId,
+    conceptId: args.conceptId,
+  });
+
+  // Build the updated concept payload by merging existing data with provided updates
+  const updatedPayload: ConceptPayload = {
+    prefLabel: args.prefLabel ?? existingConcept.prefLabel,
+    uri: args.uri !== undefined ? args.uri : existingConcept.uri,
+    altLabels: args.altLabels ?? existingConcept.altLabels,
+    hiddenLabels: args.hiddenLabels ?? existingConcept.hiddenLabels,
+    definition: args.definition ?? existingConcept.definition,
+    editorialNote: args.editorialNote ?? existingConcept.editorialNote,
+    historyNote: args.historyNote ?? existingConcept.historyNote,
+    example: args.example ?? existingConcept.example,
+    note: args.note ?? existingConcept.note,
+    scopeNote: args.scopeNote ?? existingConcept.scopeNote,
+    notations: args.notations ?? existingConcept.notations,
+    broader: args.broader ?? existingConcept.broader,
+    related: args.related ?? existingConcept.related,
+  };
+
+  // Update the concept using the PUT method
+  const updatedConcept = await contentfulClient.concept.updatePut(
+    {
+      organizationId: args.organizationId,
+      conceptId: args.conceptId,
+      version: args.version,
+    },
+    updatedPayload,
+  );
+
+  return createSuccessResponse('Concept updated successfully', {
+    updatedConcept,
+  });
+}
+
+export const updateConceptTool = withErrorHandling(
+  tool,
+  'Error updating concept',
+);

--- a/packages/mcp-tools/src/tools/taxonomies/register.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/register.ts
@@ -1,1 +1,5 @@
-export { taxonomyTools } from './concept-schemes/register.js';
+import { taxonomyTools as conceptSchemeTools } from './concept-schemes/register.js';
+
+export const taxonomyTools = {
+  ...conceptSchemeTools,
+};

--- a/packages/mcp-tools/src/tools/taxonomies/register.ts
+++ b/packages/mcp-tools/src/tools/taxonomies/register.ts
@@ -1,5 +1,7 @@
-import { taxonomyTools as conceptSchemeTools } from './concept-schemes/register.js';
+import { conceptSchemeTools } from './concept-schemes/register.js';
+import { conceptTools } from './concepts/register.js';
 
 export const taxonomyTools = {
   ...conceptSchemeTools,
+  ...conceptTools,
 };


### PR DESCRIPTION
https://contentful.atlassian.net/browse/DX-408

## Summary

This PR introduces 5 new tools for operations on taxonomy concepts, specifically create, delete, update, get, and list. Additional updates are made in the concept-scheme directory to support the new monorepo structure, and remove inconsistent client creation methods.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
