### PR TITLE
feat: support local file uploads via base64 data URIs in upload_asset [DX-924]

### DIFF
--- a/packages/mcp-tools/src/tools/assets/mockClient.ts
+++ b/packages/mcp-tools/src/tools/assets/mockClient.ts
@@ -17,6 +17,7 @@ export const mockAssetArchive = vi.fn();
 export const mockAssetUnarchive = vi.fn();
 export const mockAssetGetMany = vi.fn();
 export const mockAssetProcessForAllLocales = vi.fn();
+export const mockUploadCreate = vi.fn();
 
 // Mock bulk operations
 export const mockBulkActionPublish = vi.fn();
@@ -38,6 +39,9 @@ export const mockClient = {
     unarchive: mockAssetUnarchive,
     getMany: mockAssetGetMany,
     processForAllLocales: mockAssetProcessForAllLocales,
+  },
+  upload: {
+    create: mockUploadCreate,
   },
   bulkAction: {
     publish: mockBulkActionPublish,

--- a/packages/mcp-tools/src/tools/assets/register.ts
+++ b/packages/mcp-tools/src/tools/assets/register.ts
@@ -29,7 +29,8 @@ export function createAssetTools(config: ContentfulConfig) {
   return {
     uploadAsset: {
       title: 'upload_asset',
-      description: 'Upload a new asset',
+      description:
+        'Upload a new asset. When uploading local binary files as base64, always re-encode from the source file immediately before the tool call — never re-use base64 from a previous tool output or from context.',
       inputParams: UploadAssetToolParams.shape,
       annotations: {
         readOnlyHint: false,

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.test.ts
@@ -274,6 +274,32 @@ describe('uploadAsset', () => {
     });
   });
 
+  it('should return a clear error when the data URI is malformed (no comma)', async () => {
+    const testArgs = {
+      ...mockArgs,
+      title: 'Bad Upload',
+      file: {
+        fileName: 'photo.jpg',
+        contentType: 'image/jpeg',
+        upload: 'data:image/jpeg;base64',
+      },
+    };
+
+    const tool = uploadAssetTool(mockConfig);
+    const result = await tool(testArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error uploading asset: Invalid data URI format. Expected data:<mime>;base64,<data>',
+        },
+      ],
+    });
+    expect(mockUploadCreate).not.toHaveBeenCalled();
+  });
+
   it('should upload an asset with a custom locale', async () => {
     const testArgs = {
       ...mockArgs,

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.test.ts
@@ -5,6 +5,7 @@ import {
   setupMockClient,
   mockAssetCreate,
   mockAssetProcessForAllLocales,
+  mockUploadCreate,
   mockArgs,
   mockFile,
   mockAsset,
@@ -223,6 +224,56 @@ describe('uploadAsset', () => {
       }),
     );
   });
+  it('should upload an asset via base64 data URI using the Upload API', async () => {
+    const base64Data = Buffer.from('fake-image-bytes').toString('base64');
+    const testArgs = {
+      ...mockArgs,
+      title: 'Local Image',
+      file: {
+        fileName: 'photo.jpg',
+        contentType: 'image/jpeg',
+        upload: `data:image/jpeg;base64,${base64Data}`,
+      },
+    };
+
+    const mockUpload = { sys: { id: 'upload-123' } };
+    mockUploadCreate.mockResolvedValue(mockUpload);
+    mockAssetCreate.mockResolvedValue(mockAsset);
+    mockAssetProcessForAllLocales.mockResolvedValue(mockProcessedAsset);
+
+    const tool = uploadAssetTool(mockConfig);
+    const result = await tool(testArgs);
+
+    expect(mockUploadCreate).toHaveBeenCalledWith(
+      { spaceId: testArgs.spaceId, environmentId: testArgs.environmentId },
+      { file: expect.any(ArrayBuffer) },
+    );
+
+    expect(mockAssetCreate).toHaveBeenCalledWith(
+      { spaceId: testArgs.spaceId, environmentId: testArgs.environmentId },
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          file: {
+            'en-US': {
+              fileName: 'photo.jpg',
+              contentType: 'image/jpeg',
+              uploadFrom: {
+                sys: { type: 'Link', linkType: 'Upload', id: 'upload-123' },
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const expectedResponse = formatResponse('Asset uploaded successfully', {
+      asset: mockProcessedAsset,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
   it('should upload an asset with a custom locale', async () => {
     const testArgs = {
       ...mockArgs,

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.ts
@@ -65,7 +65,11 @@ export function uploadAssetTool(config: ContentfulConfig) {
         );
       }
       const base64 = args.file.upload.slice(commaIndex + 1);
-      const buffer = Buffer.from(base64, 'base64').buffer;
+      const decoded = Buffer.from(base64, 'base64');
+      const buffer = decoded.buffer.slice(
+        decoded.byteOffset,
+        decoded.byteOffset + decoded.byteLength,
+      );
       const upload = await contentfulClient.upload.create(params, {
         file: buffer,
       });

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.ts
@@ -65,12 +65,7 @@ export function uploadAssetTool(config: ContentfulConfig) {
         );
       }
       const base64 = args.file.upload.slice(commaIndex + 1);
-      const binary = atob(base64);
-      const buffer = new ArrayBuffer(binary.length);
-      const view = new Uint8Array(buffer);
-      for (let i = 0; i < binary.length; i++) {
-        view[i] = binary.charCodeAt(i);
-      }
+      const buffer = Buffer.from(base64, 'base64').buffer;
       const upload = await contentfulClient.upload.create(params, {
         file: buffer,
       });

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.ts
@@ -10,7 +10,12 @@ import type { ContentfulConfig } from '../../config/types.js';
 const FileSchema = z.object({
   fileName: z.string().describe('The name of the file'),
   contentType: z.string().describe('The MIME type of the file'),
-  upload: z.string().optional().describe('The upload URL or file data'),
+  upload: z
+    .string()
+    .optional()
+    .describe(
+      'The file source. Accepts either a publicly accessible https:// URL, or a base64-encoded data URI (e.g. data:image/png;base64,...). Use the data URI format to upload local files — the MCP client should base64-encode the file before passing it here.',
+    ),
 });
 
 export const UploadAssetToolParams = BaseToolSchema.extend({
@@ -37,35 +42,66 @@ export function uploadAssetTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-  // Prepare asset properties following Contentful's structure
-  const locale = args.locale || 'en-US';
-  const assetProps = {
-    fields: {
-      title: { [locale]: args.title },
-      description: args.description
-        ? { [locale]: args.description }
-        : undefined,
-      file: { [locale]: args.file },
-    },
-    metadata: args.metadata,
-  };
+    // Prepare asset properties following Contentful's structure
+    const locale = args.locale || 'en-US';
 
-  // Create the asset
-  const asset = await contentfulClient.asset.create(params, assetProps);
+    type FileField = {
+      fileName: string;
+      contentType: string;
+      upload?: string;
+      uploadFrom?: { sys: { type: 'Link'; linkType: 'Upload'; id: string } };
+    };
 
-  // Process the asset for all locales
-  const processedAsset = await contentfulClient.asset.processForAllLocales(
-    params,
-    {
-      sys: asset.sys,
-      fields: asset.fields,
-    },
-    {},
-  );
+    const fileField: FileField = {
+      fileName: args.file.fileName,
+      contentType: args.file.contentType,
+    };
 
-  return createSuccessResponse('Asset uploaded successfully', {
-    asset: processedAsset,
-  });
+    if (args.file.upload?.startsWith('data:')) {
+      const base64 = args.file.upload.split(',')[1];
+      const binary = atob(base64);
+      const buffer = new ArrayBuffer(binary.length);
+      const view = new Uint8Array(buffer);
+      for (let i = 0; i < binary.length; i++) {
+        view[i] = binary.charCodeAt(i);
+      }
+      const upload = await contentfulClient.upload.create(params, {
+        file: buffer,
+      });
+      fileField.uploadFrom = {
+        sys: { type: 'Link', linkType: 'Upload', id: upload.sys.id },
+      };
+    } else if (args.file.upload) {
+      fileField.upload = args.file.upload;
+    }
+
+    const assetProps = {
+      fields: {
+        title: { [locale]: args.title },
+        description: args.description
+          ? { [locale]: args.description }
+          : undefined,
+        file: { [locale]: fileField },
+      },
+      metadata: args.metadata,
+    };
+
+    // Create the asset
+    const asset = await contentfulClient.asset.create(params, assetProps);
+
+    // Process the asset for all locales
+    const processedAsset = await contentfulClient.asset.processForAllLocales(
+      params,
+      {
+        sys: asset.sys,
+        fields: asset.fields,
+      },
+      {},
+    );
+
+    return createSuccessResponse('Asset uploaded successfully', {
+      asset: processedAsset,
+    });
   }
 
   return withErrorHandling(tool, 'Error uploading asset');

--- a/packages/mcp-tools/src/tools/assets/uploadAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/uploadAsset.ts
@@ -58,7 +58,13 @@ export function uploadAssetTool(config: ContentfulConfig) {
     };
 
     if (args.file.upload?.startsWith('data:')) {
-      const base64 = args.file.upload.split(',')[1];
+      const commaIndex = args.file.upload.indexOf(',');
+      if (commaIndex === -1) {
+        throw new Error(
+          'Invalid data URI format. Expected data:<mime>;base64,<data>',
+        );
+      }
+      const base64 = args.file.upload.slice(commaIndex + 1);
       const binary = atob(base64);
       const buffer = new ArrayBuffer(binary.length);
       const view = new Uint8Array(buffer);


### PR DESCRIPTION
[DX-924](https://contentful.atlassian.net/browse/DX-924)

## Summary
- Adds support for uploading local files through the remote MCP server by accepting base64-encoded data URIs (`data:<mime>;base64,...`) in the `upload_asset` tool's `file.upload` field
- Detects the `data:` prefix server-side, decodes to `ArrayBuffer` using `atob` (Cloudflare Workers-native, no `fs` required), POSTs binary to the Contentful Upload API, and creates the asset via `uploadFrom`
- Existing `https://` URL uploads are fully unchanged

Generated with [Claude Code](https://claude.com/claude-code)

[DX-924]: https://contentful.atlassian.net/browse/DX-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR optimizes the base64 decoding in the upload_asset tool for local file uploads via data URIs by improving ArrayBuffer creation using Buffer.from() and proper buffer slicing. It maintains full backward compatibility with URL-based uploads and preserves integration with the Contentful Upload API and asset creation workflow.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Optimizes base64 decoding in uploadAsset.ts by replacing direct .buffer access with proper slicing to ensure correct ArrayBuffer creation for data URI uploads</li>

<li>Maintains existing data URI validation and error handling for malformed URIs</li>

<li>Preserves integration with Contentful Upload API and asset creation workflow</li>

<li>No changes to test coverage or mock implementations</li>

</ul>
</details>

</div>