### PR TITLE
fix(mcp-server): handle CLI info flags before env validation

### DIFF
--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleCliInfoFlags } from './cli.js';
+import { getVersion } from './getVersion.js';
+
+function createOutput() {
+  return {
+    stdout: vi.fn(),
+    stderr: vi.fn(),
+  };
+}
+
+describe('CLI metadata flags', () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it.each(['--help', '-h'])('prints help for %s', (flag) => {
+    const output = createOutput();
+
+    const handled = handleCliInfoFlags([flag], output);
+
+    expect(handled).toBe(true);
+    expect(output.stdout).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: contentful-mcp-server'),
+    );
+    expect(output.stderr).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it.each(['--version', '-v'])('prints version for %s', (flag) => {
+    const output = createOutput();
+
+    const handled = handleCliInfoFlags([flag], output);
+
+    expect(handled).toBe(true);
+    expect(output.stdout).toHaveBeenCalledWith(getVersion());
+    expect(output.stderr).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('rejects unknown top-level options', () => {
+    const output = createOutput();
+
+    const handled = handleCliInfoFlags(
+      ['--definitely-not-a-real-flag'],
+      output,
+    );
+
+    expect(handled).toBe(true);
+    expect(output.stderr).toHaveBeenCalledWith(
+      'Unknown option: --definitely-not-a-real-flag',
+    );
+    expect(output.stdout).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('leaves normal server startup unhandled', () => {
+    const output = createOutput();
+
+    const handled = handleCliInfoFlags([], output);
+
+    expect(handled).toBe(false);
+    expect(output.stdout).not.toHaveBeenCalled();
+    expect(output.stderr).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,0 +1,45 @@
+import { getVersion } from './getVersion.js';
+
+interface CliOutput {
+  stdout: (message: string) => void;
+  stderr: (message: string) => void;
+}
+
+const HELP_TEXT = `Usage: contentful-mcp-server [options]
+
+Contentful MCP Server - Model Context Protocol server for Contentful
+
+Options:
+  -h, --help       display help for command
+  -v, --version    display version number`;
+
+export function handleCliInfoFlags(
+  argv = process.argv.slice(2),
+  output: CliOutput = {
+    stdout: (message: string): void => {
+      process.stdout.write(`${message}\n`);
+    },
+    stderr: (message: string): void => {
+      process.stderr.write(`${message}\n`);
+    },
+  },
+): boolean {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    output.stdout(HELP_TEXT);
+    return true;
+  }
+
+  if (argv.includes('--version') || argv.includes('-v')) {
+    output.stdout(getVersion());
+    return true;
+  }
+
+  const unknownOption = argv.find((arg) => arg.startsWith('-'));
+  if (unknownOption) {
+    output.stderr(`Unknown option: ${unknownOption}`);
+    process.exitCode = 1;
+    return true;
+  }
+
+  return false;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { registerAllPrompts } from './prompts/register.js';
-import { registerAllResources } from './resources/register.js';
-import { registerAllTools } from './tools/register.js';
+import { handleCliInfoFlags } from './cli.js';
 import { getVersion } from './getVersion.js';
 
 if (process.env.NODE_ENV === 'development') {
@@ -19,6 +15,11 @@ if (process.env.NODE_ENV === 'development') {
 const MCP_SERVER_NAME = '@contentful/mcp-server';
 
 async function initializeServer() {
+  const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+  const { registerAllTools } = await import('./tools/register.js');
+  const { registerAllPrompts } = await import('./prompts/register.js');
+  const { registerAllResources } = await import('./resources/register.js');
+
   const server = new McpServer({
     name: MCP_SERVER_NAME,
     version: getVersion(),
@@ -34,6 +35,9 @@ async function initializeServer() {
 async function main() {
   try {
     const server = await initializeServer();
+    const { StdioServerTransport } = await import(
+      '@modelcontextprotocol/sdk/server/stdio.js'
+    );
     const transport = new StdioServerTransport();
     await server.connect(transport);
   } catch (error) {
@@ -42,4 +46,6 @@ async function main() {
   }
 }
 
-main();
+if (!handleCliInfoFlags()) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Handle top-level --help/-h and --version/-v before MCP server startup.
- Return a concise error for unknown top-level flags before Contentful env validation.
- Defer imports that register tools until after CLI metadata flags are handled.
- Add focused CLI metadata flag tests.

## Why
Users should be able to inspect usage and installed version without configuring CONTENTFUL_MANAGEMENT_ACCESS_TOKEN first.

## Validation
- npm --workspace @contentful/mcp-server run test:run
- npm --workspace @contentful/mcp-server run typecheck
- npm --workspace @contentful/mcp-server run lint (0 errors, existing warnings)
- npx prettier --check packages/mcp-server/src/index.ts packages/mcp-server/src/cli.ts packages/mcp-server/src/cli.test.ts
- git diff --check
- npm --workspace @contentful/mcp-server run build
- npm --workspace @contentful/mcp-tools run build
- Dist smoke with Contentful env vars unset: --help/-h exit 0 with usage, --version/-v exit 0 with 1.9.0, unknown flag exits 1, no-args startup still reaches env validation