### PR TITLE
chore: use legacy peer deps for npm ci []

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-scripts=true
+legacy-peer-deps=true


### PR DESCRIPTION
Adding this setting ensures `npm ci` will always use legacy-peer-deps which is a requirement as nx release will do so when publishing new versions: https://github.com/nrwl/nx/issues/22066#issuecomment-2161083527