### PR TITLE
fix: mark publish/unpublish/archive tools as destructive [DX-1059]

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 ignore-scripts=true
 legacy-peer-deps=true
+registry=https://registry.npmjs.org

--- a/packages/mcp-tools/src/tools/ai-actions/register.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/register.ts
@@ -120,7 +120,7 @@ export function createAiActionTools(config: ContentfulConfig) {
       inputParams: PublishAiActionToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true, // Publishing same item multiple times has same effect
         openWorldHint: false,
       },
@@ -133,7 +133,7 @@ export function createAiActionTools(config: ContentfulConfig) {
       inputParams: UnpublishAiActionToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true, // Unpublishing same item multiple times has same effect
         openWorldHint: false,
       },

--- a/packages/mcp-tools/src/tools/assets/register.ts
+++ b/packages/mcp-tools/src/tools/assets/register.ts
@@ -92,7 +92,7 @@ export function createAssetTools(config: ContentfulConfig) {
       inputParams: PublishAssetToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -105,7 +105,7 @@ export function createAssetTools(config: ContentfulConfig) {
       inputParams: UnpublishAssetToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -118,7 +118,7 @@ export function createAssetTools(config: ContentfulConfig) {
       inputParams: ArchiveAssetToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp-tools/src/tools/content-types/register.ts
+++ b/packages/mcp-tools/src/tools/content-types/register.ts
@@ -102,7 +102,7 @@ export function createContentTypeTools(config: ContentfulConfig) {
       inputParams: PublishContentTypeToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -114,7 +114,7 @@ export function createContentTypeTools(config: ContentfulConfig) {
       inputParams: UnpublishContentTypeToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp-tools/src/tools/entries/register.ts
+++ b/packages/mcp-tools/src/tools/entries/register.ts
@@ -92,7 +92,7 @@ export function createEntryTools(config: ContentfulConfig) {
       inputParams: PublishEntryToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -105,7 +105,7 @@ export function createEntryTools(config: ContentfulConfig) {
       inputParams: UnpublishEntryToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -118,7 +118,7 @@ export function createEntryTools(config: ContentfulConfig) {
       inputParams: ArchiveEntryToolParams.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: false,
       },


### PR DESCRIPTION
[DX-1059](https://contentful.atlassian.net/browse/DX-1059)

## Summary
- Set `destructiveHint: true` on `publish_entry`, `unpublish_entry`, `archive_entry`, `publish_asset`, `unpublish_asset`, `archive_asset`, `publish_content_type`, `unpublish_content_type`, `publish_ai_action`, and `unpublish_ai_action`. MCP clients (Claude Desktop, Cursor) use this hint to decide whether to prompt for confirmation before invoking a tool.
- The bulk variants of `publish_entry` / `unpublish_entry` accept up to 100 IDs in a single call, so executing without a confirmation prompt posed an outsized safety risk — flagged by Klarna as part of GA readiness.
- Audited all other tool annotations: `delete_*` were already correct (`destructiveHint: true`); `unarchive_*` correctly remain `false` since they restore rather than alter live state; create/update/upload/list/get/search remain `false`.

## Test plan
- [x] `nx run mcp-tools:typecheck` passes
- [x] `nx run mcp-tools:lint` passes (only pre-existing warnings)
- [x] `nx run mcp-tools:test:run` — 297 / 297 tests pass
- [ ] Manual smoke: connect Claude Desktop to a build of this branch, invoke `publish_entry` and confirm the client now shows a confirmation prompt

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1059]: https://contentful.atlassian.net/browse/DX-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes incorrect tool annotations in the Contentful MCP server by marking 10 publish/unpublish/archive operations as destructive. MCP clients use the destructiveHint annotation to determine whether to prompt for user confirmation before executing a tool, and the bulk variants of these operations (accepting up to 100 IDs) posed an outsized safety risk without proper confirmation.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Sets destructiveHint: true on publish_entry, unpublish_entry, and archive_entry in entries/register.ts to trigger confirmation prompts before executing bulk content publishing operations</li>

<li>Sets destructiveHint: true on publish_asset, unpublish_asset, and archive_asset in assets/register.ts for asset state-changing operations</li>

<li>Sets destructiveHint: true on publish_content_type and unpublish_content_type in content-types/register.ts for content type publishing operations</li>

<li>Sets destructiveHint: true on publish_ai_action and unpublish_ai_action in ai-actions/register.ts for AI action state-changing operations</li>

</ul>
</details>

</div>