### PR TITLE
fix: handle cli metadata flags before startup

### DIFF
--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getCliMetadataResult } from './cli.js';
+import { getVersion } from './getVersion.js';
+
+describe('getCliMetadataResult', () => {
+  it.each([['--help'], ['-h']])('prints help for %s', (arg) => {
+    expect(getCliMetadataResult([arg])).toEqual({
+      handled: true,
+      exitCode: 0,
+      output: expect.stringContaining('Usage: contentful-mcp-server'),
+      stream: 'stdout',
+    });
+  });
+
+  it.each([['--version'], ['-v']])('prints version for %s', (arg) => {
+    expect(getCliMetadataResult([arg])).toEqual({
+      handled: true,
+      exitCode: 0,
+      output: `${getVersion()}\n`,
+      stream: 'stdout',
+    });
+  });
+
+  it('returns an error for unknown options', () => {
+    expect(getCliMetadataResult(['--definitely-not-real'])).toEqual({
+      handled: true,
+      exitCode: 1,
+      output: expect.stringContaining('Unknown option: --definitely-not-real'),
+      stream: 'stderr',
+    });
+  });
+
+  it('leaves server startup arguments unhandled', () => {
+    expect(getCliMetadataResult([])).toEqual({ handled: false });
+    expect(getCliMetadataResult(['stdio'])).toEqual({ handled: false });
+  });
+});

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,0 +1,57 @@
+import { getVersion } from './getVersion.js';
+
+const HELP_TEXT = `Usage: contentful-mcp-server [options]
+
+Options:
+  -h, --help       Show this help message
+  -v, --version    Show the server version
+`;
+
+export type CliMetadataResult =
+  | { handled: false }
+  | { handled: true; exitCode: number; output: string; stream: 'stdout' }
+  | { handled: true; exitCode: number; output: string; stream: 'stderr' };
+
+export function getCliMetadataResult(args: string[]): CliMetadataResult {
+  if (args.length === 0) {
+    return { handled: false };
+  }
+
+  const [firstArg] = args;
+
+  if (firstArg === '--help' || firstArg === '-h') {
+    return { handled: true, exitCode: 0, output: HELP_TEXT, stream: 'stdout' };
+  }
+
+  if (firstArg === '--version' || firstArg === '-v') {
+    return {
+      handled: true,
+      exitCode: 0,
+      output: `${getVersion()}\n`,
+      stream: 'stdout',
+    };
+  }
+
+  if (firstArg?.startsWith('-')) {
+    return {
+      handled: true,
+      exitCode: 1,
+      output: `Unknown option: ${firstArg}\n\n${HELP_TEXT}`,
+      stream: 'stderr',
+    };
+  }
+
+  return { handled: false };
+}
+
+export function handleCliMetadataArgs(args = process.argv.slice(2)): boolean {
+  const result = getCliMetadataResult(args);
+
+  if (!result.handled) {
+    return false;
+  }
+
+  const writer = result.stream === 'stdout' ? process.stdout : process.stderr;
+  writer.write(result.output);
+  process.exit(result.exitCode);
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { registerAllPrompts } from './prompts/register.js';
-import { registerAllResources } from './resources/register.js';
-import { registerAllTools } from './tools/register.js';
 import { getVersion } from './getVersion.js';
+import { handleCliMetadataArgs } from './cli.js';
 
 if (process.env.NODE_ENV === 'development') {
   try {
@@ -18,7 +16,19 @@ if (process.env.NODE_ENV === 'development') {
 
 const MCP_SERVER_NAME = '@contentful/mcp-server';
 
+handleCliMetadataArgs();
+
 async function initializeServer() {
+  const [
+    { registerAllPrompts },
+    { registerAllResources },
+    { registerAllTools },
+  ] = await Promise.all([
+    import('./prompts/register.js'),
+    import('./resources/register.js'),
+    import('./tools/register.js'),
+  ]);
+
   const server = new McpServer({
     name: MCP_SERVER_NAME,
     version: getVersion(),


### PR DESCRIPTION
## Summary

- Handle `--help` / `-h` and `--version` / `-v` before starting the MCP server.
- Return a concise non-zero error for unknown top-level CLI options.
- Delay prompt/resource/tool registration imports until after metadata flags are handled, so simple CLI inspection does not require runtime startup paths.

## Verification

- `npm run test:run --workspace @contentful/mcp-server -- src/cli.test.ts`
- `npm run typecheck --workspace @contentful/mcp-server`
- `npm run build --workspace @contentful/mcp-server`
- `npx prettier --check packages/mcp-server/src/cli.ts packages/mcp-server/src/cli.test.ts packages/mcp-server/src/index.ts`
- `node packages\mcp-server\dist\index.js --help`
- `node packages\mcp-server\dist\index.js --version`
- `node packages\mcp-server\dist\index.js --definitely-not-real`
- `node packages\mcp-server\dist\index.js` still requires `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` for normal server startup.