### PR TITLE
fix: lazy import used for contentful-export

### DIFF
--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -1,8 +1,4 @@
 import { z } from 'zod';
-import * as contentfulExportModule from 'contentful-export';
-const contentfulExport =
-  (contentfulExportModule as any).default ?? contentfulExportModule;
-import { join } from 'path';
 import {
   createSuccessResponse,
   withErrorHandling,
@@ -144,9 +140,13 @@ export function createExportSpaceTool(config: ContentfulConfig) {
     } as any;
 
     try {
-      const result = await contentfulExport(exportOptions);
+      const contentfulExport = await import('contentful-export');
+      const path = await import('path');
 
-      const exportPath = join(
+      // @ts-ignore The dynamic import is typed differently across project configs, but the runtime default export is callable.
+      const result = await contentfulExport.default(exportOptions);
+
+      const exportPath = path.join(
         exportOptions.exportDir,
         exportOptions.contentFile,
       );

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -143,7 +143,8 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       const contentfulExport = await import('contentful-export');
       const path = await import('path');
 
-      // @ts-ignore The dynamic import is typed differently across project configs, but the runtime default export is callable.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore The runtime default export is callable even though the import is typed as a module namespace here.
       const result = await contentfulExport.default(exportOptions);
 
       const exportPath = path.join(


### PR DESCRIPTION
A previous merge removed lazy import from this path, which caused the remote server to break. This PR reimplements lazy importing here with adding typescript flags to pass the typecheck. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>A previous merge removed lazy import from this path, which caused the remote server to break. This PR reimplements lazy importing here with adding typescript flags to pass the typecheck, modifying the exportSpace.ts file to use dynamic imports instead of static ones. The changes introduce dynamic imports for contentful-export and path modules inside the createExportSpaceTool function to enable lazy loading and prevent remote server failures.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces dynamic import for 'contentful-export' module inside the createExportSpaceTool function to enable lazy loading (exportSpace.ts).</li>

<li>Adds dynamic import for 'path' module to maintain consistency with lazy loading approach (exportSpace.ts).</li>

<li>Updates the export call to use contentfulExport.default() instead of the previous static import (exportSpace.ts).</li>

<li>Includes a @ts-ignore comment with eslint-disable-next-line to bypass TypeScript type checking for dynamic import typing differences (exportSpace.ts).</li>

</ul>
</details>

</div>