### PR TITLE
fix(mcp-server): publish source and type files

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "dist",
+    "src",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/mcp-server/tsup.config.ts
+++ b/packages/mcp-server/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   shims: true,


### PR DESCRIPTION
## Summary
- Include `src` in the published `@contentful/mcp-server` files so the custom `@contentful/mcp-server` export condition resolves
- Enable tsup declaration output so the declared `./dist/index.d.ts` types path is produced

## Why
The published `@contentful/mcp-server@1.12.2` package exports `@contentful/mcp-server` to `./src/index.ts`, but the package `files` list only ships `dist`, `package.json`, `README.md`, and `LICENSE`. The same tarball also declares `types: ./dist/index.d.ts`, but no `dist/index.d.ts` is present because tsup declaration output is disabled.

## Validation
- `git diff --check`
- Parsed `packages/mcp-server/package.json` as JSON
- Verified the source export target exists locally and is covered by the patched `files` list
- Verified `dts: true` is enabled for the declared package types path
- Confirmed the current published `@contentful/mcp-server@1.12.2` tarball lacks both `src/index.ts` and `dist/index.d.ts`

Full npm build/test was not run locally because this environment does not have `npm`, `pnpm`, or `corepack` installed.