### PR TITLE
feat(exo): implement Fragment CRUD MCP tools [AIS-76]

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -87,5 +87,6 @@
         "createRelease": "github"
       }
     }
-  }
+  },
+  "analytics": false
 }

--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -82,6 +82,7 @@ describe('registerAllTools', () => {
       mcpTools.getEditorInterfaceTools(),
       mcpTools.getEntryTools(),
       mcpTools.getEnvironmentTools(),
+      mcpTools.getFragmentTools(),
       mcpTools.getLocaleTools(),
       mcpTools.getOrgTools(),
       mcpTools.getSpaceTools(),

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -55,6 +55,7 @@ export function registerAllTools(server: McpServer): void {
   const editorInterfaceTools = tools.getEditorInterfaceTools();
   const entryTools = tools.getEntryTools();
   const environmentTools = tools.getEnvironmentTools();
+  const fragmentTools = tools.getFragmentTools();
   const localeTools = tools.getLocaleTools();
   const orgTools = tools.getOrgTools();
   const spaceTools = tools.getSpaceTools();
@@ -71,6 +72,7 @@ export function registerAllTools(server: McpServer): void {
     editorInterfaceTools,
     entryTools,
     environmentTools,
+    fragmentTools,
     localeTools,
     orgTools,
     spaceTools,

--- a/packages/mcp-tools/src/ContentfulMcpTools.ts
+++ b/packages/mcp-tools/src/ContentfulMcpTools.ts
@@ -13,6 +13,7 @@ import { createTagTools } from './tools/tags/register.js';
 import { createTaxonomyTools } from './tools/taxonomies/register.js';
 import { createJobTools } from './tools/jobs/space-to-space-migration/register.js';
 import { createComponentTypeTools } from './tools/exo/component-types/register.js';
+import { createFragmentTools } from './tools/exo/fragments/register.js';
 
 /**
  * Main class for Contentful MCP Tools
@@ -131,6 +132,13 @@ export class ContentfulMcpTools {
    */
   getTaxonomyTools() {
     return createTaxonomyTools(this.config);
+  }
+
+  /**
+   * Get ExO fragment tools
+   */
+  getFragmentTools() {
+    return createFragmentTools(this.config);
   }
 
   /**

--- a/packages/mcp-tools/src/tools/exo/fragments/createFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/createFragment.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockFragmentCreate, mockFragment } from './mockClient.js';
+import { createFragmentTool } from './createFragment.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('createFragment', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+    name: 'Test Fragment',
+    description: 'A test fragment',
+    componentType: {
+      sys: {
+        type: 'ResourceLink' as const,
+        linkType: 'Contentful:ComponentType' as const,
+        urn: 'crn:contentful:::content:spaces/test-space-id/component-types/test-component-type-id',
+      },
+    },
+    viewports: [],
+    designProperties: {},
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a fragment successfully', async () => {
+    mockFragmentCreate.mockResolvedValue(mockFragment);
+
+    const tool = createFragmentTool(mockConfig);
+    const result = await tool(baseArgs);
+
+    expect(mockFragmentCreate).toHaveBeenCalledWith(
+      { spaceId: baseArgs.spaceId, environmentId: baseArgs.environmentId },
+      expect.objectContaining({
+        name: baseArgs.name,
+        description: baseArgs.description,
+        componentType: baseArgs.componentType,
+        viewports: [],
+        designProperties: {},
+      }),
+    );
+    expect(result.content[0].text).toContain('Fragment created successfully');
+  });
+
+  it('rejects creates in a protected environment', async () => {
+    const tool = createFragmentTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(baseArgs);
+    expect(mockFragmentCreate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockFragmentCreate.mockRejectedValue(new Error('boom'));
+    const tool = createFragmentTool(mockConfig);
+    const result = await tool(baseArgs);
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error creating fragment: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/createFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/createFragment.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const CreateFragmentToolParams = BaseToolSchema.extend({
+  name: z.string().describe('The name of the fragment'),
+  description: z.string().describe('Description of the fragment'),
+  componentType: z
+    .object({
+      sys: z.object({
+        type: z.literal('ResourceLink'),
+        linkType: z.literal('Contentful:ComponentType'),
+        urn: z.string(),
+      }),
+    })
+    .describe('Resource link to the component type this fragment is based on'),
+  viewports: z.array(z.unknown()).describe('Viewport definitions (may be empty)'),
+  designProperties: z
+    .record(z.unknown())
+    .describe('Design property values keyed by property ID (may be empty object)'),
+  contentBindings: z
+    .record(z.unknown())
+    .optional()
+    .describe('Optional content bindings for the fragment'),
+  slots: z
+    .record(z.array(z.unknown()))
+    .optional()
+    .describe('Optional slot node definitions keyed by slot ID'),
+  metadata: z
+    .object({
+      tags: z.array(z.unknown()).optional(),
+      concepts: z.array(z.unknown()).optional(),
+    })
+    .optional()
+    .describe('Optional ExO metadata (tags, concepts)'),
+});
+
+type Params = z.infer<typeof CreateFragmentToolParams>;
+
+export function createFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const contentfulClient = createToolClient(config, args);
+
+    const fragment = await contentfulClient.fragment.create(
+      { spaceId: args.spaceId, environmentId: args.environmentId },
+      {
+        name: args.name,
+        description: args.description,
+        componentType: args.componentType,
+        viewports: args.viewports,
+        designProperties: args.designProperties,
+        ...(args.contentBindings && { contentBindings: args.contentBindings }),
+        ...(args.slots && { slots: args.slots }),
+        ...(args.metadata && { metadata: args.metadata }),
+      } as Parameters<typeof contentfulClient.fragment.create>[1],
+    );
+
+    return createSuccessResponse('Fragment created successfully', {
+      fragment,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error creating fragment');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/deleteFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/deleteFragment.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockFragmentGet,
+  mockFragmentDelete,
+  mockFragment,
+  mockArgs,
+} from './mockClient.js';
+import { deleteFragmentTool } from './deleteFragment.js';
+import { buildConfirmToken } from '../../../utils/confirmation.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('deleteFragment', () => {
+  const mockConfig = createMockConfig();
+  const validToken = buildConfirmToken(
+    'fragment',
+    mockArgs.fragmentId,
+    mockFragment.sys.version,
+  );
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a confirmation preview when confirm is missing', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+
+    const tool = deleteFragmentTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockFragmentDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+    expect(result.content[0].text).toContain(validToken);
+  });
+
+  it('returns a preview when the confirmToken is wrong', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+
+    const tool = deleteFragmentTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      confirm: true,
+      confirmToken: 'wrong',
+    });
+
+    expect(mockFragmentDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+  });
+
+  it('deletes when confirm is true and the token matches', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+    mockFragmentDelete.mockResolvedValue(undefined);
+
+    const tool = deleteFragmentTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      confirm: true,
+      confirmToken: validToken,
+    });
+
+    expect(mockFragmentDelete).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+    });
+    expect(result.content[0].text).toContain('Fragment deleted successfully');
+  });
+
+  it('rejects deletes in a protected environment', async () => {
+    const tool = deleteFragmentTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(mockArgs);
+    expect(mockFragmentGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/deleteFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/deleteFragment.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import {
+  buildConfirmToken,
+  buildConfirmationPreview,
+  CONFIRMATION_MESSAGE_PREFIX,
+} from '../../../utils/confirmation.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const DeleteFragmentToolParams = BaseToolSchema.extend({
+  fragmentId: z.string().describe('The ID of the fragment to delete'),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true on the second call to actually perform the deletion. Required together with confirmToken.',
+    ),
+  confirmToken: z
+    .string()
+    .optional()
+    .describe(
+      'Token returned by the preview call; must be supplied with confirm: true.',
+    ),
+});
+
+type Params = z.infer<typeof DeleteFragmentToolParams>;
+
+export function deleteFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      fragmentId: args.fragmentId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+    const fragment = await contentfulClient.fragment.get(params);
+
+    const expectedToken = buildConfirmToken(
+      'fragment',
+      args.fragmentId,
+      fragment.sys.version,
+    );
+    if (args.confirm !== true || args.confirmToken !== expectedToken) {
+      return createSuccessResponse(
+        `${CONFIRMATION_MESSAGE_PREFIX} fragment`,
+        buildConfirmationPreview(
+          'fragment',
+          args.fragmentId,
+          { fragment },
+          expectedToken,
+        ),
+      );
+    }
+
+    await contentfulClient.fragment.delete(params);
+
+    return createSuccessResponse('Fragment deleted successfully', {
+      fragmentId: args.fragmentId,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error deleting fragment');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/getFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/getFragment.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mockFragmentGet, mockFragment, mockArgs } from './mockClient.js';
+import { getFragmentTool } from './getFragment.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('getFragment', () => {
+  const mockConfig = createMockConfig();
+
+  it('retrieves a fragment successfully', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+
+    const tool = getFragmentTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    const expectedResponse = formatResponse('Fragment retrieved successfully', {
+      fragment: mockFragment,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockFragmentGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+    });
+  });
+
+  it('handles errors when the fragment is not found', async () => {
+    mockFragmentGet.mockRejectedValue(new Error('Fragment not found'));
+
+    const tool = getFragmentTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving fragment: Fragment not found',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/getFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/getFragment.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const GetFragmentToolParams = BaseToolSchema.extend({
+  fragmentId: z.string().describe('The ID of the fragment to retrieve details for'),
+});
+
+type Params = z.infer<typeof GetFragmentToolParams>;
+
+export function getFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const fragment = await contentfulClient.fragment.get({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      fragmentId: args.fragmentId,
+    });
+
+    return createSuccessResponse('Fragment retrieved successfully', {
+      fragment,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving fragment');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/listFragments.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/listFragments.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mockFragmentGetMany, mockFragmentsResponse } from './mockClient.js';
+import { listFragmentsTool } from './listFragments.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('listFragments', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+  };
+
+  it('lists fragments and clamps limit to 10', async () => {
+    mockFragmentGetMany.mockResolvedValue(mockFragmentsResponse);
+
+    const tool = listFragmentsTool(mockConfig);
+    const result = await tool({ ...baseArgs, limit: 50 });
+
+    expect(mockFragmentGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10 },
+    });
+    expect(result.content[0].text).toContain('Fragments retrieved successfully');
+  });
+
+  it('forwards cursor and order params', async () => {
+    mockFragmentGetMany.mockResolvedValue(mockFragmentsResponse);
+
+    const tool = listFragmentsTool(mockConfig);
+    await tool({ ...baseArgs, pageNext: 'cursor-1', order: 'sys.createdAt' });
+
+    expect(mockFragmentGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, pageNext: 'cursor-1', order: 'sys.createdAt' },
+    });
+  });
+
+  it('forwards pagePrev cursor param', async () => {
+    mockFragmentGetMany.mockResolvedValue(mockFragmentsResponse);
+
+    const tool = listFragmentsTool(mockConfig);
+    await tool({ ...baseArgs, pagePrev: 'cursor-back' });
+
+    expect(mockFragmentGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, pagePrev: 'cursor-back' },
+    });
+  });
+
+  it('handles errors', async () => {
+    mockFragmentGetMany.mockRejectedValue(new Error('boom'));
+
+    const tool = listFragmentsTool(mockConfig);
+    const result = await tool(baseArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error listing fragments: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/listFragments.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/listFragments.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { summarizeData } from '../../../utils/summarizer.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const ListFragmentsToolParams = BaseToolSchema.extend({
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of fragments to return (max 10)'),
+  pageNext: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the next page of results'),
+  pagePrev: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the previous page of results'),
+  order: z
+    .string()
+    .optional()
+    .describe('Order fragments by this field (e.g. sys.createdAt)'),
+});
+
+type Params = z.infer<typeof ListFragmentsToolParams>;
+
+export function listFragmentsTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const fragments = await contentfulClient.fragment.getMany({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      query: {
+        limit: Math.min(args.limit || 10, 10),
+        ...(args.pageNext && { pageNext: args.pageNext }),
+        ...(args.pagePrev && { pagePrev: args.pagePrev }),
+        ...(args.order && { order: args.order }),
+      } as unknown as Parameters<typeof contentfulClient.fragment.getMany>[0]['query'],
+    });
+
+    const summarized = summarizeData(fragments, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more fragments, ask me to retrieve the next page using the pageNext cursor.',
+    });
+
+    return createSuccessResponse('Fragments retrieved successfully', {
+      fragments: summarized,
+      total: fragments.total,
+      limit: fragments.limit,
+      pages: fragments.pages,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error listing fragments');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/mockClient.ts
@@ -1,0 +1,121 @@
+import { vi } from 'vitest';
+
+const {
+  mockFragmentGet,
+  mockFragmentGetMany,
+  mockFragmentCreate,
+  mockFragmentUpsert,
+  mockFragmentDelete,
+  mockFragmentPublish,
+  mockFragmentUnpublish,
+  mockCreateToolClient,
+} = vi.hoisted(() => {
+  return {
+    mockFragmentGet: vi.fn(),
+    mockFragmentGetMany: vi.fn(),
+    mockFragmentCreate: vi.fn(),
+    mockFragmentUpsert: vi.fn(),
+    mockFragmentDelete: vi.fn(),
+    mockFragmentPublish: vi.fn(),
+    mockFragmentUnpublish: vi.fn(),
+    mockCreateToolClient: vi.fn(() => {
+      return {
+        fragment: {
+          get: mockFragmentGet,
+          getMany: mockFragmentGetMany,
+          create: mockFragmentCreate,
+          upsert: mockFragmentUpsert,
+          delete: mockFragmentDelete,
+          publish: mockFragmentPublish,
+          unpublish: mockFragmentUnpublish,
+        },
+      };
+    }),
+  };
+});
+
+vi.mock('../../../utils/tools.js', async (importOriginal) => {
+  const org = await importOriginal<typeof import('../../../utils/tools.js')>();
+  return {
+    ...org,
+    createToolClient: mockCreateToolClient,
+  };
+});
+
+export {
+  mockFragmentGet,
+  mockFragmentGetMany,
+  mockFragmentCreate,
+  mockFragmentUpsert,
+  mockFragmentDelete,
+  mockFragmentPublish,
+  mockFragmentUnpublish,
+  mockCreateToolClient,
+};
+
+/**
+ * Standard mock Fragment object used across tests.
+ */
+export const mockFragment = {
+  sys: {
+    id: 'test-fragment-id',
+    type: 'Fragment' as const,
+    version: 1,
+    space: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Space' as const,
+        id: 'test-space-id',
+      },
+    },
+    environment: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Environment' as const,
+        id: 'test-environment',
+      },
+    },
+    componentType: {
+      sys: {
+        type: 'ResourceLink' as const,
+        linkType: 'Contentful:ComponentType' as const,
+        urn: 'crn:contentful:::content:spaces/test-space-id/component-types/test-component-type-id',
+      },
+    },
+    createdAt: '2023-01-01T00:00:00Z',
+    createdBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } },
+    updatedAt: '2023-01-01T00:00:00Z',
+    updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } },
+  },
+  name: 'Test Fragment',
+  description: 'A test fragment for unit tests',
+  viewports: [],
+  designProperties: {},
+};
+
+/**
+ * Standard test arguments for fragment operations.
+ */
+export const mockArgs = {
+  spaceId: 'test-space-id',
+  environmentId: 'test-environment',
+  fragmentId: 'test-fragment-id',
+};
+
+/**
+ * Mock cursor-paginated list response.
+ */
+export const mockFragmentsResponse = {
+  sys: { type: 'Array' as const },
+  total: 2,
+  limit: 10,
+  items: [
+    mockFragment,
+    {
+      ...mockFragment,
+      sys: { ...mockFragment.sys, id: 'another-fragment' },
+      name: 'Another Fragment',
+    },
+  ],
+  pages: { next: 'next-cursor-token' },
+};

