### PR TITLE
fix: remove host/proxy/headers from export_space and import_space tool schemas [DX-1177]

### DIFF
--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -19,6 +19,18 @@ const EnvSchema = z.object({
     .default('master')
     .describe('Contentful environment ID'),
   ORGANIZATION_ID: z.string().optional().describe('Contentful organization ID'),
+  CONTENTFUL_DELIVERY_TOKEN: z
+    .string()
+    .optional()
+    .describe(
+      'Contentful CDA token (used with export_space to export only published content)',
+    ),
+  CONTENTFUL_DELIVERY_HOST: z
+    .string()
+    .optional()
+    .describe(
+      'Contentful Delivery API host (used with CONTENTFUL_DELIVERY_TOKEN for custom CDA endpoints)',
+    ),
 });
 
 export const env = EnvSchema.safeParse(process.env);

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -25,6 +25,8 @@ export function registerAllTools(server: McpServer): void {
     organizationId: env.data.ORGANIZATION_ID,
     appId: env.data.APP_ID,
     mcpVersion: getVersion(),
+    deliveryToken: env.data.CONTENTFUL_DELIVERY_TOKEN,
+    hostDelivery: env.data.CONTENTFUL_DELIVERY_HOST,
   });
 
   // Get tool collections

--- a/packages/mcp-tools/src/config/types.ts
+++ b/packages/mcp-tools/src/config/types.ts
@@ -16,4 +16,8 @@ export interface ContentfulConfig {
   appId?: string;
   /** Version number to use for MCP tool calls */
   mcpVersion: string;
+  /** Contentful CDA token for exporting only published content */
+  deliveryToken?: string;
+  /** Contentful Delivery API host (used with deliveryToken for custom CDA endpoints) */
+  hostDelivery?: string;
 }

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
@@ -107,21 +107,26 @@ describe('exportSpace', () => {
       // Asset and performance options
       downloadAssets: true,
       maxAllowedLimit: 500,
-      deliveryToken: 'test-delivery-token',
-      hostDelivery: 'cdn.eu.contentful.com',
 
       // Logging and debugging
       errorLogFile: '/logs/export.log',
       useVerboseRenderer: true,
     });
 
-    const tool = createExportSpaceTool(mockConfig);
+    const configWithDelivery = createMockConfig({
+      deliveryToken: 'cfg-delivery-token',
+      hostDelivery: 'cdn.eu.contentful.com',
+    });
+
+    const tool = createExportSpaceTool(configWithDelivery);
     const result = await tool(testArgs);
 
     expect(mockContentfulExport).toHaveBeenCalledWith({
       ...testArgs,
-      managementToken: mockConfig.accessToken,
+      managementToken: configWithDelivery.accessToken,
       host: 'api.contentful.com',
+      deliveryToken: 'cfg-delivery-token',
+      hostDelivery: 'cdn.eu.contentful.com',
     });
 
     expect(result.content[0].text).toContain('Space exported successfully');
@@ -130,17 +135,21 @@ describe('exportSpace', () => {
     );
   });
 
