### PR TITLE
feat: add semantic_search MCP tool [DX-1211]

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Below is a sample configuration:
 |                           | `unpublish_content_type`   | Unpublish content types                          |
 |                           | `delete_content_type`      | Remove content types                             |
 | **Entries**               | `search_entries`           | Search and filter entries                        |
+|                           | `semantic_search`          | Find entries by meaning (vector search)          |
 |                           | `get_entry`                | Retrieve specific entries                        |
 |                           | `create_entry`             | Create new content entries                       |
 |                           | `update_entry`             | Modify existing entries                          |

--- a/packages/mcp-tools/src/tools/entries/mockClient.ts
+++ b/packages/mcp-tools/src/tools/entries/mockClient.ts
@@ -18,6 +18,7 @@ export const mockEntryUnarchive = vi.fn();
 export const mockEntryGetMany = vi.fn();
 export const mockBulkActionPublish = vi.fn();
 export const mockBulkActionUnpublish = vi.fn();
+export const mockSemanticSearchGet = vi.fn();
 
 /**
  * Standard mock Contentful client with all entry operations
@@ -37,6 +38,9 @@ export const mockClient = {
   bulkAction: {
     publish: mockBulkActionPublish,
     unpublish: mockBulkActionUnpublish,
+  },
+  semanticSearch: {
+    get: mockSemanticSearchGet,
   },
 };
 

--- a/packages/mcp-tools/src/tools/entries/register.ts
+++ b/packages/mcp-tools/src/tools/entries/register.ts
@@ -1,4 +1,8 @@
 import { searchEntriesTool, SearchEntriesToolParams } from './searchEntries.js';
+import {
+  semanticSearchTool,
+  SemanticSearchToolParams,
+} from './semanticSearch.js';
 import { createEntryTool, CreateEntryToolParams } from './createEntry.js';
 import { deleteEntryTool, DeleteEntryToolParams } from './deleteEntry.js';
 import { updateEntryTool, UpdateEntryToolParams } from './updateEntry.js';
@@ -17,6 +21,7 @@ import type { ContentfulConfig } from '../../config/types.js';
 
 export function createEntryTools(config: ContentfulConfig) {
   const searchEntries = searchEntriesTool(config);
+  const semanticSearch = semanticSearchTool(config);
   const createEntry = createEntryTool(config);
   const deleteEntry = deleteEntryTool(config);
   const updateEntry = updateEntryTool(config);
@@ -36,6 +41,17 @@ export function createEntryTools(config: ContentfulConfig) {
         openWorldHint: false,
       },
       tool: searchEntries,
+    },
+    semanticSearch: {
+      title: 'semantic_search',
+      description:
+        "Find entries by meaning using semantic (vector) search. Provide a descriptive natural-language query of what you're looking for — phrases resembling entry content work best (not questions or JSON). Optionally restrict to specific content types. Returns up to 10 matching entry references (unranked); use get_entry to fetch full content. Requires semantic search to be enabled for the environment.",
+      inputParams: SemanticSearchToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      tool: semanticSearch,
     },
     createEntry: {
       title: 'create_entry',

--- a/packages/mcp-tools/src/tools/entries/semanticSearch.test.ts
+++ b/packages/mcp-tools/src/tools/entries/semanticSearch.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { semanticSearchTool } from './semanticSearch.js';
+import {
+  semanticSearchTool,
+  SemanticSearchToolParams,
+} from './semanticSearch.js';
 import { formatResponse } from '../../utils/formatters.js';
 import { setupMockClient, mockSemanticSearchGet } from './mockClient.js';
 import { createMockConfig } from '../../test-helpers/mockConfig.js';
 
-vi.mock('../../../src/utils/tools.js');
+vi.mock('../../utils/tools.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../utils/tools.js')>();
+  return {
+    ...orig,
+    createToolClient: vi.fn(),
+  };
+});
 
 const mockArgs = {
   spaceId: 'test-space-id',
@@ -34,7 +43,7 @@ describe('semanticSearch', () => {
     mockSemanticSearchGet.mockReset();
   });
 
-  it('returns mapped entry references and correlationId', async () => {
+  it('should return mapped entry references and correlationId', async () => {
     mockSemanticSearchGet.mockResolvedValue(
       semanticResult(['entry-1', 'entry-2'], 'corr-123'),
     );
@@ -54,7 +63,7 @@ describe('semanticSearch', () => {
     });
   });
 
-  it('calls the endpoint without a filter when no contentTypeIds are given', async () => {
+  it('should call the endpoint without a filter when no contentTypeIds are given', async () => {
     mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
 
     const tool = semanticSearchTool(mockConfig);
@@ -66,7 +75,7 @@ describe('semanticSearch', () => {
     );
   });
 
-  it('builds a filter with entityType Entry when contentTypeIds are given', async () => {
+  it('should build a filter with entityType Entry when contentTypeIds are given', async () => {
     mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
 
     const tool = semanticSearchTool(mockConfig);
@@ -85,19 +94,17 @@ describe('semanticSearch', () => {
     );
   });
 
-  it('omits the filter when contentTypeIds is an empty array', async () => {
-    mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
+  it('should reject an empty contentTypeIds array at the schema layer', () => {
+    const result = SemanticSearchToolParams.safeParse({
+      ...mockArgs,
+      query: 'something',
+      contentTypeIds: [],
+    });
 
-    const tool = semanticSearchTool(mockConfig);
-    await tool({ ...mockArgs, query: 'something', contentTypeIds: [] });
-
-    expect(mockSemanticSearchGet).toHaveBeenCalledWith(
-      { spaceId: 'test-space-id', environmentId: 'test-environment' },
-      { query: 'something' },
-    );
+    expect(result.success).toBe(false);
   });
 
-  it('tolerates a missing correlationId', async () => {
+  it('should tolerate a missing correlationId', async () => {
     mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
 
     const tool = semanticSearchTool(mockConfig);
@@ -114,7 +121,7 @@ describe('semanticSearch', () => {
     });
   });
 
-  it('surfaces CMA errors via the standard error handler', async () => {
+  it('should surface CMA errors via the standard error handler', async () => {
     mockSemanticSearchGet.mockRejectedValue(
       new Error('Semantic search is not enabled for this environment'),
     );

--- a/packages/mcp-tools/src/tools/entries/semanticSearch.test.ts
+++ b/packages/mcp-tools/src/tools/entries/semanticSearch.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { semanticSearchTool } from './semanticSearch.js';
+import { formatResponse } from '../../utils/formatters.js';
+import { setupMockClient, mockSemanticSearchGet } from './mockClient.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+vi.mock('../../../src/utils/tools.js');
+
+const mockArgs = {
+  spaceId: 'test-space-id',
+  environmentId: 'test-environment',
+};
+
+function semanticResult(ids: string[], correlationId?: string) {
+  return {
+    sys: {
+      type: 'Array' as const,
+      ...(correlationId ? { correlationId } : {}),
+    },
+    items: ids.map((id) => ({
+      sys: {
+        type: 'SemanticSearchResult' as const,
+        entity: { sys: { type: 'Link', linkType: 'Entry', id } },
+      },
+    })),
+  };
+}
+
+describe('semanticSearch', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    setupMockClient();
+    mockSemanticSearchGet.mockReset();
+  });
+
+  it('returns mapped entry references and correlationId', async () => {
+    mockSemanticSearchGet.mockResolvedValue(
+      semanticResult(['entry-1', 'entry-2'], 'corr-123'),
+    );
+
+    const tool = semanticSearchTool(mockConfig);
+    const result = await tool({ ...mockArgs, query: 'a red bicycle for kids' });
+
+    const expectedResponse = formatResponse(
+      'Semantic search results retrieved successfully',
+      {
+        entries: [{ id: 'entry-1' }, { id: 'entry-2' }],
+        correlationId: 'corr-123',
+      },
+    );
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
+  it('calls the endpoint without a filter when no contentTypeIds are given', async () => {
+    mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
+
+    const tool = semanticSearchTool(mockConfig);
+    await tool({ ...mockArgs, query: 'something' });
+
+    expect(mockSemanticSearchGet).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment' },
+      { query: 'something' },
+    );
+  });
+
+  it('builds a filter with entityType Entry when contentTypeIds are given', async () => {
+    mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
+
+    const tool = semanticSearchTool(mockConfig);
+    await tool({
+      ...mockArgs,
+      query: 'something',
+      contentTypeIds: ['blogPost', 'author'],
+    });
+
+    expect(mockSemanticSearchGet).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment' },
+      {
+        query: 'something',
+        filter: { entityType: 'Entry', contentTypeIds: ['blogPost', 'author'] },
+      },
+    );
+  });
+
+  it('omits the filter when contentTypeIds is an empty array', async () => {
+    mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
+
+    const tool = semanticSearchTool(mockConfig);
+    await tool({ ...mockArgs, query: 'something', contentTypeIds: [] });
+
+    expect(mockSemanticSearchGet).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment' },
+      { query: 'something' },
+    );
+  });
+
+  it('tolerates a missing correlationId', async () => {
+    mockSemanticSearchGet.mockResolvedValue(semanticResult(['entry-1']));
+
+    const tool = semanticSearchTool(mockConfig);
+    const result = await tool({ ...mockArgs, query: 'something' });
+
+    const expectedResponse = formatResponse(
+      'Semantic search results retrieved successfully',
+      {
+        entries: [{ id: 'entry-1' }],
+      },
+    );
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
+  it('surfaces CMA errors via the standard error handler', async () => {
+    mockSemanticSearchGet.mockRejectedValue(
+      new Error('Semantic search is not enabled for this environment'),
+    );
+
+    const tool = semanticSearchTool(mockConfig);
+    const result = await tool({ ...mockArgs, query: 'something' });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error performing semantic search: Semantic search is not enabled for this environment',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/entries/semanticSearch.ts
+++ b/packages/mcp-tools/src/tools/entries/semanticSearch.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export const SemanticSearchToolParams = BaseToolSchema.extend({
+  query: z
+    .string()
+    .describe(
+      'Natural-language description of what you are looking for. Phrases that resemble the content of the entries you want match best — avoid questions or JSON.',
+    ),
+  contentTypeIds: z
+    .array(z.string())
+    .optional()
+    .describe('Restrict the search to entries of these content type IDs'),
+});
+
+type Params = z.infer<typeof SemanticSearchToolParams>;
+
+export function semanticSearchTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const filter =
+      args.contentTypeIds && args.contentTypeIds.length > 0
+        ? { entityType: 'Entry' as const, contentTypeIds: args.contentTypeIds }
+        : undefined;
+
+    const results = await contentfulClient.semanticSearch.get(
+      {
+        spaceId: args.spaceId,
+        environmentId: args.environmentId,
+      },
+      {
+        query: args.query,
+        ...(filter ? { filter } : {}),
+      },
+    );
+
+    const entries = results.items.map((item) => ({
+      id: item.sys.entity.sys.id,
+    }));
+
+    return createSuccessResponse(
+      'Semantic search results retrieved successfully',
+      {
+        entries,
+        correlationId: results.sys.correlationId,
+      },
+    );
+  }
+
+  return withErrorHandling(tool, 'Error performing semantic search');
+}

--- a/packages/mcp-tools/src/tools/entries/semanticSearch.ts
+++ b/packages/mcp-tools/src/tools/entries/semanticSearch.ts
@@ -14,6 +14,7 @@ export const SemanticSearchToolParams = BaseToolSchema.extend({
     ),
   contentTypeIds: z
     .array(z.string())
+    .min(1)
     .optional()
     .describe('Restrict the search to entries of these content type IDs'),
 });
@@ -48,7 +49,9 @@ export function semanticSearchTool(config: ContentfulConfig) {
       'Semantic search results retrieved successfully',
       {
         entries,
-        correlationId: results.sys.correlationId,
+        ...(results.sys.correlationId !== undefined
+          ? { correlationId: results.sys.correlationId }
+          : {}),
       },
     );
   }


### PR DESCRIPTION
[DX-1211](https://contentful.atlassian.net/browse/DX-1211)

## Summary
- Add a read-only `semantic_search` MCP tool that wraps the CMA semantic search endpoint (`POST /spaces/{spaceId}/environments/{environmentId}/semantic/search`) via `client.semanticSearch.get`.
- Takes a natural-language `query` plus an optional `contentTypeIds` filter; returns up to 10 matching **entry references** (`[{ id }]`) and the `correlationId`. No entry hydration, no ranking (the endpoint returns an unordered candidate pool), and no `limit`/pagination param (endpoint hard-caps at 10).
- Lives in the entries tool collection alongside `searchEntries`; auto-registers on the local MCP server via `getEntryTools()`. **Local server only** — remote-server `permissions-map.ts` enablement is intentionally out of scope (tracked separately under DX-753).

## Test plan
- [x] Unit tests cover success mapping, filter present/absent, `contentTypeIds` `.min(1)` schema contract, missing `correlationId`, and CMA error passthrough (6 tests)
- [x] `npm run typecheck` clean (lib + spec)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` succeeds
- [x] Full `mcp-tools` suite: 461/461 pass
- [ ] Manual smoke test against a space with semantic search enabled

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1211]: https://contentful.atlassian.net/browse/DX-1211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a new semantic_search MCP tool that enables vector-based semantic search against Contentful entries via the CMA API. The tool is read-only, accepts natural-language queries with optional content type filtering, and returns up to 10 matching entry references with correlation IDs. It integrates into the existing entries tool collection and registers via createEntryTools() for the local MCP server.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces new semanticSearchTool in semanticSearch.ts wrapping client.semanticSearch.get, with Zod validation requiring a query string and optional contentTypeIds array (.min(1) constraint)</li>

<li>Registers the tool in register.ts within createEntryTools() alongside existing entry tools, with read-only annotations (readOnlyHint: true, openWorldHint: false)</li>

<li>Adds comprehensive test coverage in semanticSearch.test.ts with 6 unit tests covering success mapping, filter handling, schema contract, missing correlationId, and CMA error passthrough</li>

<li>Updates mockClient.ts with mockSemanticSearchGet to support isolated unit testing of the semantic search client integration</li>

</ul>
</details>

</div>