### PR TITLE
fix: normalize array filters in search_entries to fix CMA 400 [DX-1171]

### DIFF
--- a/packages/mcp-tools/src/tools/entries/searchEntries.test.ts
+++ b/packages/mcp-tools/src/tools/entries/searchEntries.test.ts
@@ -154,6 +154,46 @@ describe('searchEntries', () => {
     });
   });
 
+  it('should normalize array-valued filters into comma-separated strings', async () => {
+    const testArgs = {
+      ...mockArgs,
+      query: {
+        content_type: 'article',
+        'sys.id[in]': ['id-1', 'id-2', 'id-3'],
+        'metadata.tags.sys.id[in]': ['tag-1', 'tag-2'],
+        'fields.tags[nin]': ['archived'],
+      },
+    };
+
+    mockEntryGetMany.mockResolvedValue({
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 10,
+    });
+    vi.mocked(summarizeData).mockReturnValue({
+      items: [],
+      total: 0,
+      displayed: 0,
+    });
+
+    const tool = searchEntriesTool(mockConfig);
+    await tool(testArgs);
+
+    expect(mockEntryGetMany).toHaveBeenCalledWith({
+      spaceId: testArgs.spaceId,
+      environmentId: testArgs.environmentId,
+      query: {
+        content_type: 'article',
+        'sys.id[in]': 'id-1,id-2,id-3',
+        'metadata.tags.sys.id[in]': 'tag-1,tag-2',
+        'fields.tags[nin]': 'archived',
+        limit: 10,
+        skip: 0,
+      },
+    });
+  });
+
   it('should handle errors when search fails', async () => {
     const testArgs = {
       ...mockArgs,

--- a/packages/mcp-tools/src/tools/entries/searchEntries.ts
+++ b/packages/mcp-tools/src/tools/entries/searchEntries.ts
@@ -6,6 +6,7 @@ import {
 import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
 import { summarizeData } from '../../utils/summarizer.js';
 import { searchLimit } from '../../utils/limits.js';
+import { normalizeArrayFilters } from '../../utils/queryParams.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const SearchEntriesToolParams = BaseToolSchema.extend({
@@ -122,11 +123,11 @@ export function searchEntriesTool(config: ContentfulConfig) {
 
     const entries = await contentfulClient.entry.getMany({
       ...params,
-      query: {
+      query: normalizeArrayFilters({
         ...args.query,
         limit: searchLimit(args.query.limit),
         skip: args.query.skip || 0,
-      },
+      }),
     });
 
     const summarized = summarizeData(entries, {

--- a/packages/mcp-tools/src/utils/queryParams.test.ts
+++ b/packages/mcp-tools/src/utils/queryParams.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeArrayFilters } from './queryParams.js';
+
+describe('normalizeArrayFilters', () => {
+  it('joins array values into comma-separated strings', () => {
+    const result = normalizeArrayFilters({
+      'sys.id[in]': ['a', 'b', 'c'],
+    });
+
+    expect(result).toEqual({ 'sys.id[in]': 'a,b,c' });
+  });
+
+  it('leaves scalar values untouched', () => {
+    const query = {
+      content_type: 'article',
+      limit: 10,
+      skip: 0,
+      'fields.title': 'hello',
+    };
+
+    expect(normalizeArrayFilters(query)).toEqual(query);
+  });
+
+  it('handles a mix of array and scalar values', () => {
+    const result = normalizeArrayFilters({
+      content_type: 'article',
+      'sys.id[in]': ['a', 'b'],
+      'metadata.tags.sys.id[in]': ['t1', 't2', 't3'],
+      limit: 25,
+    });
+
+    expect(result).toEqual({
+      content_type: 'article',
+      'sys.id[in]': 'a,b',
+      'metadata.tags.sys.id[in]': 't1,t2,t3',
+      limit: 25,
+    });
+  });
+
+  it('normalizes catchall array filters regardless of suffix', () => {
+    const result = normalizeArrayFilters({
+      'fields.tags[nin]': ['archived', 'draft'],
+      'fields.categories[all]': ['news', 'tech'],
+      'fields.title[match]': ['quick', 'brown'],
+    });
+
+    expect(result).toEqual({
+      'fields.tags[nin]': 'archived,draft',
+      'fields.categories[all]': 'news,tech',
+      'fields.title[match]': 'quick,brown',
+    });
+  });
+
+  it('coerces single-element arrays to plain strings', () => {
+    const result = normalizeArrayFilters({
+      'sys.id[in]': ['only-one'],
+    });
+
+    expect(result).toEqual({ 'sys.id[in]': 'only-one' });
+  });
+
+  it('returns the same reference when no arrays are present', () => {
+    const query = { content_type: 'article', limit: 10 };
+
+    expect(normalizeArrayFilters(query)).toBe(query);
+  });
+
+  it('does not mutate the input query', () => {
+    const ids = ['a', 'b'];
+    const query = { 'sys.id[in]': ids };
+
+    normalizeArrayFilters(query);
+
+    expect(query['sys.id[in]']).toBe(ids);
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('handles empty arrays by emitting an empty string', () => {
+    const result = normalizeArrayFilters({ 'sys.id[in]': [] });
+
+    expect(result).toEqual({ 'sys.id[in]': '' });
+  });
+});

--- a/packages/mcp-tools/src/utils/queryParams.ts
+++ b/packages/mcp-tools/src/utils/queryParams.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizes array-valued query parameters into comma-separated strings so the
+ * Contentful Management API receives `?key=a,b,c` instead of `?key[0]=a&key[1]=b`.
+ *
+ * The CMA SDK passes params through to qs.stringify with its default
+ * `arrayFormat: 'indices'`, which the API rejects with HTTP 400 for filter
+ * operators like `[in]`, `[nin]`, `[all]`, and `[match]`. Mirrors the behavior
+ * of `normalizeSearchParameters` in contentful.js.
+ */
+export function normalizeArrayFilters<T extends Record<string, unknown>>(
+  query: T,
+): T {
+  const normalized: Record<string, unknown> = {};
+  let didConvert = false;
+
+  for (const key of Object.keys(query)) {
+    const value = query[key];
+    if (Array.isArray(value)) {
+      normalized[key] = value.join(',');
+      didConvert = true;
+    }
+  }
+
+  return didConvert ? { ...query, ...normalized } : query;
+}


### PR DESCRIPTION
## Summary

- The CMA SDK passes query params through to `qs.stringify` with its default `arrayFormat: 'indices'`, so array filters were serialized as `?key[0]=a&key[1]=b` and rejected by the API with HTTP 400. `search_entries` was the one MCP surface that exposed this — `contentful.js` already normalizes via `normalizeSearchParameters`, but `contentful-management.js` does not, and the MCP layer never bridged the gap.
- Adds `normalizeArrayFilters` (mirrors the contentful.js helper) and applies it inside `searchEntriesTool` before calling `entry.getMany`. Covers `[in]`, `[nin]`, `[all]`, `[match]`, and any catchall array filter.
- Other list tools have closed Zod schemas without array filters, and bulk-action tools loop one ID at a time — so `search_entries` is the only tool that needed the change today.

## Repro

Reported by Robinhood (ES-325 / Jobe Teehan) — calling `search_entries` with `sys.id[in]: ['id-1', 'id-2']` returned HTTP 400 from `/spaces/.../entries`. After this fix, the same call serializes to `?sys.id%5Bin%5D=id-1%2Cid-2` and succeeds.

## Test plan

- [x] New unit tests for `normalizeArrayFilters` (8 cases: arrays, scalars, mixed, all suffix variants, single-element arrays, identity for no-array input, no input mutation, empty arrays)
- [x] New `search_entries` integration test asserting array filters are joined before reaching `entry.getMany`
- [x] Existing `search_entries` tests still pass
- [x] `npm test`, `npm run lint`, and `nx run mcp-tools:typecheck` clean

Resolves [DX-1171](https://contentful.atlassian.net/browse/DX-1171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-1171]: https://contentful.atlassian.net/browse/DX-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes an HTTP 400 error in the `search_entries` MCP tool by normalizing array-valued query parameters into comma-separated strings before sending them to the Contentful Management API. The issue occurred because the CMA SDK uses `qs.stringify` with default `arrayFormat: 'indices'`, producing `?key[0]=a&key[1]=b` format which the API rejects for filter operators like `[in]`, `[nin]`, `[all]`, and `[match]`.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds `normalizeArrayFilters` utility in `queryParams.ts` that converts array-valued parameters to comma-separated strings, fixing API 400 errors when using array filter operators.</li>

<li>Applies `normalizeArrayFilters` in `searchEntriesTool` before calling `entry.getMany`, ensuring all array filter query parameters are properly serialized for CMA API compatibility.</li>

<li>Adds 8 unit tests in `queryParams.test.ts` covering array joining, scalar passthrough, mixed values, suffix variants, single-element arrays, input immutability, and empty arrays.</li>

<li>Adds integration test in `searchEntries.test.ts` verifying that array filters like `sys.id[in]: ['id-1', 'id-2']` are correctly normalized to `'id-1,id-2'` before reaching `entry.getMany`.</li>

</ul>
</details>

</div>