-  it('should always use config host, ignoring any host provided in args (GHSA-2xhg-73j7-rrgx)', async () => {
-    const customHostConfig = createMockConfig({
+  it('should always use config host/deliveryToken/hostDelivery, never from args (GHSA-2xhg-73j7-rrgx)', async () => {
+    const configWithAll = createMockConfig({
       host: 'eu.api.contentful.com',
+      deliveryToken: 'cfg-cda-token',
+      hostDelivery: 'cdn.eu.contentful.com',
     });
     const testArgs = createExportTestArgs();
 
-    const tool = createExportSpaceTool(customHostConfig);
+    const tool = createExportSpaceTool(configWithAll);
     await tool(testArgs);
 
     const calledWith = mockContentfulExport.mock.calls[0][0];
     expect(calledWith.host).toBe('eu.api.contentful.com');
+    expect(calledWith.deliveryToken).toBe('cfg-cda-token');
+    expect(calledWith.hostDelivery).toBe('cdn.eu.contentful.com');
     expect(calledWith.proxy).toBeUndefined();
     expect(calledWith.rawProxy).toBeUndefined();
   });

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
@@ -108,6 +108,7 @@ describe('exportSpace', () => {
       downloadAssets: true,
       maxAllowedLimit: 500,
       deliveryToken: 'test-delivery-token',
+      hostDelivery: 'cdn.eu.contentful.com',
 
       // Logging and debugging
       errorLogFile: '/logs/export.log',

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.test.ts
@@ -42,6 +42,7 @@ describe('exportSpace', () => {
     expect(mockContentfulExport).toHaveBeenCalledWith({
       ...testArgs,
       managementToken: mockConfig.accessToken,
+      host: 'api.contentful.com',
       environmentId: 'test-environment',
       exportDir: process.cwd(),
       contentFile: 'contentful-export-test-space-id.json',
@@ -108,20 +109,9 @@ describe('exportSpace', () => {
       maxAllowedLimit: 500,
       deliveryToken: 'test-delivery-token',
 
-      // Network options
-      host: 'eu.contentful.com',
-      hostDelivery: 'cdn.contentful.com',
-      proxy: 'user:pass@proxy:8080',
-      rawProxy: true,
-
       // Logging and debugging
-      headers: {
-        'X-Custom': 'value',
-        'User-Agent': 'test-agent',
-      },
       errorLogFile: '/logs/export.log',
       useVerboseRenderer: true,
-      config: '/config/export.json',
     });
 
     const tool = createExportSpaceTool(mockConfig);
@@ -130,12 +120,28 @@ describe('exportSpace', () => {
     expect(mockContentfulExport).toHaveBeenCalledWith({
       ...testArgs,
       managementToken: mockConfig.accessToken,
+      host: 'api.contentful.com',
     });
 
     expect(result.content[0].text).toContain('Space exported successfully');
     expect(result.content[0].text).toContain(
       '/custom/export/dir/custom-export.json',
     );
+  });
+
+  it('should always use config host, ignoring any host provided in args (GHSA-2xhg-73j7-rrgx)', async () => {
+    const customHostConfig = createMockConfig({
+      host: 'eu.api.contentful.com',
+    });
+    const testArgs = createExportTestArgs();
+
+    const tool = createExportSpaceTool(customHostConfig);
+    await tool(testArgs);
+
+    const calledWith = mockContentfulExport.mock.calls[0][0];
+    expect(calledWith.host).toBe('eu.api.contentful.com');
+    expect(calledWith.proxy).toBeUndefined();
+    expect(calledWith.rawProxy).toBeUndefined();
   });
 
   it('should handle contentful-export errors', async () => {

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -111,60 +111,18 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Explicitly destructure only the fields exposed in ExportSpaceToolParams so
-    // that future schema additions do not accidentally reach contentful-export.
     // host, deliveryToken, and hostDelivery are always sourced from server config
-    // — never from LLM-controlled args.
-    const {
-      spaceId,
-      environmentId,
-      exportDir,
-      saveFile,
-      contentFile,
-      includeDrafts,
-      includeArchived,
-      skipContentModel,
-      skipEditorInterfaces,
-      skipContent,
-      skipRoles,
-      skipTags,
-      skipWebhooks,
-      stripTags,
-      contentOnly,
-      queryEntries,
-      queryAssets,
-      downloadAssets,
-      maxAllowedLimit,
-      errorLogFile,
-      useVerboseRenderer,
-    } = args;
-
+    // — never from LLM-controlled args. Zod strips unknown fields before this
+    // point, so ...args only contains schema-declared fields.
     const exportOptions = {
-      spaceId,
+      ...args,
       managementToken,
       host: config.host ?? 'api.contentful.com',
       ...(config.deliveryToken && { deliveryToken: config.deliveryToken }),
       ...(config.hostDelivery && { hostDelivery: config.hostDelivery }),
-      environmentId: environmentId || 'master',
-      exportDir: exportDir || process.cwd(),
-      contentFile: contentFile || `contentful-export-${spaceId}.json`,
-      saveFile,
-      includeDrafts,
-      includeArchived,
-      skipContentModel,
-      skipEditorInterfaces,
-      skipContent,
-      skipRoles,
-      skipTags,
-      skipWebhooks,
-      stripTags,
-      contentOnly,
-      queryEntries,
-      queryAssets,
-      downloadAssets,
-      maxAllowedLimit,
-      errorLogFile,
-      useVerboseRenderer,
+      environmentId: args.environmentId || 'master',
+      exportDir: args.exportDir || process.cwd(),
+      contentFile: args.contentFile || `contentful-export-${args.spaceId}.json`,
     } as any;
 
     try {
@@ -181,8 +139,8 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       );
 
       return createSuccessResponse('Space exported successfully', {
-        spaceId,
-        environmentId: environmentId || 'master',
+        spaceId: args.spaceId,
+        environmentId: args.environmentId || 'master',
         exportPath,
         contentTypes: result.contentTypes?.length || 0,
         entries: result.entries?.length || 0,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -96,6 +96,12 @@ export const ExportSpaceToolParams = BaseToolSchema.extend({
     .string()
     .optional()
     .describe('CDA token to export only published content (excludes tags)'),
+  hostDelivery: z
+    .string()
+    .optional()
+    .describe(
+      'Delivery API host (used with deliveryToken for custom CDA endpoints)',
+    ),
   errorLogFile: z.string().optional().describe('Path to error log output file'),
   useVerboseRenderer: z
     .boolean()

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -111,18 +111,60 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Consolidate args with defaults and additional required fields.
+    // Explicitly destructure only the fields exposed in ExportSpaceToolParams so
+    // that future schema additions do not accidentally reach contentful-export.
     // host, deliveryToken, and hostDelivery are always sourced from server config
     // — never from LLM-controlled args.
+    const {
+      spaceId,
+      environmentId,
+      exportDir,
+      saveFile,
+      contentFile,
+      includeDrafts,
+      includeArchived,
+      skipContentModel,
+      skipEditorInterfaces,
+      skipContent,
+      skipRoles,
+      skipTags,
+      skipWebhooks,
+      stripTags,
+      contentOnly,
+      queryEntries,
+      queryAssets,
+      downloadAssets,
+      maxAllowedLimit,
+      errorLogFile,
+      useVerboseRenderer,
+    } = args;
+
     const exportOptions = {
-      ...args,
+      spaceId,
       managementToken,
       host: config.host ?? 'api.contentful.com',
       ...(config.deliveryToken && { deliveryToken: config.deliveryToken }),
       ...(config.hostDelivery && { hostDelivery: config.hostDelivery }),
-      environmentId: args.environmentId || 'master',
-      exportDir: args.exportDir || process.cwd(),
-      contentFile: args.contentFile || `contentful-export-${args.spaceId}.json`,
+      environmentId: environmentId || 'master',
+      exportDir: exportDir || process.cwd(),
+      contentFile: contentFile || `contentful-export-${spaceId}.json`,
+      saveFile,
+      includeDrafts,
+      includeArchived,
+      skipContentModel,
+      skipEditorInterfaces,
+      skipContent,
+      skipRoles,
+      skipTags,
+      skipWebhooks,
+      stripTags,
+      contentOnly,
+      queryEntries,
+      queryAssets,
+      downloadAssets,
+      maxAllowedLimit,
+      errorLogFile,
+      useVerboseRenderer,
     } as any;
 
     try {
@@ -139,8 +181,8 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       );
 
       return createSuccessResponse('Space exported successfully', {
-        spaceId: args.spaceId,
-        environmentId: args.environmentId || 'master',
+        spaceId,
+        environmentId: environmentId || 'master',
         exportPath,
         contentTypes: result.contentTypes?.length || 0,
         entries: result.entries?.length || 0,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -92,16 +92,6 @@ export const ExportSpaceToolParams = BaseToolSchema.extend({
     .optional()
     .default(1000)
     .describe('Maximum number of items per request'),
-  deliveryToken: z
-    .string()
-    .optional()
-    .describe('CDA token to export only published content (excludes tags)'),
-  hostDelivery: z
-    .string()
-    .optional()
-    .describe(
-      'Delivery API host (used with deliveryToken for custom CDA endpoints)',
-    ),
   errorLogFile: z.string().optional().describe('Path to error log output file'),
   useVerboseRenderer: z
     .boolean()
@@ -122,11 +112,14 @@ export function createExportSpaceTool(config: ContentfulConfig) {
     }
 
     // Consolidate args with defaults and additional required fields.
-    // host is always sourced from server config — never from LLM-controlled args.
+    // host, deliveryToken, and hostDelivery are always sourced from server config
+    // — never from LLM-controlled args.
     const exportOptions = {
       ...args,
       managementToken,
       host: config.host ?? 'api.contentful.com',
+      ...(config.deliveryToken && { deliveryToken: config.deliveryToken }),
+      ...(config.hostDelivery && { hostDelivery: config.hostDelivery }),
       environmentId: args.environmentId || 'master',
       exportDir: args.exportDir || process.cwd(),
       contentFile: args.contentFile || `contentful-export-${args.spaceId}.json`,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -96,26 +96,11 @@ export const ExportSpaceToolParams = BaseToolSchema.extend({
     .string()
     .optional()
     .describe('CDA token to export only published content (excludes tags)'),
-  host: z.string().optional().describe('Management API host'),
-  hostDelivery: z.string().optional().describe('Delivery API host'),
-  proxy: z.string().optional().describe('HTTP/HTTPS proxy config'),
-  rawProxy: z
-    .boolean()
-    .optional()
-    .describe('Pass raw proxy config directly to Axios'),
-  headers: z
-    .record(z.string())
-    .optional()
-    .describe('Additional headers to include in requests'),
   errorLogFile: z.string().optional().describe('Path to error log output file'),
   useVerboseRenderer: z
     .boolean()
     .optional()
     .describe('Line-by-line logging, useful for CI'),
-  config: z
-    .string()
-    .optional()
-    .describe('Path to a JSON config file with all options'),
 });
 
 type Params = z.infer<typeof ExportSpaceToolParams>;
@@ -130,10 +115,12 @@ export function createExportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Consolidate args with defaults and additional required fields
+    // Consolidate args with defaults and additional required fields.
+    // host is always sourced from server config — never from LLM-controlled args.
     const exportOptions = {
       ...args,
       managementToken,
+      host: config.host ?? 'api.contentful.com',
       environmentId: args.environmentId || 'master',
       exportDir: args.exportDir || process.cwd(),
       contentFile: args.contentFile || `contentful-export-${args.spaceId}.json`,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.test.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.test.ts
@@ -38,6 +38,7 @@ describe('importSpace', () => {
     expect(mockContentfulImport).toHaveBeenCalledWith({
       ...testArgs,
       managementToken: mockConfig.accessToken,
+      host: 'api.contentful.com',
       environmentId: 'test-environment',
     });
 
@@ -87,19 +88,9 @@ describe('importSpace', () => {
       retryLimit: 15,
       rateLimit: 10,
 
-      // Network options
-      host: 'eu.contentful.com',
-      proxy: 'user:pass@proxy:8080',
-      rawProxy: true,
-
       // Logging and debugging
-      headers: {
-        'X-Custom': 'value',
-        'User-Agent': 'test-agent',
-      },
       errorLogFile: '/logs/import.log',
       useVerboseRenderer: true,
-      config: '/config/import.json',
     });
 
     const tool = createImportSpaceTool(mockConfig);
@@ -108,9 +99,27 @@ describe('importSpace', () => {
     expect(mockContentfulImport).toHaveBeenCalledWith({
       ...testArgs,
       managementToken: mockConfig.accessToken,
+      host: 'api.contentful.com',
     });
 
     expect(result.content[0].text).toContain('Space imported successfully');
+  });
+
+  it('should always use config host, ignoring any host provided in args (GHSA-2xhg-73j7-rrgx)', async () => {
+    const customHostConfig = createMockConfig({
+      host: 'eu.api.contentful.com',
+    });
+    const testArgs = createImportTestArgs({
+      content: { contentTypes: [], entries: [] },
+    });
+
+    const tool = createImportSpaceTool(customHostConfig);
+    await tool(testArgs);
+
+    const calledWith = mockContentfulImport.mock.calls[0][0];
+    expect(calledWith.host).toBe('eu.api.contentful.com');
+    expect(calledWith.proxy).toBeUndefined();
+    expect(calledWith.rawProxy).toBeUndefined();
   });
 
   it('should handle contentful-import errors', async () => {

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
@@ -90,49 +90,14 @@ export function createImportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Explicitly destructure only the fields exposed in ImportSpaceToolParams so
-    // that future schema additions do not accidentally reach contentful-import.
     // host is always sourced from server config — never from LLM-controlled args.
-    const {
-      spaceId,
-      environmentId,
-      contentFile,
-      content,
-      contentModelOnly,
-      skipContentModel,
-      skipLocales,
-      skipContentUpdates,
-      skipContentPublishing,
-      uploadAssets,
-      skipAssetUpdates,
-      assetsDirectory,
-      timeout,
-      retryLimit,
-      rateLimit,
-      errorLogFile,
-      useVerboseRenderer,
-    } = args;
-
+    // Zod strips unknown fields before this point, so ...args only contains
+    // schema-declared fields.
     const importOptions = {
-      spaceId,
+      ...args,
       managementToken,
       host: config.host ?? 'api.contentful.com',
-      environmentId: environmentId || 'master',
-      contentFile,
-      content,
-      contentModelOnly,
-      skipContentModel,
-      skipLocales,
-      skipContentUpdates,
-      skipContentPublishing,
-      uploadAssets,
-      skipAssetUpdates,
-      assetsDirectory,
-      timeout,
-      retryLimit,
-      rateLimit,
-      errorLogFile,
-      useVerboseRenderer,
+      environmentId: args.environmentId || 'master',
     } as any;
 
     try {
@@ -140,8 +105,8 @@ export function createImportSpaceTool(config: ContentfulConfig) {
       const result = await contentfulImport.default(importOptions);
 
       return createSuccessResponse('Space imported successfully', {
-        spaceId,
-        environmentId: environmentId || 'master',
+        spaceId: args.spaceId,
+        environmentId: args.environmentId || 'master',
         contentTypes: result.contentTypes?.length || 0,
         entries: result.entries?.length || 0,
         assets: result.assets?.length || 0,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
@@ -90,13 +90,49 @@ export function createImportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Consolidate args with defaults and additional required fields.
+    // Explicitly destructure only the fields exposed in ImportSpaceToolParams so
+    // that future schema additions do not accidentally reach contentful-import.
     // host is always sourced from server config — never from LLM-controlled args.
+    const {
+      spaceId,
+      environmentId,
+      contentFile,
+      content,
+      contentModelOnly,
+      skipContentModel,
+      skipLocales,
+      skipContentUpdates,
+      skipContentPublishing,
+      uploadAssets,
+      skipAssetUpdates,
+      assetsDirectory,
+      timeout,
+      retryLimit,
+      rateLimit,
+      errorLogFile,
+      useVerboseRenderer,
+    } = args;
+
     const importOptions = {
-      ...args,
+      spaceId,
       managementToken,
       host: config.host ?? 'api.contentful.com',
-      environmentId: args.environmentId || 'master',
+      environmentId: environmentId || 'master',
+      contentFile,
+      content,
+      contentModelOnly,
+      skipContentModel,
+      skipLocales,
+      skipContentUpdates,
+      skipContentPublishing,
+      uploadAssets,
+      skipAssetUpdates,
+      assetsDirectory,
+      timeout,
+      retryLimit,
+      rateLimit,
+      errorLogFile,
+      useVerboseRenderer,
     } as any;
 
     try {
@@ -104,8 +140,8 @@ export function createImportSpaceTool(config: ContentfulConfig) {
       const result = await contentfulImport.default(importOptions);
 
       return createSuccessResponse('Space imported successfully', {
-        spaceId: args.spaceId,
-        environmentId: args.environmentId || 'master',
+        spaceId,
+        environmentId: environmentId || 'master',
         contentTypes: result.contentTypes?.length || 0,
         entries: result.entries?.length || 0,
         assets: result.assets?.length || 0,

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
@@ -66,33 +66,16 @@ export const ImportSpaceToolParams = BaseToolSchema.extend({
     .optional()
     .default(10)
     .describe('Max retries for asset processing'),
-  host: z.string().optional().describe('Management API host'),
-  proxy: z
-    .string()
-    .optional()
-    .describe('HTTP/HTTPS proxy string (host:port or user:pass@host:port)'),
-  rawProxy: z
-    .boolean()
-    .optional()
-    .describe('Pass proxy config directly to Axios'),
   rateLimit: z
     .number()
     .optional()
     .default(7)
     .describe('Max requests per second to the API'),
-  headers: z
-    .record(z.any())
-    .optional()
-    .describe('Additional headers to attach to requests'),
   errorLogFile: z.string().optional().describe('Path to error log file'),
   useVerboseRenderer: z
     .boolean()
     .optional()
     .describe('Line-by-line progress output (good for CI)'),
-  config: z
-    .string()
-    .optional()
-    .describe('Path to config JSON file (merged with CLI args)'),
 });
 
 type Params = z.infer<typeof ImportSpaceToolParams>;
@@ -107,10 +90,12 @@ export function createImportSpaceTool(config: ContentfulConfig) {
       throw new Error('Contentful management token is not configured');
     }
 
-    // Consolidate args with defaults and additional required fields
+    // Consolidate args with defaults and additional required fields.
+    // host is always sourced from server config — never from LLM-controlled args.
     const importOptions = {
       ...args,
       managementToken,
+      host: config.host ?? 'api.contentful.com',
       environmentId: args.environmentId || 'master',
     } as any;
 

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/mockClient.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/mockClient.ts
@@ -135,7 +135,6 @@ export const createExportTestArgs = (
   contentOnly: false,
   downloadAssets: false,
   maxAllowedLimit: 1000,
-  rawProxy: false,
   useVerboseRenderer: false,
   ...overrides,
 });


### PR DESCRIPTION
Fixes GHSA-2xhg-73j7-rrgx

## Summary
- `export_space` and `import_space` accepted LLM-controllable `host`, `proxy`, `rawProxy`, `headers`, `hostDelivery`, and `config` parameters that were spread directly into the options passed to `contentful-export`/`contentful-import`, allowing an attacker to redirect all CMA requests — including the server's PAT — to an attacker-controlled endpoint (SSRF/CWE-918)
- Removed those fields from both Zod schemas so they are never accepted from LLM-controlled input
- Explicitly pinned `host: config.host ?? 'api.contentful.com'` after the `...args` spread in both tools so the server config always wins
- Added security regression tests (`GHSA-2xhg-73j7-rrgx`) verifying host is always sourced from server config and that `proxy`/`rawProxy` are never passed through

## Test plan
- [ ] `npm run test:run` passes (308/308)
- [ ] TypeScript check clean (`tsc --noEmit`)
- [ ] Verify `export_space` and `import_space` tool schemas no longer expose `host`, `proxy`, `rawProxy`, `headers`, or `config` fields to the LLM
- [ ] Regression tests for GHSA-2xhg-73j7-rrgx pass in both `exportSpace.test.ts` and `importSpace.test.ts`

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes critical SSRF vulnerability GHSA-2xhg-73j7-rrgx in the Contentful MCP server's export_space and import_space tools by refactoring the options building logic to rely on Zod schema field stripping. The changes ensure that sensitive network parameters (host, proxy, rawProxy, headers, config) can only be sourced from server configuration and are never accepted from LLM-controlled input, preventing attackers from redirecting CMA API requests to arbitrary endpoints.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Refactored exportSpace.ts to use `...args` spread instead of explicit destructuring, relying on Zod to strip unknown fields before they reach contentful-export, while explicitly pinning host, deliveryToken, and hostDelivery from server config only</li>

<li>Simplified importSpace.ts similarly by replacing explicit field destructuring with `...args` spread, ensuring host is always sourced from server config and cannot be overridden by LLM-supplied parameters</li>

<li>Added defensive server-side pinning of `host: config.host ?? 'api.contentful.com'` after the args spread in both tools, guaranteeing server configuration always wins over any LLM input</li>

</ul>
</details>

</div>