### PR TITLE
fix: suppress all dotenv logs [DX-629]

### DIFF
--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import dotenv from 'dotenv';
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const EnvSchema = z.object({
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: z


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

This PR suppresses all dotenv logs and resolves this issue: #298 

## Description

When running the MCP server directly, this was seen in the output:
<img width="661" height="30" alt="Screenshot 2025-12-23 at 9 36 49 AM" src="https://github.com/user-attachments/assets/d1c444e3-b74c-457b-8773-1b43746c0e0b" />

This PR sets `{quite: true}` for `dotenv.config()`

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Fixes #298 and prevents any extraneous output to stdout which can corrupt the JSON-RPC messages.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
