### PR TITLE
fix: require array-only entryId to prevent LLM character truncation [DX-736]

### DIFF
--- a/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
@@ -23,7 +23,7 @@ describe('archiveEntry', () => {
     it('should archive entry successfully with valid parameters', async () => {
       const testArgs = {
         ...mockArgs,
-        entryId: 'test-entry-id',
+        entryId: ['test-entry-id'],
       };
 
       mockEntryArchive.mockResolvedValue(mockArchivedEntry);
@@ -35,7 +35,7 @@ describe('archiveEntry', () => {
       expect(mockEntryArchive).toHaveBeenCalledWith({
         spaceId: testArgs.spaceId,
         environmentId: testArgs.environmentId,
-        entryId: testArgs.entryId,
+        entryId: testArgs.entryId[0],
       });
 
       // Verify response format
@@ -56,7 +56,7 @@ describe('archiveEntry', () => {
     it('should throw error when archive fails', async () => {
       const testArgs = {
         ...mockArgs,
-        entryId: 'test-entry-id',
+        entryId: ['test-entry-id'],
       };
 
       const error = new Error('Entry must be unpublished before archiving');

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.ts
@@ -8,9 +8,11 @@ import type { ContentfulConfig } from '../../config/types.js';
 
 export const ArchiveEntryToolParams = BaseToolSchema.extend({
   entryId: z
-    .union([z.string(), z.array(z.string()).max(100)])
+    .array(z.string())
+    .min(1)
+    .max(100)
     .describe(
-      'The ID of the entry to archive (string) or an array of entry IDs (up to 100 entries)',
+      'Array of entry IDs to archive. Pass a single-element array for one entry, or up to 100 IDs for batch operations.',
     ),
 });
 
@@ -25,47 +27,46 @@ export function archiveEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-  // Normalize input to always be an array
-  const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];
+    const entryIds = args.entryId;
 
-  // Track successfully archived entries
-  const successfullyArchived: string[] = [];
+    // Track successfully archived entries
+    const successfullyArchived: string[] = [];
 
-  // Process each entry sequentially, stopping at first failure
-  for (const entryId of entryIds) {
-    try {
-      const params = {
-        ...baseParams,
-        entryId,
-      };
+    // Process each entry sequentially, stopping at first failure
+    for (const entryId of entryIds) {
+      try {
+        const params = {
+          ...baseParams,
+          entryId,
+        };
 
-      // Archive the entry - will throw on error
-      await contentfulClient.entry.archive(params);
-      successfullyArchived.push(entryId);
-    } catch (error) {
-      // Enhance error with context about successful operations
-      const errorMessage =
-        successfullyArchived.length > 0
-          ? `Failed to archive entry '${entryId}' after successfully archiving ${successfullyArchived.length} entry(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-          : `Failed to archive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
+        // Archive the entry - will throw on error
+        await contentfulClient.entry.archive(params);
+        successfullyArchived.push(entryId);
+      } catch (error) {
+        // Enhance error with context about successful operations
+        const errorMessage =
+          successfullyArchived.length > 0
+            ? `Failed to archive entry '${entryId}' after successfully archiving ${successfullyArchived.length} entry(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
+            : `Failed to archive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
 
-      throw new Error(errorMessage);
+        throw new Error(errorMessage);
+      }
     }
-  }
 
-  if (entryIds.length === 1) {
-    return createSuccessResponse('Entry archived successfully', {
-      entryId: entryIds[0],
-    });
-  } else {
-    return createSuccessResponse(
-      `Successfully archived ${entryIds.length} entries`,
-      {
-        archivedCount: entryIds.length,
-        entryIds,
-      },
-    );
-  }
+    if (entryIds.length === 1) {
+      return createSuccessResponse('Entry archived successfully', {
+        entryId: entryIds[0],
+      });
+    } else {
+      return createSuccessResponse(
+        `Successfully archived ${entryIds.length} entries`,
+        {
+          archivedCount: entryIds.length,
+          entryIds,
+        },
+      );
+    }
   }
 
   return withErrorHandling(tool, 'Error archiving entry');

--- a/packages/mcp-tools/src/tools/entries/deleteEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/deleteEntry.test.ts
@@ -24,7 +24,7 @@ describe('deleteEntry', () => {
     mockEntryDelete.mockResolvedValue(undefined);
 
     const tool = deleteEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     const expectedResponse = formatResponse('Entry deleted successfully', {
       entry: mockEntry,
@@ -44,7 +44,7 @@ describe('deleteEntry', () => {
     mockEntryGet.mockRejectedValue(error);
 
     const tool = deleteEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     expect(result).toEqual({
       isError: true,
@@ -63,7 +63,7 @@ describe('deleteEntry', () => {
     mockEntryDelete.mockRejectedValue(deleteError);
 
     const tool = deleteEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     expect(result).toEqual({
       isError: true,

--- a/packages/mcp-tools/src/tools/entries/getEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/getEntry.test.ts
@@ -22,7 +22,7 @@ describe('getEntry', () => {
     mockEntryGet.mockResolvedValue(mockEntry);
 
     const tool = getEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     const expectedResponse = formatResponse('Entry retrieved successfully', {
       entry: mockEntry,
@@ -46,7 +46,7 @@ describe('getEntry', () => {
     mockEntryGet.mockResolvedValue(mockEmptyEntry);
 
     const tool = getEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     const expectedResponse = formatResponse('Entry retrieved successfully', {
       entry: mockEmptyEntry,
@@ -66,7 +66,7 @@ describe('getEntry', () => {
     mockEntryGet.mockRejectedValue(error);
 
     const tool = getEntryTool(mockConfig);
-    const result = await tool(mockArgs);
+    const result = await tool({ ...mockArgs, entryId: 'test-entry-id' });
 
     expect(result).toEqual({
       isError: true,

--- a/packages/mcp-tools/src/tools/entries/mockClient.ts
+++ b/packages/mcp-tools/src/tools/entries/mockClient.ts
@@ -90,7 +90,7 @@ export const mockArchivedEntry = {
 export const mockArgs = {
   spaceId: 'test-space-id',
   environmentId: 'test-environment',
-  entryId: 'test-entry-id',
+  entryId: ['test-entry-id'],
 };
 
 /**

--- a/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
@@ -40,7 +40,7 @@ describe('publishEntry', () => {
 
     const expectedResponse = formatResponse('Entry published successfully', {
       status: mockPublishedEntry.sys.status,
-      entryId: mockArgs.entryId,
+      entryId: mockArgs.entryId[0],
     });
     expect(result).toEqual({
       content: [
@@ -134,7 +134,7 @@ describe('publishEntry', () => {
   it('should handle errors when entry publishing fails', async () => {
     const testArgs = {
       ...mockArgs,
-      entryId: 'non-existent-entry',
+      entryId: ['non-existent-entry'],
     };
 
     const error = new Error('Entry not found');

--- a/packages/mcp-tools/src/tools/entries/publishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.ts
@@ -14,9 +14,11 @@ import type { ContentfulConfig } from '../../config/types.js';
 
 export const PublishEntryToolParams = BaseToolSchema.extend({
   entryId: z
-    .union([z.string(), z.array(z.string()).max(100)])
+    .array(z.string())
+    .min(1)
+    .max(100)
     .describe(
-      'The ID of the entry to publish (string) or an array of entry IDs (up to 100 entries)',
+      'Array of entry IDs to publish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations.',
     ),
 });
 
@@ -31,56 +33,58 @@ export function publishEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-  // Normalize input to always be an array
-  const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];
+    const entryIds = args.entryId;
 
-  // For single entry, use individual publish for simplicity
-  if (entryIds.length === 1) {
-    const entryId = entryIds[0];
-    const params = {
-      ...baseParams,
-      entryId,
-    };
+    // For single entry, use individual publish for simplicity
+    if (entryIds.length === 1) {
+      const entryId = entryIds[0];
+      const params = {
+        ...baseParams,
+        entryId,
+      };
 
-    // Get the entry first
-    const entry = await contentfulClient.entry.get(params);
+      // Get the entry first
+      const entry = await contentfulClient.entry.get(params);
 
-    // Publish the entry
-    const publishedEntry = await contentfulClient.entry.publish(params, entry);
+      // Publish the entry
+      const publishedEntry = await contentfulClient.entry.publish(
+        params,
+        entry,
+      );
 
-    return createSuccessResponse('Entry published successfully', {
-      status: publishedEntry.sys.status,
-      entryId,
+      return createSuccessResponse('Entry published successfully', {
+        status: publishedEntry.sys.status,
+        entryId,
+      });
+    }
+
+    // For multiple entries, use bulk action API
+    // Get the current version of each entry
+    const entityVersions = await createEntryVersionedLinks(
+      contentfulClient,
+      baseParams,
+      entryIds,
+    );
+
+    // Create the collection object
+    const entitiesCollection = createEntitiesCollection(entityVersions);
+
+    // Create the bulk action
+    const bulkAction = await contentfulClient.bulkAction.publish(baseParams, {
+      entities: entitiesCollection,
     });
-  }
 
-  // For multiple entries, use bulk action API
-  // Get the current version of each entry
-  const entityVersions = await createEntryVersionedLinks(
-    contentfulClient,
-    baseParams,
-    entryIds,
-  );
+    // Wait for the bulk action to complete
+    const action = await waitForBulkActionCompletion(
+      contentfulClient,
+      baseParams,
+      bulkAction.sys.id,
+    );
 
-  // Create the collection object
-  const entitiesCollection = createEntitiesCollection(entityVersions);
-
-  // Create the bulk action
-  const bulkAction = await contentfulClient.bulkAction.publish(baseParams, {
-    entities: entitiesCollection,
-  });
-
-  // Wait for the bulk action to complete
-  const action = await waitForBulkActionCompletion(
-    contentfulClient,
-    baseParams,
-    bulkAction.sys.id,
-  );
-
-  return createSuccessResponse('Entry(s) published successfully', {
-    status: action.sys.status,
-    entryIds,
-  });
+    return createSuccessResponse('Entry(s) published successfully', {
+      status: action.sys.status,
+      entryIds,
+    });
   }
 
   return withErrorHandling(tool, 'Error publishing entry');

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
@@ -23,7 +23,7 @@ describe('unarchiveEntry', () => {
     it('should unarchive entry successfully with valid parameters', async () => {
       const testArgs = {
         ...mockArgs,
-        entryId: 'test-entry-id',
+        entryId: ['test-entry-id'],
       };
 
       mockEntryUnarchive.mockResolvedValue(mockEntry);
@@ -35,7 +35,7 @@ describe('unarchiveEntry', () => {
       expect(mockEntryUnarchive).toHaveBeenCalledWith({
         spaceId: testArgs.spaceId,
         environmentId: testArgs.environmentId,
-        entryId: testArgs.entryId,
+        entryId: testArgs.entryId[0],
       });
 
       // Verify response format
@@ -56,7 +56,7 @@ describe('unarchiveEntry', () => {
     it('should throw error when unarchive fails', async () => {
       const testArgs = {
         ...mockArgs,
-        entryId: 'test-entry-id',
+        entryId: ['test-entry-id'],
       };
 
       const error = new Error('Entry is not archived');

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
@@ -8,9 +8,11 @@ import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnarchiveEntryToolParams = BaseToolSchema.extend({
   entryId: z
-    .union([z.string(), z.array(z.string()).max(100)])
+    .array(z.string())
+    .min(1)
+    .max(100)
     .describe(
-      'The ID of the entry to unarchive (string) or an array of entry IDs (up to 100 entries)',
+      'Array of entry IDs to unarchive. Pass a single-element array for one entry, or up to 100 IDs for batch operations.',
     ),
 });
 
@@ -25,47 +27,46 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-  // Normalize input to always be an array
-  const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];
+    const entryIds = args.entryId;
 
-  // Track successfully unarchived entries
-  const successfullyUnarchived: string[] = [];
+    // Track successfully unarchived entries
+    const successfullyUnarchived: string[] = [];
 
-  // Process each entry sequentially, stopping at first failure
-  for (const entryId of entryIds) {
-    try {
-      const params = {
-        ...baseParams,
-        entryId,
-      };
+    // Process each entry sequentially, stopping at first failure
+    for (const entryId of entryIds) {
+      try {
+        const params = {
+          ...baseParams,
+          entryId,
+        };
 
-      // Unarchive the entry - will throw on error
-      await contentfulClient.entry.unarchive(params);
-      successfullyUnarchived.push(entryId);
-    } catch (error) {
-      // Enhance error with context about successful operations
-      const errorMessage =
-        successfullyUnarchived.length > 0
-          ? `Failed to unarchive entry '${entryId}' after successfully unarchiving ${successfullyUnarchived.length} entry(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-          : `Failed to unarchive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
+        // Unarchive the entry - will throw on error
+        await contentfulClient.entry.unarchive(params);
+        successfullyUnarchived.push(entryId);
+      } catch (error) {
+        // Enhance error with context about successful operations
+        const errorMessage =
+          successfullyUnarchived.length > 0
+            ? `Failed to unarchive entry '${entryId}' after successfully unarchiving ${successfullyUnarchived.length} entry(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
+            : `Failed to unarchive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
 
-      throw new Error(errorMessage);
+        throw new Error(errorMessage);
+      }
     }
-  }
 
-  if (entryIds.length === 1) {
-    return createSuccessResponse('Entry unarchived successfully', {
-      entryId: entryIds[0],
-    });
-  } else {
-    return createSuccessResponse(
-      `Successfully unarchived ${entryIds.length} entries`,
-      {
-        unarchivedCount: entryIds.length,
-        entryIds,
-      },
-    );
-  }
+    if (entryIds.length === 1) {
+      return createSuccessResponse('Entry unarchived successfully', {
+        entryId: entryIds[0],
+      });
+    } else {
+      return createSuccessResponse(
+        `Successfully unarchived ${entryIds.length} entries`,
+        {
+          unarchivedCount: entryIds.length,
+          entryIds,
+        },
+      );
+    }
   }
 
   return withErrorHandling(tool, 'Error unarchiving entry');

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
@@ -49,7 +49,7 @@ describe('unpublishEntry', () => {
 
     const expectedResponse = formatResponse('Entry unpublished successfully', {
       status: mockUnpublishedEntry.sys.status,
-      entryId: mockArgs.entryId,
+      entryId: mockArgs.entryId[0],
     });
     expect(result).toEqual({
       content: [

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
@@ -14,9 +14,11 @@ import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnpublishEntryToolParams = BaseToolSchema.extend({
   entryId: z
-    .union([z.string(), z.array(z.string()).max(100)])
+    .array(z.string())
+    .min(1)
+    .max(100)
     .describe(
-      'The ID of the entry to unpublish (string) or an array of entry IDs (up to 100 entries)',
+      'Array of entry IDs to unpublish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations.',
     ),
 });
 
@@ -31,59 +33,58 @@ export function unpublishEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-  // Normalize input to always be an array
-  const entryIds = Array.isArray(args.entryId) ? args.entryId : [args.entryId];
+    const entryIds = args.entryId;
 
-  // For single entry, use individual unpublish for simplicity
-  if (entryIds.length === 1) {
-    const entryId = entryIds[0];
-    const params = {
-      ...baseParams,
-      entryId,
-    };
+    // For single entry, use individual unpublish for simplicity
+    if (entryIds.length === 1) {
+      const entryId = entryIds[0];
+      const params = {
+        ...baseParams,
+        entryId,
+      };
 
-    // Get the entry first
-    const entry = await contentfulClient.entry.get(params);
+      // Get the entry first
+      const entry = await contentfulClient.entry.get(params);
 
-    // Unpublish the entry
-    const unpublishedEntry = await contentfulClient.entry.unpublish(
-      params,
-      entry,
+      // Unpublish the entry
+      const unpublishedEntry = await contentfulClient.entry.unpublish(
+        params,
+        entry,
+      );
+
+      return createSuccessResponse('Entry unpublished successfully', {
+        status: unpublishedEntry.sys.status,
+        entryId,
+      });
+    }
+
+    // For multiple entries, use bulk action API
+    // Get the unversioned links for each entry (unpublish doesn't need version info)
+    const entityLinks = await createEntryUnversionedLinks(
+      contentfulClient,
+      baseParams,
+      entryIds,
     );
 
-    return createSuccessResponse('Entry unpublished successfully', {
-      status: unpublishedEntry.sys.status,
-      entryId,
+    // Create the collection object
+    const entitiesCollection = createEntitiesCollection(entityLinks);
+
+    // Create the bulk action
+    const bulkAction = await contentfulClient.bulkAction.unpublish(baseParams, {
+      entities: entitiesCollection,
     });
-  }
 
-  // For multiple entries, use bulk action API
-  // Get the unversioned links for each entry (unpublish doesn't need version info)
-  const entityLinks = await createEntryUnversionedLinks(
-    contentfulClient,
-    baseParams,
-    entryIds,
-  );
+    // Wait for the bulk action to complete
+    const action = await waitForBulkActionCompletion(
+      contentfulClient,
+      baseParams,
+      bulkAction.sys.id,
+    );
 
-  // Create the collection object
-  const entitiesCollection = createEntitiesCollection(entityLinks);
-
-  // Create the bulk action
-  const bulkAction = await contentfulClient.bulkAction.unpublish(baseParams, {
-    entities: entitiesCollection,
-  });
-
-  // Wait for the bulk action to complete
-  const action = await waitForBulkActionCompletion(
-    contentfulClient,
-    baseParams,
-    bulkAction.sys.id,
-  );
-
-  return createSuccessResponse('Entry(s) unpublished successfully', {
-    status: action.sys.status,
-    entryIds,
-  });
+    return createSuccessResponse('Entry(s) unpublished successfully', {
+      status: action.sys.status,
+      entryIds,
+    });
   }
 
   return withErrorHandling(tool, 'Error unpublishing entry');

--- a/packages/mcp-tools/src/tools/entries/updateEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/updateEntry.test.ts
@@ -24,6 +24,7 @@ describe('updateEntry', () => {
   it('should update an entry successfully with fields only', async () => {
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {
         title: { 'en-US': 'Updated Title' },
         description: { 'en-US': 'Updated Description' },
@@ -76,6 +77,7 @@ describe('updateEntry', () => {
   it('should update an entry with metadata tags', async () => {
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {
         title: { 'en-US': 'Updated Title' },
       },
@@ -285,6 +287,7 @@ describe('updateEntry', () => {
 
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {
         title: { 'en-US': 'Updated Title', fr: 'Titre mis à jour' },
         body: { 'en-US': richTextEnUS, fr: richTextFr },
@@ -418,6 +421,7 @@ describe('updateEntry', () => {
 
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {
         body: { 'en-US': richTextWithEmbeds },
       },
@@ -468,6 +472,7 @@ describe('updateEntry', () => {
   it('should update an entry with empty fields', async () => {
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {},
     };
 
@@ -532,6 +537,7 @@ describe('updateEntry', () => {
   it('should handle errors when entry retrieval succeeds but update fails', async () => {
     const testArgs = {
       ...mockArgs,
+      entryId: 'test-entry-id',
       fields: {
         title: { 'en-US': 'Updated Title' },
       },


### PR DESCRIPTION
[DX-736](https://contentful.atlassian.net/browse/DX-736)

## Summary
- The `entryId` parameter in `publish_entry`, `unpublish_entry`, `archive_entry`, and `unarchive_entry` tools previously accepted `string | string[]` via a Zod union. An LLM can confuse the union and spread a bare string character-by-character (e.g. `"abc123"` → `["a","b","c","1","2","3"]`), causing entries to silently fail or operate on non-existent IDs.
- Changed all four schemas to `z.array(z.string()).min(1).max(100)` — array-only, no union. Updated descriptions to explicitly instruct callers to wrap single IDs in an array.
- Removed the now-unnecessary `Array.isArray` normalization guard in each tool. Updated test files (`mockClient.ts`, `updateEntry`, `getEntry`, `deleteEntry`) that spread `mockArgs` to pin `entryId` as the correct type for their respective tool schemas.

## Test plan
- [ ] Run `npm run test` — all tests pass
- [ ] Run `npm run typecheck` — clean
- [ ] Run `npm run build` — clean
- [ ] Manually test `publish_entry` with a single entry ID passed as `["<id>"]` — entry publishes correctly
- [ ] Confirm an LLM no longer truncates IDs: prompt an AI to publish an entry by ID and verify the full ID reaches the API

Generated with [Claude Code](https://claude.com/claude-code)

[DX-736]: https://contentful.atlassian.net/browse/DX-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bug where LLMs could incorrectly spread a bare string entryId character-by-character instead of treating it as a single ID. The fix changes the entryId parameter schema from a union type (string | string[]) to an array-only type across four entry management tools: publishEntry, unpublishEntry, archiveEntry, and unarchiveEntry. The Array.isArray() normalization guards were removed as they are no longer needed.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changed entryId schema from z.union([z.string(), z.array(z.string()).max(100)]) to z.array(z.string()).min(1).max(100) in archiveEntry.ts, unarchiveEntry.ts, publishEntry.ts, and unpublishEntry.ts to enforce array-only input and prevent LLM character truncation.</li>

<li>Removed Array.isArray() normalization guards from all four entry management tools since entryId is now guaranteed to be an array, simplifying the implementation.</li>

<li>Updated schema descriptions to explicitly instruct callers to pass a single-element array for one entry, or up to 100 IDs for batch operations.</li>

<li>Updated test files (archiveEntry.test.ts, unarchiveEntry.test.ts, publishEntry.test.ts, unpublishEntry.test.ts) and mockClient.ts to use array format for entryId, including adjusting assertions like entryId: mockArgs.entryId[0].</li>

<li>Updated getEntry.test.ts, deleteEntry.test.ts, and updateEntry.test.ts to explicitly provide entryId with correct type instead of relying on mockArgs which now has array-typed entryId.</li>

</ul>
</details>

</div>