### PR TITLE
feat: add MAX_BULK_SIZE limit and dryRun to bulk MCP tools [DX-1063]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ SPACE_ID=your_space_id_here
 # Optional
 ENVIRONMENT_ID=master
 CONTENTFUL_HOST=api.contentful.com
+
+# Optional: maximum bulk operation size (1-100, default 10). Caps how many IDs can be passed
+# to publish_entry, unpublish_entry, archive_entry, unarchive_entry, publish_asset,
+# unpublish_asset, archive_asset, unarchive_asset in a single call.
+MAX_BULK_SIZE=10

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -63,13 +63,14 @@ npm run build
 
 ### Environment Variables
 
-| Environment Variable                 | Required | Default Value        | Description                                          |
-| ------------------------------------ | -------- | -------------------- | ---------------------------------------------------- |
-| `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | ✅ Yes   | -                    | Your Contentful Management API personal access token |
-| `SPACE_ID`                           | ✅ Yes   | -                    | Your Contentful Space ID                             |
-| `ENVIRONMENT_ID`                     | ❌ No    | `master`             | Target environment within your space                 |
-| `CONTENTFUL_HOST`                    | ❌ No    | `api.contentful.com` | Contentful API host                                  |
-| `NODE_ENV`                           | ❌ No    | `production`         | Node Environment to run in                           |
+| Environment Variable                 | Required | Default Value        | Description                                                                                                                                                                                              |
+| ------------------------------------ | -------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | ✅ Yes   | -                    | Your Contentful Management API personal access token                                                                                                                                                     |
+| `SPACE_ID`                           | ✅ Yes   | -                    | Your Contentful Space ID                                                                                                                                                                                 |
+| `ENVIRONMENT_ID`                     | ❌ No    | `master`             | Target environment within your space                                                                                                                                                                     |
+| `CONTENTFUL_HOST`                    | ❌ No    | `api.contentful.com` | Contentful API host                                                                                                                                                                                      |
+| `NODE_ENV`                           | ❌ No    | `production`         | Node Environment to run in                                                                                                                                                                               |
+| `MAX_BULK_SIZE`                      | ❌ No    | `10`                 | Maximum number of IDs allowed in a single bulk-operation tool call (1–100). Caps publish/unpublish/archive/unarchive on entries and assets. Mitigates accidental mass operations from AI hallucinations. |
 
 ### Configuration
 

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -24,6 +24,18 @@ const EnvSchema = z.object({
     .describe(
       'Comma-separated list of environment IDs protected from write/delete operations (e.g., master,staging)',
     ),
+  MAX_BULK_SIZE: z
+    .string()
+    .optional()
+    .refine(
+      (v) =>
+        v === undefined ||
+        (/^\d+$/.test(v) && Number(v) > 0 && Number(v) <= 100),
+      { message: 'MAX_BULK_SIZE must be a positive integer between 1 and 100' },
+    )
+    .describe(
+      'Maximum number of IDs allowed in a single bulk-operation tool call (default: 10, max: 100). Mitigates accidental mass operations from AI hallucinations.',
+    ),
   ORGANIZATION_ID: z.string().optional().describe('Contentful organization ID'),
   CONTENTFUL_DELIVERY_TOKEN: z
     .string()

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -27,6 +27,10 @@ export function registerAllTools(server: McpServer): void {
     ? parsedProtectedEnvs
     : undefined;
 
+  const maxBulkSize = env.data.MAX_BULK_SIZE
+    ? Number(env.data.MAX_BULK_SIZE)
+    : undefined;
+
   // Initialize tools with configuration from environment variables
   const tools = new ContentfulMcpTools({
     accessToken: env.data.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
@@ -39,6 +43,7 @@ export function registerAllTools(server: McpServer): void {
     deliveryToken: env.data.CONTENTFUL_DELIVERY_TOKEN,
     hostDelivery: env.data.CONTENTFUL_DELIVERY_HOST,
     protectedEnvironments,
+    maxBulkSize,
   });
 
   // Get tool collections

--- a/packages/mcp-tools/src/config/types.ts
+++ b/packages/mcp-tools/src/config/types.ts
@@ -22,4 +22,6 @@ export interface ContentfulConfig {
   hostDelivery?: string;
   /** Environment IDs that are protected from write/delete operations */
   protectedEnvironments?: string[];
+  /** Maximum number of IDs allowed in a single bulk-operation tool call. Defaults to 10 when unset. */
+  maxBulkSize?: number;
 }

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.test.ts
@@ -247,4 +247,25 @@ describe('archiveAsset', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = archiveAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetArchive).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.test.ts
@@ -171,4 +171,80 @@ describe('archiveAsset', () => {
       expect(result.content[0].text).toContain('asset-1');
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = archiveAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetArchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = archiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'archive',
+      entityType: 'asset',
+      count: 2,
+      ids: ['a1', 'a2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would archive 2 assets in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockAssetArchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single asset without executing', async () => {
+    const tool = archiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: 'a1',
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockAssetArchive).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = archiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: Array.from({ length: 11 }, (_, i) => `a${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving asset: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.ts
@@ -18,13 +18,13 @@ export const ArchiveAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to archive (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+      'A single asset ID (string) or an array of asset IDs to archive (up to MAX_BULK_SIZE per call; default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.ts
@@ -8,13 +8,23 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../utils/tools.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const ArchiveAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to archive (string) or an array of asset IDs (up to 100 assets)',
+      'The ID of the asset to archive (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -26,6 +36,26 @@ export function archiveAssetTool(config: ContentfulConfig) {
       args.environmentId,
       config.protectedEnvironments,
     );
+
+    const assetIds = Array.isArray(args.assetId)
+      ? args.assetId
+      : [args.assetId];
+
+    assertBulkSizeAllowed(assetIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'archive',
+          entityType: 'asset',
+          ids: assetIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -33,15 +63,8 @@ export function archiveAssetTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    // Normalize input to always be an array
-    const assetIds = Array.isArray(args.assetId)
-      ? args.assetId
-      : [args.assetId];
-
-    // Track successfully archived assets
     const successfullyArchived: string[] = [];
 
-    // Process each asset sequentially, stopping at first failure
     for (const assetId of assetIds) {
       try {
         const params = {
@@ -49,11 +72,9 @@ export function archiveAssetTool(config: ContentfulConfig) {
           assetId,
         };
 
-        // Archive the asset - will throw on error
         await contentfulClient.asset.archive(params);
         successfullyArchived.push(assetId);
       } catch (error) {
-        // Enhance error with context about successful operations
         const errorMessage =
           successfullyArchived.length > 0
             ? `Failed to archive asset '${assetId}' after successfully archiving ${successfullyArchived.length} asset(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
@@ -382,4 +382,27 @@ describe('publishAsset', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = publishAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetGet).not.toHaveBeenCalled();
+    expect(mockAssetPublish).not.toHaveBeenCalled();
+    expect(mockBulkActionPublish).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
@@ -263,6 +263,7 @@ describe('publishAsset', () => {
   });
 
   it('should respect maximum bulk limit of 100 assets', async () => {
+    const expandedConfig = createMockConfig({ maxBulkSize: 100 });
     const manyAssets = Array.from({ length: 100 }, (_, i) => `asset${i + 1}`);
     const testArgs = {
       ...mockArgs,
@@ -271,7 +272,7 @@ describe('publishAsset', () => {
 
     mockBulkActionPublish.mockResolvedValue(mockBulkAction);
 
-    const tool = publishAssetTool(mockConfig);
+    const tool = publishAssetTool(expandedConfig);
     const result = await tool(testArgs);
 
     expect(result).toEqual({
@@ -301,5 +302,84 @@ describe('publishAsset', () => {
       ],
     });
     expect(mockAssetPublish).not.toHaveBeenCalled();
+  });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = publishAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetPublish).not.toHaveBeenCalled();
+    expect(mockBulkActionPublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = publishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'publish',
+      entityType: 'asset',
+      count: 2,
+      ids: ['a1', 'a2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would publish 2 assets in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockAssetPublish).not.toHaveBeenCalled();
+    expect(mockBulkActionPublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single asset without executing', async () => {
+    const tool = publishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: 'a1',
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockAssetGet).not.toHaveBeenCalled();
+    expect(mockAssetPublish).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = publishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: Array.from({ length: 11 }, (_, i) => `a${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing asset: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
   });
 });

--- a/packages/mcp-tools/src/tools/assets/publishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.ts
@@ -14,13 +14,23 @@ import {
   createEntitiesCollection,
   waitForBulkActionCompletion,
 } from '../../utils/bulkOperations.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const PublishAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to publish (string) or an array of asset IDs (up to 100 assets)',
+      'The ID of the asset to publish (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -32,6 +42,26 @@ export function publishAssetTool(config: ContentfulConfig) {
       args.environmentId,
       config.protectedEnvironments,
     );
+
+    const assetIds = Array.isArray(args.assetId)
+      ? args.assetId
+      : [args.assetId];
+
+    assertBulkSizeAllowed(assetIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'publish',
+          entityType: 'asset',
+          ids: assetIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams: BulkOperationParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -39,12 +69,6 @@ export function publishAssetTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    // Normalize input to always be an array
-    const assetIds = Array.isArray(args.assetId)
-      ? args.assetId
-      : [args.assetId];
-
-    // For single asset, use individual publish
     if (assetIds.length === 1) {
       try {
         const assetId = assetIds[0];
@@ -53,10 +77,7 @@ export function publishAssetTool(config: ContentfulConfig) {
           assetId,
         };
 
-        // Get the asset first
         const asset = await contentfulClient.asset.get(params);
-
-        // Publish the asset
         const publishedAsset = await contentfulClient.asset.publish(
           params,
           asset,
@@ -74,23 +95,18 @@ export function publishAssetTool(config: ContentfulConfig) {
       }
     }
 
-    // For multiple assets, use bulk action API
-    // Get the current version of each asset
     const entityVersions = await createAssetVersionedLinks(
       contentfulClient,
       baseParams,
       assetIds,
     );
 
-    // Create the collection object
     const entitiesCollection = createEntitiesCollection(entityVersions);
 
-    // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.publish(baseParams, {
       entities: entitiesCollection,
     });
 
-    // Wait for the bulk action to complete
     const action = await waitForBulkActionCompletion(
       contentfulClient,
       baseParams,

--- a/packages/mcp-tools/src/tools/assets/publishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.ts
@@ -24,13 +24,13 @@ export const PublishAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to publish (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+      'A single asset ID (string) or an array of asset IDs to publish (up to MAX_BULK_SIZE per call; default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.test.ts
@@ -248,4 +248,25 @@ describe('unarchiveAsset', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unarchiveAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetUnarchive).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.test.ts
@@ -172,4 +172,80 @@ describe('unarchiveAsset', () => {
       expect(result.content[0].text).toContain('asset-1');
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unarchiveAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = unarchiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'unarchive',
+      entityType: 'asset',
+      count: 2,
+      ids: ['a1', 'a2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would unarchive 2 assets in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockAssetUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single asset without executing', async () => {
+    const tool = unarchiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: 'a1',
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockAssetUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = unarchiveAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: Array.from({ length: 11 }, (_, i) => `a${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving asset: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
@@ -18,13 +18,13 @@ export const UnarchiveAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to unarchive (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+      'A single asset ID (string) or an array of asset IDs to unarchive (up to MAX_BULK_SIZE per call; default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
@@ -8,13 +8,23 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../utils/tools.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnarchiveAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to unarchive (string) or an array of asset IDs (up to 100 assets)',
+      'The ID of the asset to unarchive (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -26,6 +36,26 @@ export function unarchiveAssetTool(config: ContentfulConfig) {
       args.environmentId,
       config.protectedEnvironments,
     );
+
+    const assetIds = Array.isArray(args.assetId)
+      ? args.assetId
+      : [args.assetId];
+
+    assertBulkSizeAllowed(assetIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'unarchive',
+          entityType: 'asset',
+          ids: assetIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -33,15 +63,8 @@ export function unarchiveAssetTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    // Normalize input to always be an array
-    const assetIds = Array.isArray(args.assetId)
-      ? args.assetId
-      : [args.assetId];
-
-    // Track successfully unarchived assets
     const successfullyUnarchived: string[] = [];
 
-    // Process each asset sequentially, stopping at first failure
     for (const assetId of assetIds) {
       try {
         const params = {
@@ -49,11 +72,9 @@ export function unarchiveAssetTool(config: ContentfulConfig) {
           assetId,
         };
 
-        // Unarchive the asset - will throw on error
         await contentfulClient.asset.unarchive(params);
         successfullyUnarchived.push(assetId);
       } catch (error) {
-        // Enhance error with context about successful operations
         const errorMessage =
           successfullyUnarchived.length > 0
             ? `Failed to unarchive asset '${assetId}' after successfully unarchiving ${successfullyUnarchived.length} asset(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
@@ -412,4 +412,27 @@ describe('unpublishAsset', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unpublishAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetGet).not.toHaveBeenCalled();
+    expect(mockAssetUnpublish).not.toHaveBeenCalled();
+    expect(mockBulkActionUnpublish).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
@@ -267,6 +267,7 @@ describe('unpublishAsset', () => {
   });
 
   it('should respect maximum bulk limit of 100 assets', async () => {
+    const expandedConfig = createMockConfig({ maxBulkSize: 100 });
     const manyAssets = Array.from({ length: 100 }, (_, i) => `asset${i + 1}`);
     const testArgs = {
       ...mockArgs,
@@ -275,7 +276,7 @@ describe('unpublishAsset', () => {
 
     mockBulkActionUnpublish.mockResolvedValue(mockBulkAction);
 
-    const tool = unpublishAssetTool(mockConfig);
+    const tool = unpublishAssetTool(expandedConfig);
     const result = await tool(testArgs);
 
     expect(result).toEqual({
@@ -328,6 +329,85 @@ describe('unpublishAsset', () => {
         {
           type: 'text',
           text: expect.stringContaining('Asset unpublished successfully'),
+        },
+      ],
+    });
+  });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unpublishAssetTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2', 'a3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing asset: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockAssetUnpublish).not.toHaveBeenCalled();
+    expect(mockBulkActionUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = unpublishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: ['a1', 'a2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'unpublish',
+      entityType: 'asset',
+      count: 2,
+      ids: ['a1', 'a2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would unpublish 2 assets in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockAssetUnpublish).not.toHaveBeenCalled();
+    expect(mockBulkActionUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single asset without executing', async () => {
+    const tool = unpublishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: 'a1',
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockAssetGet).not.toHaveBeenCalled();
+    expect(mockAssetUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = unpublishAssetTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      assetId: Array.from({ length: 11 }, (_, i) => `a${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing asset: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
         },
       ],
     });

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
@@ -24,13 +24,13 @@ export const UnpublishAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to unpublish (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+      'A single asset ID (string) or an array of asset IDs to unpublish (up to MAX_BULK_SIZE per call; default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
@@ -14,13 +14,23 @@ import {
   waitForBulkActionCompletion,
   createAssetUnversionedLinks,
 } from '../../utils/bulkOperations.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnpublishAssetToolParams = BaseToolSchema.extend({
   assetId: z
     .union([z.string(), z.array(z.string()).max(100)])
     .describe(
-      'The ID of the asset to unpublish (string) or an array of asset IDs (up to 100 assets)',
+      'The ID of the asset to unpublish (string) or an array of asset IDs (up to 100 assets, subject to MAX_BULK_SIZE)',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -32,6 +42,26 @@ export function unpublishAssetTool(config: ContentfulConfig) {
       args.environmentId,
       config.protectedEnvironments,
     );
+
+    const assetIds = Array.isArray(args.assetId)
+      ? args.assetId
+      : [args.assetId];
+
+    assertBulkSizeAllowed(assetIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'unpublish',
+          entityType: 'asset',
+          ids: assetIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams: BulkOperationParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -39,12 +69,6 @@ export function unpublishAssetTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    // Normalize input to always be an array
-    const assetIds = Array.isArray(args.assetId)
-      ? args.assetId
-      : [args.assetId];
-
-    // For single asset, use individual unpublish for simplicity
     if (assetIds.length === 1) {
       try {
         const assetId = assetIds[0];
@@ -53,10 +77,7 @@ export function unpublishAssetTool(config: ContentfulConfig) {
           assetId,
         };
 
-        // Get the asset first
         const asset = await contentfulClient.asset.get(params);
-
-        // Unpublish the asset
         const unpublishedAsset = await contentfulClient.asset.unpublish(
           params,
           asset,
@@ -74,23 +95,18 @@ export function unpublishAssetTool(config: ContentfulConfig) {
       }
     }
 
-    // For multiple assets, use bulk action API
-    // Get the unversioned links for each asset (unpublish doesn't need version info)
     const assetLinks = await createAssetUnversionedLinks(
       contentfulClient,
       baseParams,
       assetIds,
     );
 
-    // Create the collection object
     const entitiesCollection = createEntitiesCollection(assetLinks);
 
-    // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.unpublish(baseParams, {
       entities: entitiesCollection,
     });
 
-    // Wait for the bulk action to complete
     const action = await waitForBulkActionCompletion(
       contentfulClient,
       baseParams,

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
@@ -167,4 +167,80 @@ describe('archiveEntry', () => {
       expect(result.content[0].text).toContain('entry-1');
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = archiveEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryArchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = archiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'archive',
+      entityType: 'entry',
+      count: 2,
+      ids: ['e1', 'e2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would archive 2 entries in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockEntryArchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single entry without executing', async () => {
+    const tool = archiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1'],
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockEntryArchive).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = archiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: Array.from({ length: 11 }, (_, i) => `e${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving entry: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.test.ts
@@ -243,4 +243,25 @@ describe('archiveEntry', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = archiveEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error archiving entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryArchive).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.ts
@@ -20,13 +20,13 @@ export const ArchiveEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to archive. Pass a single-element array for one entry, or up to 100 IDs for batch operations (subject to MAX_BULK_SIZE).',
+      'Array of entry IDs to archive. Single-element array for one entry, or up to MAX_BULK_SIZE per call (default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.ts
@@ -8,6 +8,10 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../utils/tools.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const ArchiveEntryToolParams = BaseToolSchema.extend({
@@ -16,7 +20,13 @@ export const ArchiveEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to archive. Pass a single-element array for one entry, or up to 100 IDs for batch operations.',
+      'Array of entry IDs to archive. Pass a single-element array for one entry, or up to 100 IDs for batch operations (subject to MAX_BULK_SIZE).',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -29,6 +39,22 @@ export function archiveEntryTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
+    const entryIds = args.entryId;
+    assertBulkSizeAllowed(entryIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'archive',
+          entityType: 'entry',
+          ids: entryIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -36,12 +62,8 @@ export function archiveEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    const entryIds = args.entryId;
-
-    // Track successfully archived entries
     const successfullyArchived: string[] = [];
 
-    // Process each entry sequentially, stopping at first failure
     for (const entryId of entryIds) {
       try {
         const params = {
@@ -49,11 +71,9 @@ export function archiveEntryTool(config: ContentfulConfig) {
           entryId,
         };
 
-        // Archive the entry - will throw on error
         await contentfulClient.entry.archive(params);
         successfullyArchived.push(entryId);
       } catch (error) {
-        // Enhance error with context about successful operations
         const errorMessage =
           successfullyArchived.length > 0
             ? `Failed to archive entry '${entryId}' after successfully archiving ${successfullyArchived.length} entry(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
@@ -179,4 +179,69 @@ describe('publishEntry', () => {
       ],
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = publishEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryPublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = publishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'publish',
+      entityType: 'entry',
+      count: 2,
+      ids: ['e1', 'e2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would publish 2 entries in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockEntryPublish).not.toHaveBeenCalled();
+    expect(mockBulkActionPublish).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = publishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: Array.from({ length: 11 }, (_, i) => `e${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing entry: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
@@ -227,6 +227,19 @@ describe('publishEntry', () => {
     expect(mockBulkActionPublish).not.toHaveBeenCalled();
   });
 
+  it('should return a dry-run preview for a single entry without executing', async () => {
+    const tool = publishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1'],
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockEntryGet).not.toHaveBeenCalled();
+    expect(mockEntryPublish).not.toHaveBeenCalled();
+  });
+
   it('uses the default limit (10) when maxBulkSize is unset', async () => {
     const tool = publishEntryTool(mockConfig);
     const result = await tool({

--- a/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.test.ts
@@ -257,4 +257,26 @@ describe('publishEntry', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = publishEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error publishing entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryPublish).not.toHaveBeenCalled();
+    expect(mockBulkActionPublish).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/publishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.ts
@@ -14,6 +14,10 @@ import {
   createEntitiesCollection,
   waitForBulkActionCompletion,
 } from '../../utils/bulkOperations.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const PublishEntryToolParams = BaseToolSchema.extend({
@@ -22,7 +26,13 @@ export const PublishEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to publish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations.',
+      'Array of entry IDs to publish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations (subject to MAX_BULK_SIZE).',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -35,6 +45,21 @@ export function publishEntryTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
+    const entryIds = args.entryId;
+    assertBulkSizeAllowed(entryIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse('Dry run: no changes were made', {
+        ...buildDryRunPreview({
+          operation: 'publish',
+          entityType: 'entry',
+          ids: entryIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      });
+    }
+
     const baseParams: BulkOperationParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -42,9 +67,6 @@ export function publishEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    const entryIds = args.entryId;
-
-    // For single entry, use individual publish for simplicity
     if (entryIds.length === 1) {
       const entryId = entryIds[0];
       const params = {
@@ -52,10 +74,7 @@ export function publishEntryTool(config: ContentfulConfig) {
         entryId,
       };
 
-      // Get the entry first
       const entry = await contentfulClient.entry.get(params);
-
-      // Publish the entry
       const publishedEntry = await contentfulClient.entry.publish(
         params,
         entry,
@@ -67,23 +86,18 @@ export function publishEntryTool(config: ContentfulConfig) {
       });
     }
 
-    // For multiple entries, use bulk action API
-    // Get the current version of each entry
     const entityVersions = await createEntryVersionedLinks(
       contentfulClient,
       baseParams,
       entryIds,
     );
 
-    // Create the collection object
     const entitiesCollection = createEntitiesCollection(entityVersions);
 
-    // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.publish(baseParams, {
       entities: entitiesCollection,
     });
 
-    // Wait for the bulk action to complete
     const action = await waitForBulkActionCompletion(
       contentfulClient,
       baseParams,

--- a/packages/mcp-tools/src/tools/entries/publishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.ts
@@ -49,15 +49,16 @@ export function publishEntryTool(config: ContentfulConfig) {
     assertBulkSizeAllowed(entryIds.length, config.maxBulkSize);
 
     if (args.dryRun) {
-      return createSuccessResponse('Dry run: no changes were made', {
-        ...buildDryRunPreview({
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
           operation: 'publish',
           entityType: 'entry',
           ids: entryIds,
           spaceId: args.spaceId,
           environmentId: args.environmentId,
         }),
-      });
+      );
     }
 
     const baseParams: BulkOperationParams = {

--- a/packages/mcp-tools/src/tools/entries/publishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/publishEntry.ts
@@ -26,13 +26,13 @@ export const PublishEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to publish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations (subject to MAX_BULK_SIZE).',
+      'Array of entry IDs to publish. Single-element array for one entry, or up to MAX_BULK_SIZE per call (default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
@@ -167,4 +167,80 @@ describe('unarchiveEntry', () => {
       expect(result.content[0].text).toContain('entry-1');
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unarchiveEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = unarchiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'unarchive',
+      entityType: 'entry',
+      count: 2,
+      ids: ['e1', 'e2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would unarchive 2 entries in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockEntryUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single entry without executing', async () => {
+    const tool = unarchiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1'],
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockEntryUnarchive).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = unarchiveEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: Array.from({ length: 11 }, (_, i) => `e${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving entry: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.test.ts
@@ -243,4 +243,25 @@ describe('unarchiveEntry', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unarchiveEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unarchiving entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryUnarchive).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
@@ -8,6 +8,10 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../utils/tools.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnarchiveEntryToolParams = BaseToolSchema.extend({
@@ -16,7 +20,13 @@ export const UnarchiveEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to unarchive. Pass a single-element array for one entry, or up to 100 IDs for batch operations.',
+      'Array of entry IDs to unarchive. Pass a single-element array for one entry, or up to 100 IDs for batch operations (subject to MAX_BULK_SIZE).',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -29,6 +39,22 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
+    const entryIds = args.entryId;
+    assertBulkSizeAllowed(entryIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'unarchive',
+          entityType: 'entry',
+          ids: entryIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -36,12 +62,8 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    const entryIds = args.entryId;
-
-    // Track successfully unarchived entries
     const successfullyUnarchived: string[] = [];
 
-    // Process each entry sequentially, stopping at first failure
     for (const entryId of entryIds) {
       try {
         const params = {
@@ -49,11 +71,9 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
           entryId,
         };
 
-        // Unarchive the entry - will throw on error
         await contentfulClient.entry.unarchive(params);
         successfullyUnarchived.push(entryId);
       } catch (error) {
-        // Enhance error with context about successful operations
         const errorMessage =
           successfullyUnarchived.length > 0
             ? `Failed to unarchive entry '${entryId}' after successfully unarchiving ${successfullyUnarchived.length} entry(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
@@ -20,13 +20,13 @@ export const UnarchiveEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to unarchive. Pass a single-element array for one entry, or up to 100 IDs for batch operations (subject to MAX_BULK_SIZE).',
+      'Array of entry IDs to unarchive. Single-element array for one entry, or up to MAX_BULK_SIZE per call (default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
@@ -184,4 +184,82 @@ describe('unpublishEntry', () => {
       ],
     });
   });
+
+  it('should reject calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unpublishEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview without executing when dryRun is true', async () => {
+    const tool = unpublishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2'],
+      dryRun: true,
+    });
+
+    const expectedResponse = formatResponse('Dry run: no changes were made', {
+      dryRun: true,
+      operation: 'unpublish',
+      entityType: 'entry',
+      count: 2,
+      ids: ['e1', 'e2'],
+      target: {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      },
+      message: `Dry run: would unpublish 2 entries in ${mockArgs.spaceId}/${mockArgs.environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockEntryUnpublish).not.toHaveBeenCalled();
+    expect(mockBulkActionUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('should return a dry-run preview for a single entry without executing', async () => {
+    const tool = unpublishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1'],
+      dryRun: true,
+    });
+
+    expect(result).not.toHaveProperty('isError');
+    expect(mockEntryGet).not.toHaveBeenCalled();
+    expect(mockEntryUnpublish).not.toHaveBeenCalled();
+  });
+
+  it('uses the default limit (10) when maxBulkSize is unset', async () => {
+    const tool = unpublishEntryTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: Array.from({ length: 11 }, (_, i) => `e${i}`),
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing entry: Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.test.ts
@@ -262,4 +262,26 @@ describe('unpublishEntry', () => {
       ],
     });
   });
+
+  it('rejects dryRun calls that exceed maxBulkSize', async () => {
+    const limitedConfig = createMockConfig({ maxBulkSize: 2 });
+    const tool = unpublishEntryTool(limitedConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: ['e1', 'e2', 'e3'],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error unpublishing entry: Bulk operation rejected: 3 IDs exceeds MAX_BULK_SIZE of 2. Reduce batch size or increase the limit.',
+        },
+      ],
+    });
+    expect(mockEntryUnpublish).not.toHaveBeenCalled();
+    expect(mockBulkActionUnpublish).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
@@ -14,6 +14,10 @@ import {
   createEntitiesCollection,
   waitForBulkActionCompletion,
 } from '../../utils/bulkOperations.js';
+import {
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from '../../utils/bulkLimits.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export const UnpublishEntryToolParams = BaseToolSchema.extend({
@@ -22,7 +26,13 @@ export const UnpublishEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to unpublish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations.',
+      'Array of entry IDs to unpublish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations (subject to MAX_BULK_SIZE).',
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
     ),
 });
 
@@ -35,6 +45,22 @@ export function unpublishEntryTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
+    const entryIds = args.entryId;
+    assertBulkSizeAllowed(entryIds.length, config.maxBulkSize);
+
+    if (args.dryRun) {
+      return createSuccessResponse(
+        'Dry run: no changes were made',
+        buildDryRunPreview({
+          operation: 'unpublish',
+          entityType: 'entry',
+          ids: entryIds,
+          spaceId: args.spaceId,
+          environmentId: args.environmentId,
+        }),
+      );
+    }
+
     const baseParams: BulkOperationParams = {
       spaceId: args.spaceId,
       environmentId: args.environmentId,
@@ -42,9 +68,6 @@ export function unpublishEntryTool(config: ContentfulConfig) {
 
     const contentfulClient = createToolClient(config, args);
 
-    const entryIds = args.entryId;
-
-    // For single entry, use individual unpublish for simplicity
     if (entryIds.length === 1) {
       const entryId = entryIds[0];
       const params = {
@@ -52,10 +75,7 @@ export function unpublishEntryTool(config: ContentfulConfig) {
         entryId,
       };
 
-      // Get the entry first
       const entry = await contentfulClient.entry.get(params);
-
-      // Unpublish the entry
       const unpublishedEntry = await contentfulClient.entry.unpublish(
         params,
         entry,
@@ -67,23 +87,18 @@ export function unpublishEntryTool(config: ContentfulConfig) {
       });
     }
 
-    // For multiple entries, use bulk action API
-    // Get the unversioned links for each entry (unpublish doesn't need version info)
     const entityLinks = await createEntryUnversionedLinks(
       contentfulClient,
       baseParams,
       entryIds,
     );
 
-    // Create the collection object
     const entitiesCollection = createEntitiesCollection(entityLinks);
 
-    // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.unpublish(baseParams, {
       entities: entitiesCollection,
     });
 
-    // Wait for the bulk action to complete
     const action = await waitForBulkActionCompletion(
       contentfulClient,
       baseParams,

--- a/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unpublishEntry.ts
@@ -26,13 +26,13 @@ export const UnpublishEntryToolParams = BaseToolSchema.extend({
     .min(1)
     .max(100)
     .describe(
-      'Array of entry IDs to unpublish. Pass a single-element array for one entry, or up to 100 IDs for bulk operations (subject to MAX_BULK_SIZE).',
+      'Array of entry IDs to unpublish. Single-element array for one entry, or up to MAX_BULK_SIZE per call (default 10, max 100 — configurable via MAX_BULK_SIZE env var).',
     ),
   dryRun: z
     .boolean()
     .optional()
     .describe(
-      'When true, returns a preview of the operation without executing it. Useful for verifying intent on bulk calls.',
+      'When true, returns a preview of the operation without executing it. Still subject to MAX_BULK_SIZE — use this to confirm intent for within-limit calls.',
     ),
 });
 

--- a/packages/mcp-tools/src/utils/bulkLimits.test.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.test.ts
@@ -64,7 +64,20 @@ describe('buildDryRunPreview', () => {
       ids: ['a', 'b', 'c'],
       target: { spaceId: 'space-1', environmentId: 'master' },
       message:
-        'Dry run: would publish 3 entry(ies) in space-1/master. No changes were made. Re-run without dryRun to execute.',
+        'Dry run: would publish 3 entries in space-1/master. No changes were made. Re-run without dryRun to execute.',
     });
+  });
+
+  it('uses singular form when there is exactly one id', () => {
+    const preview = buildDryRunPreview({
+      operation: 'archive',
+      entityType: 'asset',
+      ids: ['only-one'],
+      spaceId: 's',
+      environmentId: 'e',
+    });
+    expect(preview.message).toBe(
+      'Dry run: would archive 1 asset in s/e. No changes were made. Re-run without dryRun to execute.',
+    );
   });
 });

--- a/packages/mcp-tools/src/utils/bulkLimits.test.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MAX_BULK_SIZE,
+  resolveMaxBulkSize,
+  assertBulkSizeAllowed,
+  buildDryRunPreview,
+} from './bulkLimits.js';
+
+describe('resolveMaxBulkSize', () => {
+  it('returns the default when config value is undefined', () => {
+    expect(resolveMaxBulkSize(undefined)).toBe(DEFAULT_MAX_BULK_SIZE);
+    expect(DEFAULT_MAX_BULK_SIZE).toBe(10);
+  });
+
+  it('returns the configured value when valid', () => {
+    expect(resolveMaxBulkSize(25)).toBe(25);
+  });
+
+  it('falls back to the default for non-positive values', () => {
+    expect(resolveMaxBulkSize(0)).toBe(DEFAULT_MAX_BULK_SIZE);
+    expect(resolveMaxBulkSize(-5)).toBe(DEFAULT_MAX_BULK_SIZE);
+  });
+
+  it('falls back to the default for non-integer values', () => {
+    expect(resolveMaxBulkSize(3.5)).toBe(DEFAULT_MAX_BULK_SIZE);
+    expect(resolveMaxBulkSize(Number.NaN)).toBe(DEFAULT_MAX_BULK_SIZE);
+  });
+});
+
+describe('assertBulkSizeAllowed', () => {
+  it('does not throw when count is within the limit', () => {
+    expect(() => assertBulkSizeAllowed(5, 10)).not.toThrow();
+    expect(() => assertBulkSizeAllowed(10, 10)).not.toThrow();
+  });
+
+  it('throws a descriptive error when count exceeds the limit', () => {
+    expect(() => assertBulkSizeAllowed(47, 10)).toThrowError(
+      'Bulk operation rejected: 47 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+    );
+  });
+
+  it('uses the resolved default when limit is undefined', () => {
+    expect(() => assertBulkSizeAllowed(11, undefined)).toThrowError(
+      'Bulk operation rejected: 11 IDs exceeds MAX_BULK_SIZE of 10. Reduce batch size or increase the limit.',
+    );
+  });
+});
+
+describe('buildDryRunPreview', () => {
+  it('builds a preview describing the operation without side effects', () => {
+    const preview = buildDryRunPreview({
+      operation: 'publish',
+      entityType: 'entry',
+      ids: ['a', 'b', 'c'],
+      spaceId: 'space-1',
+      environmentId: 'master',
+    });
+
+    expect(preview).toEqual({
+      dryRun: true,
+      operation: 'publish',
+      entityType: 'entry',
+      count: 3,
+      ids: ['a', 'b', 'c'],
+      target: { spaceId: 'space-1', environmentId: 'master' },
+      message:
+        'Dry run: would publish 3 entry(ies) in space-1/master. No changes were made. Re-run without dryRun to execute.',
+    });
+  });
+});

--- a/packages/mcp-tools/src/utils/bulkLimits.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.ts
@@ -5,7 +5,7 @@
  *   1. `assertBulkSizeAllowed` — blocks calls that exceed `MAX_BULK_SIZE`.
  *      Default 10. Configurable per-server (env var on local, OAuth-time
  *      input on remote). Mitigates the catastrophic "AI hallucinated 100
- *      entry IDs for deletion" failure mode flagged by Klarna and TELUS.
+ *      entry IDs for deletion" failure mode.
  *
  *   2. `buildDryRunPreview` — returns what would happen without executing.
  *      Tools accept `dryRun: true` and short-circuit before any CMA call.

--- a/packages/mcp-tools/src/utils/bulkLimits.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.ts
@@ -1,0 +1,74 @@
+/**
+ * Safety guards for tools that accept arrays of IDs (publish/unpublish/
+ * archive/unarchive entries and assets). Two protections are exposed:
+ *
+ *   1. `assertBulkSizeAllowed` — blocks calls that exceed `MAX_BULK_SIZE`.
+ *      Default 10. Configurable per-server (env var on local, OAuth-time
+ *      input on remote). Mitigates the catastrophic "AI hallucinated 100
+ *      entry IDs for deletion" failure mode flagged by Klarna and TELUS.
+ *
+ *   2. `buildDryRunPreview` — returns what would happen without executing.
+ *      Tools accept `dryRun: true` and short-circuit before any CMA call.
+ *      Delete tools deliberately do NOT use this — DX-1057's two-phase
+ *      confirmation already provides equivalent preview behavior.
+ */
+
+export const DEFAULT_MAX_BULK_SIZE = 10;
+
+export function resolveMaxBulkSize(configured: number | undefined): number {
+  if (
+    configured === undefined ||
+    !Number.isInteger(configured) ||
+    configured <= 0
+  ) {
+    return DEFAULT_MAX_BULK_SIZE;
+  }
+  return configured;
+}
+
+export function assertBulkSizeAllowed(
+  count: number,
+  configured: number | undefined,
+): void {
+  const limit = resolveMaxBulkSize(configured);
+  if (count > limit) {
+    throw new Error(
+      `Bulk operation rejected: ${count} IDs exceeds MAX_BULK_SIZE of ${limit}. Reduce batch size or increase the limit.`,
+    );
+  }
+}
+
+export type DryRunOperation = 'publish' | 'unpublish' | 'archive' | 'unarchive';
+
+export type DryRunEntityType = 'entry' | 'asset';
+
+export interface DryRunPreviewInput {
+  operation: DryRunOperation;
+  entityType: DryRunEntityType;
+  ids: string[];
+  spaceId: string;
+  environmentId: string;
+}
+
+export interface DryRunPreview {
+  dryRun: true;
+  operation: DryRunOperation;
+  entityType: DryRunEntityType;
+  count: number;
+  ids: string[];
+  target: { spaceId: string; environmentId: string };
+  message: string;
+}
+
+export function buildDryRunPreview(input: DryRunPreviewInput): DryRunPreview {
+  const { operation, entityType, ids, spaceId, environmentId } = input;
+  return {
+    dryRun: true,
+    operation,
+    entityType,
+    count: ids.length,
+    ids,
+    target: { spaceId, environmentId },
+    message: `Dry run: would ${operation} ${ids.length} ${entityType}(ies) in ${spaceId}/${environmentId}. No changes were made. Re-run without dryRun to execute.`,
+  };
+}

--- a/packages/mcp-tools/src/utils/bulkLimits.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.ts
@@ -60,8 +60,14 @@ export interface DryRunPreview {
   message: string;
 }
 
+const PLURAL_BY_ENTITY: Record<DryRunEntityType, string> = {
+  entry: 'entries',
+  asset: 'assets',
+};
+
 export function buildDryRunPreview(input: DryRunPreviewInput): DryRunPreview {
   const { operation, entityType, ids, spaceId, environmentId } = input;
+  const noun = ids.length === 1 ? entityType : PLURAL_BY_ENTITY[entityType];
   return {
     dryRun: true,
     operation,
@@ -69,6 +75,6 @@ export function buildDryRunPreview(input: DryRunPreviewInput): DryRunPreview {
     count: ids.length,
     ids,
     target: { spaceId, environmentId },
-    message: `Dry run: would ${operation} ${ids.length} ${entityType}(ies) in ${spaceId}/${environmentId}. No changes were made. Re-run without dryRun to execute.`,
+    message: `Dry run: would ${operation} ${ids.length} ${noun} in ${spaceId}/${environmentId}. No changes were made. Re-run without dryRun to execute.`,
   };
 }

--- a/packages/mcp-tools/src/utils/bulkLimits.ts
+++ b/packages/mcp-tools/src/utils/bulkLimits.ts
@@ -50,7 +50,7 @@ export interface DryRunPreviewInput {
   environmentId: string;
 }
 
-export interface DryRunPreview {
+export type DryRunPreview = {
   dryRun: true;
   operation: DryRunOperation;
   entityType: DryRunEntityType;
@@ -58,7 +58,7 @@ export interface DryRunPreview {
   ids: string[];
   target: { spaceId: string; environmentId: string };
   message: string;
-}
+} & Record<string, unknown>;
 
 const PLURAL_BY_ENTITY: Record<DryRunEntityType, string> = {
   entry: 'entries',


### PR DESCRIPTION
[DX-1063](https://contentful.atlassian.net/browse/DX-1063)

## Summary
- Add a configurable \`MAX_BULK_SIZE\` cap (default 10, max 100) and a \`dryRun\` preview parameter to all 8 bulk MCP tools: publish/unpublish/archive/unarchive for entries and assets. Mitigates accidental mass operations from AI hallucinations (Klarna FR-7, TELUS).
- Limit and dry-run logic live in a new shared \`bulkLimits.ts\` helper in \`@contentful/mcp-tools\`. \`dryRun: true\` short-circuits before \`createToolClient\`, returning a structured preview without touching the CMA. Delete tools intentionally excluded — DX-1057's two-phase confirmation already provides equivalent preview behavior.
- Exposed via \`MAX_BULK_SIZE\` env var on the local server. Remote-server wiring lives in [contentful/remote-mcp-server#dx-1063](https://github.com/contentful/remote-mcp-server/pull/new/dx-1063-bulk-size-limit-and-dry-run) (companion PR).

## Test plan
- [ ] CI green — full mcp-tools + mcp-server suites
- [ ] \`MAX_BULK_SIZE=2\` env, run \`publish_entry\` with 3 IDs → expect rejection with the spec'd error message
- [ ] No \`MAX_BULK_SIZE\` set, run \`publish_entry\` with 11 IDs → expect rejection at default of 10
- [ ] \`dryRun: true\` on bulk publish → returns \`{ dryRun: true, operation, entityType, count, ids, target, message }\` with no CMA call
- [ ] Existing single-entity flows (1 ID) unchanged
- [ ] \`PROTECTED_ENVIRONMENTS\` enforcement still fires before bulk-size check

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1063]: https://contentful.atlassian.net/browse/DX-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds configurable safety limits and dry-run preview capabilities to all 8 bulk MCP tools (publish/unpublish/archive/unarchive for entries and assets) to mitigate accidental mass operations caused by AI hallucinations. The MAX_BULK_SIZE environment variable caps bulk operations at a configurable threshold (default 10, max 100), while the dryRun parameter enables previewing operations before execution without touching the Contentful Management API.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates parameter descriptions in all 8 bulk tool schemas (archiveAsset.ts, publishAsset.ts, unarchiveAsset.ts, unpublishAsset.ts, archiveEntry.ts, publishEntry.ts, unarchiveEntry.ts, unpublishEntry.ts) to clarify MAX_BULK_SIZE constraints (default 10, max 100) and dryRun behavior</li>

<li>Adds test coverage across all 8 tool test files verifying that dryRun calls exceeding maxBulkSize are rejected with appropriate error messages and that no CMA APIs are called</li>

<li>Updates bulkLimits.ts JSDoc to remove vendor-specific references while maintaining the safety rationale documentation</li>

</ul>
</details>

</div>