### PR TITLE
feat: add get_entry_snapshot tool [DX-755]

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Below is a sample configuration:
 |                           | `delete_content_type`      | Remove content types                             |
 | **Entries**               | `search_entries`           | Search and filter entries                        |
 |                           | `get_entry`                | Retrieve specific entries                        |
+|                           | `get_entry_snapshot`       | Retrieve entry version history (snapshots)       |
 |                           | `create_entry`             | Create new content entries                       |
 |                           | `update_entry`             | Modify existing entries                          |
 |                           | `publish_entry`            | Publish entries (single or bulk)                 |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -109,6 +109,7 @@ Below is a sample configuration:
 |                           | `delete_content_type`              | Remove content types                             |
 | **Entries**               | `search_entries`                   | Search and filter entries in your space          |
 |                           | `get_entry`                        | Retrieve specific entries                        |
+|                           | `get_entry_snapshot`               | Retrieve entry version history (snapshots)       |
 |                           | `create_entry`                     | Create new content entries with locale support   |
 |                           | `update_entry`                     | Modify existing entries with locale support      |
 |                           | `publish_entry`                    | Publish entries (single or bulk up to 100)       |

--- a/packages/mcp-tools/src/tools/entries/getEntrySnapshot.test.ts
+++ b/packages/mcp-tools/src/tools/entries/getEntrySnapshot.test.ts
@@ -92,4 +92,27 @@ describe('getEntrySnapshot', () => {
       ],
     });
   });
+
+  it('handles errors when single snapshot retrieval fails', async () => {
+    mockSnapshotGetForEntry.mockRejectedValue(
+      new Error('Snapshot not found'),
+    );
+
+    const tool = getEntrySnapshotTool(mockConfig);
+    const result = await tool({
+      ...baseArgs,
+      entryId: 'test-entry-id',
+      snapshotId: 'test-snapshot-id',
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving entry snapshot: Snapshot not found',
+        },
+      ],
+    });
+  });
 });

