### PR TITLE
fix: mark SPACE_ID as optional and document multi-space usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Below is a sample configuration:
 
 ### Working with Multiple Spaces
 
-The MCP server supports working with multiple Contentful spaces from a single instance. Space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
+The MCP server supports working with multiple Contentful spaces from a single instance. Most space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Some tools like `get_space` only require `spaceId`. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
 
 To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Below is a sample configuration:
 
 ### Working with Multiple Spaces
 
-The MCP server supports working with multiple Contentful spaces from a single instance. Every tool accepts `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call.
+The MCP server supports working with multiple Contentful spaces from a single instance. Space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
 
 To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This MCP server provides a comprehensive set of tools for content management, al
 
 - Node.js
 - npm
-- A Contentful account with a [Space ID](https://www.contentful.com/help/spaces/find-space-id/)
+- A Contentful account with one or more [Spaces](https://www.contentful.com/help/spaces/find-space-id/)
 - [Contentful Management API personal access token](https://www.contentful.com/help/token-management/personal-access-tokens/)
 
 ### Installation
@@ -72,7 +72,7 @@ npm run build
 | Environment Variable                 | Required | Default Value        | Description                                          |
 | ------------------------------------ | -------- | -------------------- | ---------------------------------------------------- |
 | `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | ✅ Yes   | -                    | Your Contentful Management API personal access token |
-| `SPACE_ID`                           | ✅ Yes   | -                    | Your Contentful Space ID                             |
+| `SPACE_ID`                           | ❌ No    | -                    | Default Contentful Space ID (can be overridden per tool call) |
 | `ENVIRONMENT_ID`                     | ❌ No    | `master`             | Target environment within your space                 |
 | `CONTENTFUL_HOST`                    | ❌ No    | `api.contentful.com` | Contentful API host                                  |
 | `NODE_ENV`                           | ❌ No    | `production`         | Node Environment to run in                           |
@@ -99,6 +99,28 @@ Below is a sample configuration:
   }
 }
 ```
+
+### Working with Multiple Spaces
+
+The MCP server supports working with multiple Contentful spaces from a single instance. Every tool accepts `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call.
+
+To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
+
+```json
+{
+  "mcpServers": {
+    "contentful-mcp": {
+      "command": "npx",
+      "args": ["-y", "@contentful/mcp-server"],
+      "env": {
+        "CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "your-CMA-token"
+      }
+    }
+  }
+}
+```
+
+The AI assistant can use `list_spaces` to discover available spaces and switch between them dynamically. If `SPACE_ID` is provided, it serves as the default but can be overridden on any tool call.
 
 ## 🛠️ Available Tools
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -37,7 +37,7 @@ This MCP server provides a comprehensive set of tools for content management, al
 
 - Node.js
 - npm
-- A Contentful account with a [Space ID](https://www.contentful.com/help/spaces/find-space-id/)
+- A Contentful account with one or more [Spaces](https://www.contentful.com/help/spaces/find-space-id/)
 - [Contentful Management API personal access token](https://www.contentful.com/help/token-management/personal-access-tokens/)
 
 ### Installation
@@ -66,7 +66,7 @@ npm run build
 | Environment Variable                 | Required | Default Value        | Description                                          |
 | ------------------------------------ | -------- | -------------------- | ---------------------------------------------------- |
 | `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | ✅ Yes   | -                    | Your Contentful Management API personal access token |
-| `SPACE_ID`                           | ✅ Yes   | -                    | Your Contentful Space ID                             |
+| `SPACE_ID`                           | ❌ No    | -                    | Default Contentful Space ID (can be overridden per tool call) |
 | `ENVIRONMENT_ID`                     | ❌ No    | `master`             | Target environment within your space                 |
 | `CONTENTFUL_HOST`                    | ❌ No    | `api.contentful.com` | Contentful API host                                  |
 | `NODE_ENV`                           | ❌ No    | `production`         | Node Environment to run in                           |
@@ -93,6 +93,28 @@ Below is a sample configuration:
   }
 }
 ```
+
+### Working with Multiple Spaces
+
+The MCP server supports working with multiple Contentful spaces from a single instance. Every tool accepts `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call.
+
+To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
+
+```json
+{
+  "mcpServers": {
+    "contentful-mcp": {
+      "command": "npx",
+      "args": ["-y", "@contentful/mcp-server"],
+      "env": {
+        "CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "your-CMA-token"
+      }
+    }
+  }
+}
+```
+
+The AI assistant can use `list_spaces` to discover available spaces and switch between them dynamically. If `SPACE_ID` is provided, it serves as the default but can be overridden on any tool call.
 
 ## 🛠️ Available Tools
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -96,7 +96,7 @@ Below is a sample configuration:
 
 ### Working with Multiple Spaces
 
-The MCP server supports working with multiple Contentful spaces from a single instance. Every tool accepts `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call.
+The MCP server supports working with multiple Contentful spaces from a single instance. Space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
 
 To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -96,7 +96,7 @@ Below is a sample configuration:
 
 ### Working with Multiple Spaces
 
-The MCP server supports working with multiple Contentful spaces from a single instance. Space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
+The MCP server supports working with multiple Contentful spaces from a single instance. Most space-scoped tools (entries, assets, content types, etc.) accept `spaceId` and `environmentId` as parameters, allowing the AI assistant to target any space accessible by your token on each tool call. Some tools like `get_space` only require `spaceId`. Organization-level tools like `list_spaces` and `list_orgs` work across all accessible spaces without requiring these parameters.
 
 To work with multiple spaces, omit `SPACE_ID` from your configuration and ensure your CMA token has access to all desired spaces:
 

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -308,8 +308,8 @@
     "SPACE_ID": {
       "type": "string",
       "title": "SPACE_ID",
-      "description": "Contentful Space ID",
-      "required": true
+      "description": "Default Contentful Space ID (optional — omit to work with multiple spaces)",
+      "required": false
     },
     "ENVIRONMENT_ID": {
       "type": "string",


### PR DESCRIPTION
## Summary

- **Mark `SPACE_ID` as optional** in the environment variables table and `manifest.json`, aligning documentation with the actual behavior in `env.ts` where it is already defined as `z.string().optional()`
- **Add "Working with Multiple Spaces" section** to both READMEs with a configuration example for users managing multiple spaces from a single MCP server instance
- **Fix `manifest.json`**: change `SPACE_ID` from `required: true` to `required: false`, so Claude Desktop (`.dxt`) users are not blocked from multi-space setups

### Context

Users with access to multiple Contentful spaces currently have no documentation indicating they can use a single MCP server instance across all their spaces. Since every tool already accepts `spaceId` as a parameter (via `BaseToolSchema`), and `createToolClient` resolves space as `params.spaceId ?? config.spaceId`, multi-space usage already works — it's just not documented and the manifest incorrectly enforces a required `SPACE_ID`.

This was confirmed in #314 (multi-environment support), where a maintainer clarified that the configured values are just defaults and can be overridden per tool call. However, the documentation was never updated to reflect this.

## Test plan

- [ ] Verify `npm run build` succeeds (no code changes, only docs + manifest)
- [ ] Verify `npm run lint` passes
- [ ] Confirm the `.dxt` configuration flow in Claude Desktop no longer requires `SPACE_ID`
- [ ] Manually test multi-space usage: configure without `SPACE_ID`, use `list_spaces`, then operate on different spaces