--- a/packages/mcp-tools/src/tools/exo/fragments/publishFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/publishFragment.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockFragmentGet,
+  mockFragmentPublish,
+  mockFragment,
+  mockArgs,
+} from './mockClient.js';
+import { publishFragmentTool } from './publishFragment.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('publishFragment', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then publishes with it', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+    mockFragmentPublish.mockResolvedValue(mockFragment);
+
+    const tool = publishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockFragmentGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+    });
+    expect(mockFragmentPublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+      version: mockFragment.sys.version,
+    });
+    expect(result.content[0].text).toContain('Fragment published successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment); // sys.version === 1
+
+    const tool = publishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockFragmentPublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = publishFragmentTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockFragmentGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockFragmentGet.mockRejectedValue(new Error('boom'));
+    const tool = publishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error publishing fragment: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/publishFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/publishFragment.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const PublishFragmentToolParams = BaseToolSchema.extend({
+  fragmentId: z.string().describe('The ID of the fragment to publish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The fragment's sys.version as returned by get_fragment. " +
+        'You must call get_fragment first to read the current state and version. ' +
+        'The publish is rejected if this does not match the current version, which means ' +
+        'the fragment changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof PublishFragmentToolParams>;
+
+export function publishFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      fragmentId: args.fragmentId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the publish endpoint requires the current version.
+    const current = await contentfulClient.fragment.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the fragment has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the fragment with get_fragment and retry with the latest sys.version.`,
+      );
+    }
+
+    const fragment = await contentfulClient.fragment.publish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Fragment published successfully', {
+      fragment,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error publishing fragment');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/register.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/register.ts
@@ -1,0 +1,130 @@
+import {
+  getFragmentTool,
+  GetFragmentToolParams,
+} from './getFragment.js';
+import {
+  listFragmentsTool,
+  ListFragmentsToolParams,
+} from './listFragments.js';
+import {
+  createFragmentTool,
+  CreateFragmentToolParams,
+} from './createFragment.js';
+import {
+  updateFragmentTool,
+  UpdateFragmentToolParams,
+} from './updateFragment.js';
+import {
+  deleteFragmentTool,
+  DeleteFragmentToolParams,
+} from './deleteFragment.js';
+import {
+  publishFragmentTool,
+  PublishFragmentToolParams,
+} from './publishFragment.js';
+import {
+  unpublishFragmentTool,
+  UnpublishFragmentToolParams,
+} from './unpublishFragment.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export function createFragmentTools(config: ContentfulConfig) {
+  const getFragment = getFragmentTool(config);
+  const listFragments = listFragmentsTool(config);
+  const createFragment = createFragmentTool(config);
+  const updateFragment = updateFragmentTool(config);
+  const deleteFragment = deleteFragmentTool(config);
+  const publishFragment = publishFragmentTool(config);
+  const unpublishFragment = unpublishFragmentTool(config);
+
+  return {
+    getFragment: {
+      title: 'get_fragment',
+      description:
+        'Get details about a specific ExO fragment (a reusable content unit that can be referenced across multiple Experiences and ComponentTypes).',
+      inputParams: GetFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getFragment,
+    },
+    listFragments: {
+      title: 'list_fragments',
+      description:
+        'List ExO fragments in a space and environment. Returns a maximum of 10 items per request; use the pageNext cursor (returned in pages.next) to paginate.',
+      inputParams: ListFragmentsToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: listFragments,
+    },
+    createFragment: {
+      title: 'create_fragment',
+      description: 'Create a new ExO fragment.',
+      inputParams: CreateFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: createFragment,
+    },
+    updateFragment: {
+      title: 'update_fragment',
+      description:
+        'Update an existing ExO fragment. You MUST call get_fragment first to read the current state, then pass the sys.version you received as the version parameter. The handler merges your updates with the existing fragment fields, so you only need to provide the fields you want to change. If the version is stale (the fragment changed since you read it), the update is rejected and you must re-fetch with get_fragment.',
+      inputParams: UpdateFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: updateFragment,
+    },
+    deleteFragment: {
+      title: 'delete_fragment',
+      description:
+        'Delete an ExO fragment. Two-phase: the first call (without confirm/confirmToken) returns a preview and a confirmToken. To complete the deletion, call again with the same fragmentId, confirm: true, and the confirmToken from the preview.',
+      inputParams: DeleteFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: deleteFragment,
+    },
+    publishFragment: {
+      title: 'publish_fragment',
+      description:
+        'Publish an ExO fragment. You MUST call get_fragment first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_fragment.',
+      inputParams: PublishFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: publishFragment,
+    },
+    unpublishFragment: {
+      title: 'unpublish_fragment',
+      description:
+        'Unpublish an ExO fragment. You MUST call get_fragment first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_fragment.',
+      inputParams: UnpublishFragmentToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: unpublishFragment,
+    },
+  };
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/unpublishFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/unpublishFragment.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockFragmentGet,
+  mockFragmentUnpublish,
+  mockFragment,
+  mockArgs,
+} from './mockClient.js';
+import { unpublishFragmentTool } from './unpublishFragment.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('unpublishFragment', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then unpublishes with it', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+    mockFragmentUnpublish.mockResolvedValue(mockFragment);
+
+    const tool = unpublishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockFragmentGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+    });
+    expect(mockFragmentUnpublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+      version: mockFragment.sys.version,
+    });
+    expect(result.content[0].text).toContain('Fragment unpublished successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment); // sys.version === 1
+
+    const tool = unpublishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockFragmentUnpublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = unpublishFragmentTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockFragmentGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockFragmentGet.mockRejectedValue(new Error('boom'));
+    const tool = unpublishFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error unpublishing fragment: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/unpublishFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/unpublishFragment.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UnpublishFragmentToolParams = BaseToolSchema.extend({
+  fragmentId: z.string().describe('The ID of the fragment to unpublish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The fragment's sys.version as returned by get_fragment. " +
+        'You must call get_fragment first to read the current state and version. ' +
+        'The unpublish is rejected if this does not match the current version, which means ' +
+        'the fragment changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof UnpublishFragmentToolParams>;
+
+export function unpublishFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      fragmentId: args.fragmentId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the unpublish endpoint requires the current version.
+    const current = await contentfulClient.fragment.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the fragment has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the fragment with get_fragment and retry with the latest sys.version.`,
+      );
+    }
+
+    const fragment = await contentfulClient.fragment.unpublish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Fragment unpublished successfully', {
+      fragment,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error unpublishing fragment');
+}

--- a/packages/mcp-tools/src/tools/exo/fragments/updateFragment.test.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/updateFragment.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockFragmentGet,
+  mockFragmentUpsert,
+  mockFragment,
+  mockArgs,
+} from './mockClient.js';
+import { updateFragmentTool } from './updateFragment.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('updateFragment', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads before writing and merges fields', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment);
+    mockFragmentUpsert.mockResolvedValue({
+      ...mockFragment,
+      name: 'Updated Fragment',
+      sys: { ...mockFragment.sys, version: 2 },
+    });
+
+    const tool = updateFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1, name: 'Updated Fragment' });
+
+    expect(mockFragmentGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      fragmentId: mockArgs.fragmentId,
+    });
+    expect(mockFragmentUpsert).toHaveBeenCalledWith(
+      {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+        fragmentId: mockArgs.fragmentId,
+      },
+      expect.objectContaining({
+        name: 'Updated Fragment',
+        description: mockFragment.description,
+      }),
+    );
+    expect(result.content[0].text).toContain('Fragment updated successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockFragmentGet.mockResolvedValue(mockFragment); // sys.version === 1
+
+    const tool = updateFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockFragmentUpsert).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = updateFragmentTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockFragmentGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockFragmentGet.mockRejectedValue(new Error('boom'));
+    const tool = updateFragmentTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error updating fragment: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/fragments/updateFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/updateFragment.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UpdateFragmentToolParams = BaseToolSchema.extend({
+  fragmentId: z.string().describe('The ID of the fragment to update'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The fragment's sys.version as returned by get_fragment. " +
+        'You must call get_fragment first to read the current state and version. ' +
+        'The update is rejected if this does not match the current version, which means ' +
+        'the fragment changed since you read it.',
+    ),
+  name: z.string().optional().describe('The name of the fragment'),
+  description: z.string().optional().describe('Description of the fragment'),
+  viewports: z
+    .array(z.unknown())
+    .optional()
+    .describe('Viewport definitions; replaces existing viewports if provided'),
+  designProperties: z
+    .record(z.unknown())
+    .optional()
+    .describe('Design property values; replaces existing if provided'),
+  contentBindings: z
+    .record(z.unknown())
+    .optional()
+    .describe('Content bindings; replaces existing if provided'),
+  slots: z
+    .record(z.array(z.unknown()))
+    .optional()
+    .describe('Slot node definitions; replaces existing if provided'),
+  metadata: z
+    .object({
+      tags: z.array(z.unknown()).optional(),
+      concepts: z.array(z.unknown()).optional(),
+    })
+    .optional()
+    .describe('ExO metadata (tags, concepts); replaces existing if provided'),
+});
+
+type Params = z.infer<typeof UpdateFragmentToolParams>;
+
+export function updateFragmentTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      fragmentId: args.fragmentId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: fetch current state to preserve fields the caller did not supply.
+    const current = await contentfulClient.fragment.get(params);
+
+    // Enforce read-before-write: the caller must supply the version it read.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the fragment has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the fragment with get_fragment and retry the update with the latest sys.version.`,
+      );
+    }
+
+    const fragment = await contentfulClient.fragment.upsert(params, {
+      sys: {
+        id: current.sys.id,
+        type: 'Fragment',
+        version: current.sys.version,
+      },
+      name: args.name ?? current.name,
+      description: args.description ?? current.description,
+      viewports: args.viewports ?? current.viewports,
+      designProperties: args.designProperties ?? current.designProperties,
+      ...((args.contentBindings ?? current.contentBindings)
+        ? { contentBindings: args.contentBindings ?? current.contentBindings }
+        : {}),
+      ...((args.slots ?? current.slots)
+        ? { slots: args.slots ?? current.slots }
+        : {}),
+      ...((args.metadata ?? current.metadata)
+        ? { metadata: args.metadata ?? current.metadata }
+        : {}),
+    } as Parameters<typeof contentfulClient.fragment.upsert>[1]);
+
+    return createSuccessResponse('Fragment updated successfully', {
+      fragment,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error updating fragment');
+}

--- a/packages/mcp-tools/src/utils/confirmation.ts
+++ b/packages/mcp-tools/src/utils/confirmation.ts
@@ -9,7 +9,8 @@ export type DestructiveResource =
   | 'locale'
   | 'concept'
   | 'conceptScheme'
-  | 'componentType';
+  | 'componentType'
+  | 'fragment';
 
 export const CONFIRMATION_MESSAGE_PREFIX = 'Confirmation required to delete';
 
@@ -47,6 +48,7 @@ const RESOURCE_DISPLAY_NAME: Record<DestructiveResource, string> = {
   concept: 'concept',
   conceptScheme: 'concept scheme',
   componentType: 'component type',
+  fragment: 'fragment',
 };
 
 /**


### PR DESCRIPTION
[AIS-76](https://contentful.atlassian.net/browse/AIS-76)

## Summary
- Adds 7 ExO Fragment MCP tools: `get_fragment`, `list_fragments`, `create_fragment`, `update_fragment`, `publish_fragment`, `unpublish_fragment`, `delete_fragment`
- Follows the ComponentType tool pattern from AIS-73: read-before-write version guard on update/publish/unpublish, two-phase confirm/token flow on delete, cursor pagination on list
- Wires `fragment` into `DestructiveResource` union and `ContentfulMcpTools` alongside the new `componentType` from AIS-73

## Test plan
- [ ] Unit tests pass: `nx test mcp-tools`
- [ ] `create_fragment` with correct `experience`-namespace ResourceLink URN (`crn:contentful:::experience:spaces/$self/environments/$self/componentTypes/<id>`) creates successfully
- [ ] `update_fragment` with stale `version` returns version-conflict error naming both versions
- [ ] `publish_fragment` with stale `version` returns version-conflict error
- [ ] `delete_fragment` phase 1 returns preview + confirmToken; phase 2 with matching token deletes; stale token (after version change) is rejected
- [ ] All 7 tools registered in `mcp-server/src/tools/register.ts` and visible in tool listing

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-76]: https://contentful.atlassian.net/browse/AIS-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