### PR TITLE
feat/EXT-7110/createToolClient-accessToken-runtime-evaluation

### DIFF
--- a/packages/mcp-tools/src/config/types.ts
+++ b/packages/mcp-tools/src/config/types.ts
@@ -3,7 +3,7 @@
  */
 export interface ContentfulConfig {
   /** Contentful CMA (Content Management API) access token */
-  accessToken: string;
+  accessToken: (() => Promise<string>) | string;
   /** Contentful API host (default: 'api.contentful.com') */
   host?: string;
   /** Contentful Space ID */

--- a/packages/mcp-tools/src/tools/ai-actions/createAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/createAiAction.ts
@@ -52,7 +52,7 @@ export function createAiActionTool(config: ContentfulConfig) {
       environmentId: args.environmentId || 'master',
     };
 
-    const contentfulClient = createToolClient(config, {
+    const contentfulClient = await createToolClient(config, {
       ...args,
       environmentId: args.environmentId || 'master',
     });

--- a/packages/mcp-tools/src/tools/ai-actions/deleteAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/deleteAiAction.ts
@@ -20,7 +20,7 @@ export function deleteAiActionTool(config: ContentfulConfig) {
       aiActionId: args.aiActionId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // First, get the AI action to store info for return
     const aiAction = await contentfulClient.aiAction.get(params);

--- a/packages/mcp-tools/src/tools/ai-actions/getAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/getAiAction.ts
@@ -20,7 +20,7 @@ export function getAiActionTool(config: ContentfulConfig) {
       aiActionId: args.aiActionId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the AI action
     const aiAction = await contentfulClient.aiAction.get(params);

--- a/packages/mcp-tools/src/tools/ai-actions/getAiActionInvocation.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/getAiActionInvocation.ts
@@ -22,7 +22,7 @@ export function getAiActionInvocationTool(config: ContentfulConfig) {
       invocationId: args.invocationId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     const aiActionInvocation =
       await contentfulClient.aiActionInvocation.get(params);

--- a/packages/mcp-tools/src/tools/ai-actions/invokeAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/invokeAiAction.ts
@@ -97,7 +97,7 @@ export function invokeAiActionTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
     const aiActions = [];
 
     for (const field of args.fields) {

--- a/packages/mcp-tools/src/tools/ai-actions/listAiActions.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/listAiActions.ts
@@ -36,7 +36,7 @@ export function listAiActionTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     const aiActions = await contentfulClient.aiAction.getMany({
       ...params,

--- a/packages/mcp-tools/src/tools/ai-actions/publishAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/publishAiAction.ts
@@ -20,7 +20,7 @@ export function publishAiActionTool(config: ContentfulConfig) {
       aiActionId: args.aiActionId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     try {
       // Get the AI action first

--- a/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.ts
@@ -20,7 +20,7 @@ export function unpublishAiActionTool(config: ContentfulConfig) {
       aiActionId: args.aiActionId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     try {
       // Unpublish the AI action

--- a/packages/mcp-tools/src/tools/ai-actions/updateAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/updateAiAction.ts
@@ -59,7 +59,7 @@ export function updateAiActionTool(config: ContentfulConfig) {
       aiActionId: args.aiActionId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get existing AI action, merge fields, and update
     const existingAiAction = await contentfulClient.aiAction.get(params);

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.ts
@@ -23,7 +23,7 @@ export function archiveAssetTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const assetIds = Array.isArray(args.assetId) ? args.assetId : [args.assetId];

--- a/packages/mcp-tools/src/tools/assets/deleteAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/deleteAsset.ts
@@ -20,7 +20,7 @@ export function deleteAssetTool(config: ContentfulConfig) {
       assetId: args.assetId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // First, get the asset to store info for return
     const asset = await contentfulClient.asset.get(params);

--- a/packages/mcp-tools/src/tools/assets/getAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/getAsset.ts
@@ -20,7 +20,7 @@ export function getAssetTool(config: ContentfulConfig) {
       assetId: args.assetId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the asset
     const asset = await contentfulClient.asset.get(params);

--- a/packages/mcp-tools/src/tools/assets/listAssets.ts
+++ b/packages/mcp-tools/src/tools/assets/listAssets.ts
@@ -43,7 +43,7 @@ export function listAssetsTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const assets = await contentfulClient.asset.getMany({
     ...params,

--- a/packages/mcp-tools/src/tools/assets/publishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.ts
@@ -29,7 +29,7 @@ export function publishAssetTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const assetIds = Array.isArray(args.assetId) ? args.assetId : [args.assetId];

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
@@ -23,7 +23,7 @@ export function unarchiveAssetTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const assetIds = Array.isArray(args.assetId) ? args.assetId : [args.assetId];

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
@@ -29,7 +29,7 @@ export function unpublishAssetTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const assetIds = Array.isArray(args.assetId) ? args.assetId : [args.assetId];

--- a/packages/mcp-tools/src/tools/assets/updateAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/updateAsset.ts
@@ -27,7 +27,7 @@ export function updateAssetTool(config: ContentfulConfig) {
       assetId: args.assetId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Get existing asset, merge fields, and update
   const existingAsset = await contentfulClient.asset.get(params);

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.ts
@@ -35,7 +35,7 @@ export function uploadAssetTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Prepare asset properties following Contentful's structure
   const locale = args.locale || 'en-US';

--- a/packages/mcp-tools/src/tools/content-types/createContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/createContentType.ts
@@ -36,7 +36,7 @@ export function createContentTypeTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const contentTypeData = {
     name: args.name,

--- a/packages/mcp-tools/src/tools/content-types/deleteContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/deleteContentType.ts
@@ -20,7 +20,7 @@ export function deleteContentTypeTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Delete the content type
     await contentfulClient.contentType.delete(params);

--- a/packages/mcp-tools/src/tools/content-types/getContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/getContentType.ts
@@ -21,7 +21,7 @@ export function getContentTypeTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the content type details
     const contentType = await contentfulClient.contentType.get({

--- a/packages/mcp-tools/src/tools/content-types/listContentTypes.ts
+++ b/packages/mcp-tools/src/tools/content-types/listContentTypes.ts
@@ -36,7 +36,7 @@ export function listContentTypesTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const contentTypes = await contentfulClient.contentType.getMany({
     ...params,

--- a/packages/mcp-tools/src/tools/content-types/publishContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/publishContentType.ts
@@ -20,7 +20,7 @@ export function publishContentTypeTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the content type first
     const currentContentType = await contentfulClient.contentType.get(params);

--- a/packages/mcp-tools/src/tools/content-types/unpublishContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/unpublishContentType.ts
@@ -20,7 +20,7 @@ export function unpublishContentTypeTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Unpublish the content type
     const contentType = await contentfulClient.contentType.unpublish(params);

--- a/packages/mcp-tools/src/tools/content-types/updateContentType.ts
+++ b/packages/mcp-tools/src/tools/content-types/updateContentType.ts
@@ -39,7 +39,7 @@ export function updateContentTypeTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Get the current content type
   const currentContentType = await contentfulClient.contentType.get(params);

--- a/packages/mcp-tools/src/tools/editor-interfaces/getEditorInterface.ts
+++ b/packages/mcp-tools/src/tools/editor-interfaces/getEditorInterface.ts
@@ -24,7 +24,7 @@ export function getEditorInterfaceTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     const editorInterface = await contentfulClient.editorInterface.get(params);
 

--- a/packages/mcp-tools/src/tools/editor-interfaces/listEditorInterfaces.ts
+++ b/packages/mcp-tools/src/tools/editor-interfaces/listEditorInterfaces.ts
@@ -18,7 +18,7 @@ export function listEditorInterfacesTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const editorInterfaces =
     await contentfulClient.editorInterface.getMany(params);

--- a/packages/mcp-tools/src/tools/editor-interfaces/updateEditorInterface.ts
+++ b/packages/mcp-tools/src/tools/editor-interfaces/updateEditorInterface.ts
@@ -103,7 +103,7 @@ export function updateEditorInterfaceTool(config: ContentfulConfig) {
       contentTypeId: args.contentTypeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Get the current editor interface
   const currentEditorInterface =

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.ts
@@ -23,7 +23,7 @@ export function archiveEntryTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];

--- a/packages/mcp-tools/src/tools/entries/createEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/createEntry.ts
@@ -28,7 +28,7 @@ export function createEntryTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
     const newEntry = await contentfulClient.entry.create(
       {
         ...params,

--- a/packages/mcp-tools/src/tools/entries/deleteEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/deleteEntry.ts
@@ -20,7 +20,7 @@ export function deleteEntryTool(config: ContentfulConfig) {
       entryId: args.entryId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // First, get the entry to check its status
     const entry = await contentfulClient.entry.get(params);

--- a/packages/mcp-tools/src/tools/entries/getEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/getEntry.ts
@@ -20,7 +20,7 @@ export function getEntryTool(config: ContentfulConfig) {
       entryId: args.entryId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the entry
     const entry = await contentfulClient.entry.get(params);

--- a/packages/mcp-tools/src/tools/entries/publishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.ts
@@ -29,7 +29,7 @@ export function publishEntryTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];

--- a/packages/mcp-tools/src/tools/entries/searchEntries.ts
+++ b/packages/mcp-tools/src/tools/entries/searchEntries.ts
@@ -118,7 +118,7 @@ export function searchEntriesTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     const entries = await contentfulClient.entry.getMany({
       ...params,

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
@@ -23,7 +23,7 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
@@ -29,7 +29,7 @@ export function unpublishEntryTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Normalize input to always be an array
   const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];

--- a/packages/mcp-tools/src/tools/entries/updateEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/updateEntry.ts
@@ -27,7 +27,7 @@ export function updateEntryTool(config: ContentfulConfig) {
       entryId: args.entryId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // First, get the existing entry
   const existingEntry = await contentfulClient.entry.get(params);

--- a/packages/mcp-tools/src/tools/environments/createEnvironment.ts
+++ b/packages/mcp-tools/src/tools/environments/createEnvironment.ts
@@ -21,7 +21,7 @@ type Params = z.infer<typeof CreateEnvironmentToolParams>;
 
 export function createEnvironmentTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Create the environment
     const environment = await contentfulClient.environment.createWithId(

--- a/packages/mcp-tools/src/tools/environments/deleteEnvironment.ts
+++ b/packages/mcp-tools/src/tools/environments/deleteEnvironment.ts
@@ -19,7 +19,7 @@ export function deleteEnvironmentTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Delete the environment
   await contentfulClient.environment.delete(params);

--- a/packages/mcp-tools/src/tools/environments/listEnvironments.ts
+++ b/packages/mcp-tools/src/tools/environments/listEnvironments.ts
@@ -39,7 +39,7 @@ export function listEnvironmentsTool(config: ContentfulConfig) {
       environmentId: args.environmentId || 'master',
     };
 
-    const contentfulClient = createToolClient(config, clientArgs);
+    const contentfulClient = await createToolClient(config, clientArgs);
 
   const environments = await contentfulClient.environment.getMany({
     spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/locales/createLocale.ts
+++ b/packages/mcp-tools/src/tools/locales/createLocale.ts
@@ -50,7 +50,7 @@ export function createLocaleTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // Create the locale
   const newLocale = await contentfulClient.locale.create(params, {

--- a/packages/mcp-tools/src/tools/locales/deleteLocale.ts
+++ b/packages/mcp-tools/src/tools/locales/deleteLocale.ts
@@ -20,7 +20,7 @@ export function deleteLocaleTool(config: ContentfulConfig) {
       localeId: args.localeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // First, get the locale to check its current state
     const locale = await contentfulClient.locale.get(params);

--- a/packages/mcp-tools/src/tools/locales/getLocale.ts
+++ b/packages/mcp-tools/src/tools/locales/getLocale.ts
@@ -20,7 +20,7 @@ export function getLocaleTool(config: ContentfulConfig) {
       localeId: args.localeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
     // Get the locale
     const locale = await contentfulClient.locale.get(params);

--- a/packages/mcp-tools/src/tools/locales/listLocales.ts
+++ b/packages/mcp-tools/src/tools/locales/listLocales.ts
@@ -30,7 +30,7 @@ export function listLocaleTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const locales = await contentfulClient.locale.getMany({
     ...params,

--- a/packages/mcp-tools/src/tools/locales/updateLocale.ts
+++ b/packages/mcp-tools/src/tools/locales/updateLocale.ts
@@ -47,7 +47,7 @@ export function updateLocaleTool(config: ContentfulConfig) {
       localeId: args.localeId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   // First, get the existing locale
   const existingLocale = await contentfulClient.locale.get(params);

--- a/packages/mcp-tools/src/tools/tags/createTag.ts
+++ b/packages/mcp-tools/src/tools/tags/createTag.ts
@@ -24,7 +24,7 @@ export function createTagTool(config: ContentfulConfig) {
       tagId: args.id,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const newTag = await contentfulClient.tag.createWithId(params, {
     name: args.name,

--- a/packages/mcp-tools/src/tools/tags/listTags.ts
+++ b/packages/mcp-tools/src/tools/tags/listTags.ts
@@ -26,7 +26,7 @@ export function listTagsTool(config: ContentfulConfig) {
       environmentId: args.environmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = await createToolClient(config, args);
 
   const tags = await contentfulClient.tag.getMany({
     ...params,

--- a/packages/mcp-tools/src/utils/tools.ts
+++ b/packages/mcp-tools/src/utils/tools.ts
@@ -15,12 +15,12 @@ export const BaseToolSchema = z.object({
  * @param params - Tool parameters that may include a resource
  * @returns Configured Contentful client
  */
-export function createToolClient(
+export async function createToolClient(
   config: ContentfulConfig,
   params: z.infer<typeof BaseToolSchema>,
 ) {
   const clientConfig: ClientOptions = {
-    accessToken: config.accessToken,
+    accessToken: typeof config.accessToken === 'function' ? await config.accessToken() : config.accessToken,
     host: config.host ?? 'api.contentful.com',
     space: params.spaceId ?? config.spaceId,
     headers: {


### PR DESCRIPTION
# Summary
The client can now evaluate accessTokens at execute time.

# Description
- `createToolClient` is async
- `ContentfulConfig.accessToken` can be either a string OR a function that returns a string promise

## Motivation and Context
This supports cases where the accessToken may change (i.e. rotation, expiration, etc).

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [X] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [X] PR doesn't contain any sensitive information
- [X] There are no breaking changes
