### PR TITLE
fix(ci): migrate releaseTagPattern to releaseTag.pattern for Nx 23

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -65,7 +65,9 @@
   "release": {
     "projectsRelationship": "independent",
     "projects": ["packages/mcp-server", "packages/mcp-tools"],
-    "releaseTagPattern": "{projectName}@{version}",
+    "releaseTag": {
+      "pattern": "{projectName}@{version}"
+    },
     "git": {
       "commit": true,
       "commitMessage": "chore(release): publish v{version} [skip ci]",


### PR DESCRIPTION
## Summary
- `nx.json` used `release.releaseTagPattern` which was deprecated in Nx 22 and removed in Nx 23
- Moves it to `release.releaseTag.pattern` per the Nx 23 migration
- Fixes the `npx nx release -y` step in the release CI workflow

## Test plan
- [x] `npx nx release --dry-run` passes without the deprecation warning
- [ ] Release workflow succeeds on next run

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a Nx 23 compatibility issue in the CI release workflow by migrating the deprecated `releaseTagPattern` configuration to the new nested `releaseTag.pattern` format in `nx.json`. The change is required as the old configuration was deprecated in Nx 22 and completely removed in Nx 23, causing the release step to fail.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Migrates `releaseTagPattern` from top-level to nested `releaseTag.pattern` in nx.json to comply with Nx 23 configuration schema</li>

<li>Fixes the `npx nx release -y` step in the release workflow that was failing due to the removed configuration key</li>

</ul>
</details>

</div>