### PR TITLE
feat: add resolve_entry_references MCP tool [DX-754]

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -113,6 +113,7 @@ Below is a sample configuration:
 |                           | `publish_entry`                    | Publish entries (single or bulk up to 100)       |
 |                           | `unpublish_entry`                  | Unpublish entries (single or bulk up to 100)     |
 |                           | `delete_entry`                     | Remove entries                                   |
+|                           | `resolve_entry_references`         | Recursively resolve an entry's references tree   |
 | **Editor Interfaces**     | `list_editor_interfaces`           | List all editor interfaces in a space            |
 |                           | `get_editor_interface`             | Get editor interface for a content type          |
 |                           | `update_editor_interface`          | Update field controls, sidebars, and layouts     |

--- a/packages/mcp-tools/src/tools/entries/mockClient.ts
+++ b/packages/mcp-tools/src/tools/entries/mockClient.ts
@@ -16,6 +16,7 @@ export const mockEntryUnpublish = vi.fn();
 export const mockEntryArchive = vi.fn();
 export const mockEntryUnarchive = vi.fn();
 export const mockEntryGetMany = vi.fn();
+export const mockEntryReferences = vi.fn();
 export const mockBulkActionPublish = vi.fn();
 export const mockBulkActionUnpublish = vi.fn();
 
