### PR TITLE
ci: add daily GitHub Traffic API export to S3

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,0 +1,77 @@
+name: Traffic stats
+
+# Daily snapshot of GitHub Traffic API stats (clones, views, top referrers)
+# uploaded to s3://mcp-usage-playground/contentful-mcp-server/. Feeds the
+# PRDA-976 dashboard for FY27 SP4 metrics. The Traffic API only retains
+# 14 days of history, so this must run at least once a fortnight to avoid
+# permanent data loss.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: traffic-stats
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: 'Retrieve Secrets from Vault'
+        id: vault
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN ;
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.MCP_USAGE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MCP_USAGE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Fetch Traffic API and upload to S3
+        env:
+          GH_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+          BUCKET: mcp-usage-playground
+          PREFIX: contentful-mcp-server
+        run: |
+          set -euo pipefail
+          DT=$(date -u +%F)
+          REPO=${{ github.repository }}
+
+          declare -A endpoints=(
+            [clones]="traffic/clones"
+            [views]="traffic/views"
+            [referrers]="traffic/popular/referrers"
+          )
+
+          for kind in "${!endpoints[@]}"; do
+            path="${endpoints[$kind]}"
+            file="${kind}.json"
+            echo "Fetching /repos/${REPO}/${path}"
+            gh api "/repos/${REPO}/${path}" > "${file}"
+            aws s3 cp "${file}" \
+              "s3://${BUCKET}/${PREFIX}/${kind}/dt=${DT}/data.json" \
+              --content-type application/json
+          done
+
+          echo "## Traffic stats uploaded for ${DT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          for kind in "${!endpoints[@]}"; do
+            echo "- s3://${BUCKET}/${PREFIX}/${kind}/dt=${DT}/data.json" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -13,8 +13,6 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch: {}
-  push:
-    branches: ['feat/traffic-stats']
 
 concurrency:
   group: traffic-stats

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch: {}
+  push:
+    branches: ['feat/traffic-stats']
 
 concurrency:
   group: traffic-stats


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Action that captures daily Traffic API stats (clones, views, top referrers) for this repo and uploads them to `s3://mcp-usage-playground/contentful-mcp-server/` partitioned by date. Powers the [PRDA-976](https://contentful.atlassian.net/browse/PRDA-976) dashboard tracking external developer traction on our public AI agent tooling — one of Craig Dickson's FY27 SP4 metrics ([PRDA-990](https://contentful.atlassian.net/browse/PRDA-990), [PRDA-1059](https://contentful.atlassian.net/browse/PRDA-1059)).

## Why now

The GitHub Traffic API only retains 14 days of history. Every day without collection is permanent data loss, so this needs to ship promptly.

## How it works

- **Schedule:** daily at 03:00 UTC + manual workflow_dispatch for backfill.
- **GitHub auth:** the existing contentful-automation app installation token minted by Vault from the -semantic-release path. A throwaway probe confirmed the token already has administration: read scope on this repo — no Platform asks needed.
- **AWS auth:** static IAM key in repo Actions Secrets (MCP_USAGE_AWS_ACCESS_KEY_ID / MCP_USAGE_AWS_SECRET_ACCESS_KEY), scoped to s3:PutObject on mcp-usage-playground/contentful-mcp-server/* only. The bucket and IAM user live in the cf-sandbox-playground account.
- **Output layout** (hive-style date partitioning so the data team can run a Snowflake COPY INTO or whatever ingestion they prefer later):
  - s3://mcp-usage-playground/contentful-mcp-server/clones/dt=YYYY-MM-DD/data.json
  - s3://mcp-usage-playground/contentful-mcp-server/views/dt=YYYY-MM-DD/data.json
  - s3://mcp-usage-playground/contentful-mcp-server/referrers/dt=YYYY-MM-DD/data.json

JSON is uploaded raw — no transformation. Schema control stays with downstream consumers.

## Test plan

- [ ] Merge to main.
- [ ] Manually dispatch the workflow once to capture the trailing 14-day backfill.
- [ ] Verify three objects appear under today's dt= prefix in S3.
- [ ] Confirm tomorrow's 03:00 UTC scheduled run also lands.
- [ ] Hand off path layout to Craig / Alejandra for ingestion planning.

## Out of scope

- Snowflake ingestion (data team owns).
- The sibling contentful/skills repo (Francois owns).
- Bucket lifecycle / retention (fine to defer; usage data is small).

[PRDA-976]: https://contentful.atlassian.net/browse/PRDA-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRDA-990]: https://contentful.atlassian.net/browse/PRDA-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRDA-1059]: https://contentful.atlassian.net/browse/PRDA-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a new GitHub Actions workflow that runs daily at 03:00 UTC to collect GitHub Traffic API statistics (clones, views, and top referrers) and upload them to an S3 bucket with date-based partitioning. The workflow supports manual triggering for backfill operations and uses Vault for GitHub authentication and AWS secrets for S3 uploads.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a new GitHub Actions workflow (.github/workflows/traffic-stats.yml) that fetches GitHub Traffic API data daily and uploads to s3://mcp-usage-playground/contentful-mcp-server/ with hive-style date partitioning</li>

<li>Uses Vault (hashicorp/vault-action@v3.4.0) to retrieve GitHub token from the semantic-release path for API authentication</li>

<li>Uses AWS credentials from repository secrets (MCP_USAGE_AWS_ACCESS_KEY_ID, MCP_USAGE_AWS_SECRET_ACCESS_KEY) to upload JSON data to S3 with content-type application/json</li>

<li>Supports manual workflow_dispatch trigger for backfill operations alongside the daily cron schedule</li>

</ul>
</details>

</div>