--- a/packages/mcp-tools/src/tools/entries/getEntrySnapshot.test.ts
+++ b/packages/mcp-tools/src/tools/entries/getEntrySnapshot.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getEntrySnapshotTool } from './getEntrySnapshot.js';
+import { formatResponse } from '../../utils/formatters.js';
+import {
+  setupMockClient,
+  mockSnapshotGetManyForEntry,
+  mockSnapshotGetForEntry,
+  mockEntrySnapshot,
+  mockEntrySnapshotCollection,
+} from './mockClient.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+vi.mock('../../../src/utils/tools.js');
+
+describe('getEntrySnapshot', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+  };
+
+  beforeEach(() => {
+    setupMockClient();
+    mockSnapshotGetManyForEntry.mockReset();
+    mockSnapshotGetForEntry.mockReset();
+  });
+
+  it('lists snapshots when no snapshotId is provided', async () => {
+    mockSnapshotGetManyForEntry.mockResolvedValue(mockEntrySnapshotCollection);
+
+    const tool = getEntrySnapshotTool(mockConfig);
+    const result = await tool({ ...baseArgs, entryId: 'test-entry-id' });
+
+    expect(mockSnapshotGetManyForEntry).toHaveBeenCalledWith({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
+      entryId: 'test-entry-id',
+    });
+    expect(mockSnapshotGetForEntry).not.toHaveBeenCalled();
+
+    const expectedResponse = formatResponse(
+      'Entry snapshots retrieved successfully',
+      { snapshots: mockEntrySnapshotCollection },
+    );
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
+  it('returns a single snapshot when snapshotId is provided', async () => {
+    mockSnapshotGetForEntry.mockResolvedValue(mockEntrySnapshot);
+
+    const tool = getEntrySnapshotTool(mockConfig);
+    const result = await tool({
+      ...baseArgs,
+      entryId: 'test-entry-id',
+      snapshotId: 'test-snapshot-id',
+    });
+
+    expect(mockSnapshotGetForEntry).toHaveBeenCalledWith({
+      spaceId: 'test-space-id',
+      environmentId: 'test-environment',
+      entryId: 'test-entry-id',
+      snapshotId: 'test-snapshot-id',
+    });
+    expect(mockSnapshotGetManyForEntry).not.toHaveBeenCalled();
+
+    const expectedResponse = formatResponse(
+      'Entry snapshot retrieved successfully',
+      { snapshot: mockEntrySnapshot },
+    );
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
+  it('handles errors when snapshot retrieval fails', async () => {
+    mockSnapshotGetManyForEntry.mockRejectedValue(
+      new Error('Snapshot not found'),
+    );
+
+    const tool = getEntrySnapshotTool(mockConfig);
+    const result = await tool({ ...baseArgs, entryId: 'test-entry-id' });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving entry snapshot: Snapshot not found',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/entries/getEntrySnapshot.ts
+++ b/packages/mcp-tools/src/tools/entries/getEntrySnapshot.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export const GetEntrySnapshotToolParams = BaseToolSchema.extend({
+  entryId: z
+    .string()
+    .describe('The ID of the entry to retrieve snapshots for'),
+  snapshotId: z
+    .string()
+    .optional()
+    .describe(
+      'Optional snapshot ID. When provided, returns the full content of that single snapshot. When omitted, lists all available snapshots for the entry.',
+    ),
+});
+
+type Params = z.infer<typeof GetEntrySnapshotToolParams>;
+
+export function getEntrySnapshotTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    // When a specific snapshotId is given, return that snapshot's full
+    // content. Otherwise list all snapshots available for the entry.
+    if (args.snapshotId) {
+      const snapshot = await contentfulClient.snapshot.getForEntry({
+        spaceId: args.spaceId,
+        environmentId: args.environmentId,
+        entryId: args.entryId,
+        snapshotId: args.snapshotId,
+      });
+
+      return createSuccessResponse('Entry snapshot retrieved successfully', {
+        snapshot,
+      });
+    }
+
+    const snapshots = await contentfulClient.snapshot.getManyForEntry({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      entryId: args.entryId,
+    });
+
+    return createSuccessResponse('Entry snapshots retrieved successfully', {
+      snapshots,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving entry snapshot');
+}

--- a/packages/mcp-tools/src/tools/entries/mockClient.ts
+++ b/packages/mcp-tools/src/tools/entries/mockClient.ts
@@ -18,6 +18,8 @@ export const mockEntryUnarchive = vi.fn();
 export const mockEntryGetMany = vi.fn();
 export const mockBulkActionPublish = vi.fn();
 export const mockBulkActionUnpublish = vi.fn();
+export const mockSnapshotGetManyForEntry = vi.fn();
+export const mockSnapshotGetForEntry = vi.fn();
 
 /**
  * Standard mock Contentful client with all entry operations
@@ -37,6 +39,10 @@ export const mockClient = {
   bulkAction: {
     publish: mockBulkActionPublish,
     unpublish: mockBulkActionUnpublish,
+  },
+  snapshot: {
+    getManyForEntry: mockSnapshotGetManyForEntry,
+    getForEntry: mockSnapshotGetForEntry,
   },
 };
 
@@ -100,4 +106,38 @@ export const mockBulkArgs = {
   spaceId: 'test-space-id',
   environmentId: 'test-environment',
   entryId: ['entry-1', 'entry-2'],
+};
+
+/**
+ * Mock single entry snapshot object (shape of SnapshotProps<EntryProps>)
+ */
+export const mockEntrySnapshot = {
+  sys: {
+    id: 'test-snapshot-id',
+    type: 'Snapshot' as const,
+    snapshotType: 'publish',
+    snapshotEntityType: 'entry',
+    createdAt: '2023-01-01T00:00:00Z',
+  },
+  snapshot: {
+    sys: {
+      id: 'test-entry-id',
+      type: 'Entry' as const,
+      version: 3,
+    },
+    fields: {
+      title: { 'en-US': 'Previous Title' },
+    },
+  },
+};
+
+/**
+ * Mock collection of entry snapshots (shape of CollectionProp<SnapshotProps<EntryProps>>)
+ */
+export const mockEntrySnapshotCollection = {
+  sys: { type: 'Array' as const },
+  total: 1,
+  skip: 0,
+  limit: 100,
+  items: [mockEntrySnapshot],
 };

--- a/packages/mcp-tools/src/tools/entries/mockClient.ts
+++ b/packages/mcp-tools/src/tools/entries/mockClient.ts
@@ -115,9 +115,11 @@ export const mockEntrySnapshot = {
   sys: {
     id: 'test-snapshot-id',
     type: 'Snapshot' as const,
+    version: 1,
     snapshotType: 'publish',
     snapshotEntityType: 'entry',
     createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
   },
   snapshot: {
     sys: {

--- a/packages/mcp-tools/src/tools/entries/register.ts
+++ b/packages/mcp-tools/src/tools/entries/register.ts
@@ -3,6 +3,10 @@ import { createEntryTool, CreateEntryToolParams } from './createEntry.js';
 import { deleteEntryTool, DeleteEntryToolParams } from './deleteEntry.js';
 import { updateEntryTool, UpdateEntryToolParams } from './updateEntry.js';
 import { getEntryTool, GetEntryToolParams } from './getEntry.js';
+import {
+  getEntrySnapshotTool,
+  GetEntrySnapshotToolParams,
+} from './getEntrySnapshot.js';
 import { publishEntryTool, PublishEntryToolParams } from './publishEntry.js';
 import {
   unpublishEntryTool,
@@ -21,6 +25,7 @@ export function createEntryTools(config: ContentfulConfig) {
   const deleteEntry = deleteEntryTool(config);
   const updateEntry = updateEntryTool(config);
   const getEntry = getEntryTool(config);
+  const getEntrySnapshot = getEntrySnapshotTool(config);
   const publishEntry = publishEntryTool(config);
   const unpublishEntry = unpublishEntryTool(config);
   const archiveEntry = archiveEntryTool(config);
@@ -59,6 +64,17 @@ export function createEntryTools(config: ContentfulConfig) {
         openWorldHint: false,
       },
       tool: getEntry,
+    },
+    getEntrySnapshot: {
+      title: 'get_entry_snapshot',
+      description:
+        'Retrieve version history (snapshots) of an entry for safe rollback. Call with only an entryId to list all available snapshots (each has a snapshot ID and metadata). Call with both entryId and snapshotId to retrieve the full field content of that specific snapshot, which can then be used to restore a previous version.',
+      inputParams: GetEntrySnapshotToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      tool: getEntrySnapshot,
     },
     updateEntry: {
       title: 'update_entry',


### PR DESCRIPTION
[DX-755](https://contentful.atlassian.net/browse/DX-755)

## Summary
- Adds a read-only `get_entry_snapshot` MCP tool that fetches an entry's version history (snapshots) for safe rollback — addresses [contentful-mcp-server#324](https://github.com/contentful/contentful-mcp-server/issues/324).
- **Two calling modes** backed by the contentful-management plain client: call with `{ entryId }` to list all snapshots (`snapshot.getManyForEntry`), or with `{ entryId, snapshotId }` to retrieve a single snapshot's full field content (`snapshot.getForEntry`).
- Auto-registered onto the **local** stdio server via `createEntryTools()`; documented in both README tool tables.

## ⚠️ Scope note — local only this PR
The ticket AC says "available on both local and remote." This PR ships the tool **local-only**. On the remote server, `toolPermissionsGuard` splits the tool name into action (`get` → `read` ✅) + entity (`entry_snapshot` ❌ not in `entityKeyMap`), so the tool is currently rejected on remote. Completing the AC requires a **follow-up**: add `['entry_snapshot', 'entries']` to `remote-mcp-server`'s `permissions-map.ts` and bump the published `@contentful/mcp-tools` version the remote pins (`^0.8.0`). Tracking separately.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full `mcp-tools` suite passes (459/459), incl. 4 new snapshot tests (list, single, + both error paths)
- [x] ESLint clean on changed files
- [x] `tsup` build succeeds
- [ ] Smoke-test locally: `get_entry_snapshot` with only `entryId` returns the snapshot list; with `entryId` + `snapshotId` returns that snapshot's fields

Generated with [Claude Code](https://claude.com/claude-code)

[DX-755]: https://contentful.atlassian.net/browse/DX-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a new read-only `get_entry_snapshot` MCP tool that enables fetching version history (snapshots) of Contentful entries for safe rollback support. The tool supports two calling modes: call with only `entryId` to list all available snapshots, or with both `entryId` and `snapshotId` to retrieve a specific snapshot's full field content. The tool is implemented in the `@contentful/mcp-tools` package and auto-registered on the local stdio server via `createEntryTools()` with `readOnlyHint: true`. Remote server exposure is documented as a deferred follow-up item.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds new `get_entry_snapshot` tool in `getEntrySnapshot.ts` using CMA plain client's `snapshot.getManyForEntry` (list mode) and `snapshot.getForEntry` (single mode) with Zod schema validation and error handling via `withErrorHandling`</li>

<li>Registers the tool in `register.ts` via `createEntryTools()` with `readOnlyHint: true` annotation, making it available on the local stdio server only (remote server exposure deferred per AC)</li>

<li>Adds snapshot mock support in `mockClient.ts` with `mockSnapshotGetManyForEntry`, `mockSnapshotGetForEntry` functions and fixture data (`mockEntrySnapshot`, `mockEntrySnapshotCollection`) for test isolation</li>

<li>Adds 4 unit tests in `getEntrySnapshot.test.ts` covering list mode, single snapshot retrieval, and error handling for both paths</li>

<li>Updates documentation in both `README.md` and `packages/mcp-server/README.md` tool tables to include the new `get_entry_snapshot` tool</li>

</ul>
</details>

</div>