@@ -33,6 +34,7 @@ export const mockClient = {
     archive: mockEntryArchive,
     unarchive: mockEntryUnarchive,
     getMany: mockEntryGetMany,
+    references: mockEntryReferences,
   },
   bulkAction: {
     publish: mockBulkActionPublish,

--- a/packages/mcp-tools/src/tools/entries/register.ts
+++ b/packages/mcp-tools/src/tools/entries/register.ts
@@ -3,6 +3,10 @@ import { createEntryTool, CreateEntryToolParams } from './createEntry.js';
 import { deleteEntryTool, DeleteEntryToolParams } from './deleteEntry.js';
 import { updateEntryTool, UpdateEntryToolParams } from './updateEntry.js';
 import { getEntryTool, GetEntryToolParams } from './getEntry.js';
+import {
+  resolveEntryReferencesTool,
+  ResolveEntryReferencesToolParams,
+} from './resolveEntryReferences.js';
 import { publishEntryTool, PublishEntryToolParams } from './publishEntry.js';
 import {
   unpublishEntryTool,
@@ -21,6 +25,7 @@ export function createEntryTools(config: ContentfulConfig) {
   const deleteEntry = deleteEntryTool(config);
   const updateEntry = updateEntryTool(config);
   const getEntry = getEntryTool(config);
+  const resolveEntryReferences = resolveEntryReferencesTool(config);
   const publishEntry = publishEntryTool(config);
   const unpublishEntry = unpublishEntryTool(config);
   const archiveEntry = archiveEntryTool(config);
@@ -59,6 +64,17 @@ export function createEntryTools(config: ContentfulConfig) {
         openWorldHint: false,
       },
       tool: getEntry,
+    },
+    resolveEntryReferences: {
+      title: 'resolve_entry_references',
+      description:
+        "Recursively resolve an entry's references and return the entry plus its descendant entries and linked assets. Useful for verifying the structure of a page or any entry that links to other entries before or after edits, without issuing one fetch per descendant. Set `include` (1-10, default 2) to control how many levels deep to walk; the CMA caps this at 10.",
+      inputParams: ResolveEntryReferencesToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      tool: resolveEntryReferences,
     },
     updateEntry: {
       title: 'update_entry',

--- a/packages/mcp-tools/src/tools/entries/resolveEntryReferences.test.ts
+++ b/packages/mcp-tools/src/tools/entries/resolveEntryReferences.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resolveEntryReferencesTool } from './resolveEntryReferences.js';
+import { formatResponse } from '../../utils/formatters.js';
+import {
+  setupMockClient,
+  mockEntryReferences,
+  mockEntry,
+  mockArgs,
+} from './mockClient.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+vi.mock('../../../src/utils/tools.js');
+
+describe('resolveEntryReferences', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    setupMockClient();
+    mockEntryReferences.mockReset();
+  });
+
+  it('should resolve entry references successfully', async () => {
+    const mockResponse = {
+      sys: { type: 'Array' },
+      total: 1,
+      skip: 0,
+      limit: 100,
+      items: [mockEntry],
+      includes: {
+        Entry: [mockEntry],
+        Asset: [],
+      },
+    };
+    mockEntryReferences.mockResolvedValue(mockResponse);
+
+    const tool = resolveEntryReferencesTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+    });
+
+    const expectedResponse = formatResponse(
+      'Entry references retrieved successfully',
+      { references: mockResponse },
+    );
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockEntryReferences).toHaveBeenCalledWith({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
+      entryId: 'test-entry-id',
+      include: 2,
+    });
+  });
+
+  it('should pass a custom include depth to the CMA client', async () => {
+    mockEntryReferences.mockResolvedValue({
+      sys: { type: 'Array' },
+      total: 0,
+      skip: 0,
+      limit: 100,
+      items: [],
+    });
+
+    const tool = resolveEntryReferencesTool(mockConfig);
+    await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      include: 5,
+    });
+
+    expect(mockEntryReferences).toHaveBeenCalledWith({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
+      entryId: 'test-entry-id',
+      include: 5,
+    });
+  });
+
+  it('should reject include values below 1', async () => {
+    const tool = resolveEntryReferencesTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      include: 0,
+    } as unknown as Parameters<typeof tool>[0]);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/include/i);
+    expect(mockEntryReferences).not.toHaveBeenCalled();
+  });
+
+  it('should reject include values above 10', async () => {
+    const tool = resolveEntryReferencesTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      include: 11,
+    } as unknown as Parameters<typeof tool>[0]);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/include/i);
+    expect(mockEntryReferences).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors when CMA call fails', async () => {
+    const error = new Error('Entry not found');
+    mockEntryReferences.mockRejectedValue(error);
+
+    const tool = resolveEntryReferencesTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'missing-entry-id',
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error resolving entry references: Entry not found',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/entries/resolveEntryReferences.test.ts
+++ b/packages/mcp-tools/src/tools/entries/resolveEntryReferences.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { resolveEntryReferencesTool } from './resolveEntryReferences.js';
+import {
+  resolveEntryReferencesTool,
+  ResolveEntryReferencesToolParams,
+} from './resolveEntryReferences.js';
 import { formatResponse } from '../../utils/formatters.js';
 import {
   setupMockClient,
@@ -7,16 +10,22 @@ import {
   mockEntry,
   mockArgs,
 } from './mockClient.js';
-import { createMockConfig } from '../../test-helpers/mockConfig.js';
 
-vi.mock('../../../src/utils/tools.js');
+vi.mock('../../utils/tools.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../utils/tools.js')>();
+  return {
+    ...orig,
+    createToolClient: vi.fn(),
+  };
+});
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
 
 describe('resolveEntryReferences', () => {
   const mockConfig = createMockConfig();
 
   beforeEach(() => {
     setupMockClient();
-    mockEntryReferences.mockReset();
+    vi.clearAllMocks();
   });
 
   it('should resolve entry references successfully', async () => {
@@ -78,33 +87,41 @@ describe('resolveEntryReferences', () => {
     });
   });
 
-  it('should reject include values below 1', async () => {
-    const tool = resolveEntryReferencesTool(mockConfig);
-    const result = await tool({
-      ...mockArgs,
+  it('should reject include values below 1 via the schema', () => {
+    const result = ResolveEntryReferencesToolParams.safeParse({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
       entryId: 'test-entry-id',
       include: 0,
-    } as unknown as Parameters<typeof tool>[0]);
+    });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/include/i);
-    expect(mockEntryReferences).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['include']);
   });
 
-  it('should reject include values above 10', async () => {
-    const tool = resolveEntryReferencesTool(mockConfig);
-    const result = await tool({
-      ...mockArgs,
+  it('should reject include values above 10 via the schema', () => {
+    const result = ResolveEntryReferencesToolParams.safeParse({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
       entryId: 'test-entry-id',
       include: 11,
-    } as unknown as Parameters<typeof tool>[0]);
+    });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/include/i);
-    expect(mockEntryReferences).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(['include']);
   });
 
-  it('should handle errors when CMA call fails', async () => {
+  it('should default include to 2 when omitted', () => {
+    const result = ResolveEntryReferencesToolParams.parse({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
+      entryId: 'test-entry-id',
+    });
+
+    expect(result.include).toBe(2);
+  });
+
+  it('should surface CMA errors via withErrorHandling', async () => {
     const error = new Error('Entry not found');
     mockEntryReferences.mockRejectedValue(error);
 

--- a/packages/mcp-tools/src/tools/entries/resolveEntryReferences.ts
+++ b/packages/mcp-tools/src/tools/entries/resolveEntryReferences.ts
@@ -22,25 +22,13 @@ export const ResolveEntryReferencesToolParams = BaseToolSchema.extend({
     ),
 });
 
+// z.input (not z.infer) so the optional-with-default `include` stays optional
+// in the handler signature; the MCP runtime applies the default via the schema.
 type Params = z.input<typeof ResolveEntryReferencesToolParams>;
-
-const DEFAULT_INCLUDE = 2;
-const MIN_INCLUDE = 1;
-const MAX_INCLUDE = 10;
 
 export function resolveEntryReferencesTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const include = args.include ?? DEFAULT_INCLUDE;
-
-    if (
-      !Number.isInteger(include) ||
-      include < MIN_INCLUDE ||
-      include > MAX_INCLUDE
-    ) {
-      throw new Error(
-        `include must be an integer between ${MIN_INCLUDE} and ${MAX_INCLUDE} (received: ${include})`,
-      );
-    }
+    const { include = 2 } = args;
 
     const params = {
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/entries/resolveEntryReferences.ts
+++ b/packages/mcp-tools/src/tools/entries/resolveEntryReferences.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export const ResolveEntryReferencesToolParams = BaseToolSchema.extend({
+  entryId: z
+    .string()
+    .describe('The ID of the entry whose references should be resolved'),
+  include: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .optional()
+    .default(2)
+    .describe(
+      'How many levels of linked entries to walk (1-10, default: 2). The CMA caps this at 10.',
+    ),
+});
+
+type Params = z.input<typeof ResolveEntryReferencesToolParams>;
+
+const DEFAULT_INCLUDE = 2;
+const MIN_INCLUDE = 1;
+const MAX_INCLUDE = 10;
+
+export function resolveEntryReferencesTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const include = args.include ?? DEFAULT_INCLUDE;
+
+    if (
+      !Number.isInteger(include) ||
+      include < MIN_INCLUDE ||
+      include > MAX_INCLUDE
+    ) {
+      throw new Error(
+        `include must be an integer between ${MIN_INCLUDE} and ${MAX_INCLUDE} (received: ${include})`,
+      );
+    }
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      entryId: args.entryId,
+      include,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    const references = await contentfulClient.entry.references(params);
+
+    return createSuccessResponse('Entry references retrieved successfully', {
+      references,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error resolving entry references');
+}


### PR DESCRIPTION
[DX-754](https://contentful.atlassian.net/browse/DX-754)

## Summary
- Adds a new MCP tool `resolve_entry_references` that wraps the CMA `entry.references()` plain-client method, returning an entry plus its descendant entries and linked assets up to 10 levels deep. Lets an LLM verify a page's section tree without one fetch per descendant. Originally requested in [contentful-mcp-server#325](https://github.com/contentful/contentful-mcp-server/issues/325).
- Schema: `entryId: string` (required), `include: number(1-10, default 2)` (optional). Read-only annotations. Implementation mirrors the `getEntry` pattern.
- Registered in `createEntryTools`, so it surfaces automatically on both this local stdio server and the Cloudflare-hosted remote MCP server (the remote will pick it up once a new `@contentful/mcp-tools` version publishes; a small permissions-map follow-up is needed there to allow the new `<action>_<entity>` name through the guard).

## Test plan
- [x] 6 new unit tests in `resolveEntryReferences.test.ts` cover: happy path, custom `include`, schema rejection of `include < 1` and `> 10` (via `safeParse` against the exported Zod schema), default of `2` when omitted, and CMA error surfacing through `withErrorHandling`
- [x] `npm run test:run` — 419/419 pass across `mcp-tools` and `mcp-server`
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (5 pre-existing warnings unchanged)
- [x] Smoke-tested live against a real space (`x6cglmfvss79:exo`) via the local server:
  - **Default depth (2)**: root `showcaseGroup` + 3 linked sections under `<includes><Entry>` ✅
  - **Custom depth (5)**: multi-hop graph from `capability` → `nt_audience` + `nt_experience` → variant `capability` + 2 assets, all returned in one call ✅
  - **`include: 11`**: rejected at the framework boundary by Zod with structured error, never reaches the handler ✅
  - **Unknown entry ID**: CMA returns an empty `Array` collection; tool passes it through faithfully (CMA does not 404 on unknown entries — upstream behavior, not tool-side)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-754]: https://contentful.atlassian.net/browse/DX-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