### PR TITLE
fix: query param changed to match param to support full text search [DX-596]

### DIFF
--- a/packages/mcp-tools/src/tools/entries/searchEntries.ts
+++ b/packages/mcp-tools/src/tools/entries/searchEntries.ts
@@ -38,7 +38,7 @@ export const SearchEntriesToolParams = BaseToolSchema.extend({
       order: z.string().optional().describe('Order entries by this field'),
 
       // Full-text search
-      query: z
+      match: z
         .string()
         .optional()
         .describe('Full-text search across all fields'),


### PR DESCRIPTION
https://contentful.atlassian.net/browse/DX-596

Previously, a 'query' parameter was used in the tool props to support a full text search on entries. This query param did not actually do anything, so full text search was not applied as expected. With this change, the correct param name 'match' is now reflected in the tool props, which is then passed to the SDK, supporting full text search correctly.
