### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "contentful-mcp-tools",
   "version": "0.0.0",
+  "bugs": {
+    "url": "https://github.com/contentful/contentful-mcp-server/issues"
+  },
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.