### PR TITLE
feat: add Template CRUD MCP tools [AIS-77]

### DIFF
--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -77,6 +77,7 @@ describe('registerAllTools', () => {
       mcpTools.getAiActionTools(),
       mcpTools.getAssetTools(),
       mcpTools.getComponentTypeTools(),
+      mcpTools.getTemplateTools(),
       mcpTools.getContentTypeTools(),
       mcpTools.getContextTools(),
       mcpTools.getEditorInterfaceTools(),

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -50,6 +50,7 @@ export function registerAllTools(server: McpServer): void {
   const aiActionTools = tools.getAiActionTools();
   const assetTools = tools.getAssetTools();
   const componentTypeTools = tools.getComponentTypeTools();
+  const templateTools = tools.getTemplateTools();
   const contentTypeTools = tools.getContentTypeTools();
   const contextTools = tools.getContextTools();
   const editorInterfaceTools = tools.getEditorInterfaceTools();
@@ -66,6 +67,7 @@ export function registerAllTools(server: McpServer): void {
     aiActionTools,
     assetTools,
     componentTypeTools,
+    templateTools,
     contentTypeTools,
     contextTools,
     editorInterfaceTools,

--- a/packages/mcp-tools/src/ContentfulMcpTools.ts
+++ b/packages/mcp-tools/src/ContentfulMcpTools.ts
@@ -13,6 +13,7 @@ import { createTagTools } from './tools/tags/register.js';
 import { createTaxonomyTools } from './tools/taxonomies/register.js';
 import { createJobTools } from './tools/jobs/space-to-space-migration/register.js';
 import { createComponentTypeTools } from './tools/exo/component-types/register.js';
+import { createTemplateTools } from './tools/exo/templates/register.js';
 
 /**
  * Main class for Contentful MCP Tools
@@ -68,6 +69,13 @@ export class ContentfulMcpTools {
    */
   getComponentTypeTools() {
     return createComponentTypeTools(this.config);
+  }
+
+  /**
+   * Get ExO template tools
+   */
+  getTemplateTools() {
+    return createTemplateTools(this.config);
   }
 
   /**

--- a/packages/mcp-tools/src/tools/exo/templates/createTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/createTemplate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockTemplateCreate, mockTemplate, mockArgs } from './mockClient.js';
+import { createTemplateTool } from './createTemplate.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+const createArgs = {
+  ...mockArgs,
+  name: 'Test Template',
+  description: 'A test template',
+  viewports: [],
+  contentProperties: [],
+  designProperties: [],
+};
+
+describe('createTemplate', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a template', async () => {
+    mockTemplateCreate.mockResolvedValue(mockTemplate);
+
+    const tool = createTemplateTool(mockConfig);
+    const result = await tool(createArgs);
+
+    expect(mockTemplateCreate).toHaveBeenCalledWith(
+      { spaceId: mockArgs.spaceId, environmentId: mockArgs.environmentId },
+      expect.objectContaining({ name: createArgs.name }),
+    );
+    expect(result.content[0].text).toContain('Template created successfully');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = createTemplateTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(createArgs);
+    expect(mockTemplateCreate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/createTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/createTemplate.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import {
+  ViewportSchema,
+  ContentPropertySchema,
+  DesignPropertySchema,
+  SlotDefinitionSchema,
+  TreeNodeSchema,
+  ComponentTypeMetadataSchema,
+} from '../../../types/componentTypeSchemas.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const CreateTemplateToolParams = BaseToolSchema.extend({
+  name: z.string().describe('The name of the template'),
+  description: z.string().describe('Description of the template'),
+  viewports: z
+    .array(ViewportSchema)
+    .describe('Viewport definitions for the template (may be empty)'),
+  contentProperties: z
+    .array(ContentPropertySchema)
+    .describe('Content property definitions (may be empty)'),
+  designProperties: z
+    .array(DesignPropertySchema)
+    .describe('Design property definitions (may be empty)'),
+  componentTree: z
+    .array(TreeNodeSchema)
+    .optional()
+    .describe('Optional component tree node definitions'),
+  slots: z
+    .array(SlotDefinitionSchema)
+    .optional()
+    .describe('Optional slot definitions'),
+  metadata: ComponentTypeMetadataSchema.optional().describe(
+    'Optional ExO metadata (tags, concepts)',
+  ),
+});
+
+type Params = z.infer<typeof CreateTemplateToolParams>;
+
+export function createTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const contentfulClient = createToolClient(config, args);
+
+    const template = await contentfulClient.template.create(
+      { spaceId: args.spaceId, environmentId: args.environmentId },
+      {
+        name: args.name,
+        description: args.description,
+        viewports: args.viewports,
+        contentProperties: args.contentProperties,
+        designProperties: args.designProperties,
+        ...(args.componentTree && { componentTree: args.componentTree }),
+        ...(args.slots && { slots: args.slots }),
+        ...(args.metadata && { metadata: args.metadata }),
+      } as Parameters<typeof contentfulClient.template.create>[1],
+    );
+
+    return createSuccessResponse('Template created successfully', {
+      template,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error creating template');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/deleteTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/deleteTemplate.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockTemplateGet,
+  mockTemplateDelete,
+  mockTemplate,
+  mockArgs,
+} from './mockClient.js';
+import { deleteTemplateTool } from './deleteTemplate.js';
+import { buildConfirmToken } from '../../../utils/confirmation.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('deleteTemplate', () => {
+  const mockConfig = createMockConfig();
+  const validToken = buildConfirmToken(
+    'template',
+    mockArgs.templateId,
+    mockTemplate.sys.version,
+  );
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a confirmation preview when confirm is missing', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+
+    const tool = deleteTemplateTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockTemplateDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+    expect(result.content[0].text).toContain(validToken);
+  });
+
+  it('returns a preview when the confirmToken is wrong', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+
+    const tool = deleteTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, confirm: true, confirmToken: 'wrong' });
+
+    expect(mockTemplateDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+  });
+
+  it('deletes when confirm is true and the token matches', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+    mockTemplateDelete.mockResolvedValue(undefined);
+
+    const tool = deleteTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, confirm: true, confirmToken: validToken });
+
+    expect(mockTemplateDelete).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    expect(result.content[0].text).toContain('Template deleted successfully');
+  });
+
+  it('rejects deletes in a protected environment', async () => {
+    const tool = deleteTemplateTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(mockArgs);
+    expect(mockTemplateGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/deleteTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/deleteTemplate.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import {
+  buildConfirmToken,
+  buildConfirmationPreview,
+  CONFIRMATION_MESSAGE_PREFIX,
+} from '../../../utils/confirmation.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const DeleteTemplateToolParams = BaseToolSchema.extend({
+  templateId: z.string().describe('The ID of the template to delete'),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true on the second call to actually perform the deletion. Required together with confirmToken.',
+    ),
+  confirmToken: z
+    .string()
+    .optional()
+    .describe(
+      'Token returned by the preview call; must be supplied with confirm: true.',
+    ),
+});
+
+type Params = z.infer<typeof DeleteTemplateToolParams>;
+
+export function deleteTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      templateId: args.templateId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+    const template = await contentfulClient.template.get(params);
+
+    const expectedToken = buildConfirmToken(
+      'template',
+      args.templateId,
+      template.sys.version,
+    );
+    if (args.confirm !== true || args.confirmToken !== expectedToken) {
+      return createSuccessResponse(
+        `${CONFIRMATION_MESSAGE_PREFIX} template`,
+        buildConfirmationPreview(
+          'template',
+          args.templateId,
+          { template },
+          expectedToken,
+        ),
+      );
+    }
+
+    await contentfulClient.template.delete(params);
+
+    return createSuccessResponse('Template deleted successfully', {
+      templateId: args.templateId,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error deleting template');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/getTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/getTemplate.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockTemplateGet, mockTemplate, mockArgs } from './mockClient.js';
+import { getTemplateTool } from './getTemplate.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('getTemplate', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('retrieves a template by ID', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+
+    const tool = getTemplateTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockTemplateGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    expect(result.content[0].text).toContain('Template retrieved successfully');
+  });
+
+  it('handles errors', async () => {
+    mockTemplateGet.mockRejectedValue(new Error('not found'));
+
+    const tool = getTemplateTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error retrieving template: not found' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/getTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/getTemplate.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const GetTemplateToolParams = BaseToolSchema.extend({
+  templateId: z.string().describe('The ID of the template to retrieve details for'),
+});
+
+type Params = z.infer<typeof GetTemplateToolParams>;
+
+export function getTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const template = await contentfulClient.template.get({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      templateId: args.templateId,
+    });
+
+    return createSuccessResponse('Template retrieved successfully', {
+      template,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving template');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/listTemplates.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/listTemplates.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockTemplateGetMany,
+  mockTemplatesResponse,
+  mockArgs,
+} from './mockClient.js';
+import { listTemplatesTool } from './listTemplates.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('listTemplates', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists templates with default limit', async () => {
+    mockTemplateGetMany.mockResolvedValue(mockTemplatesResponse);
+
+    const tool = listTemplatesTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockTemplateGetMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+      }),
+    );
+    expect(result.content[0].text).toContain('Templates retrieved successfully');
+  });
+
+  it('passes pageNext cursor when provided', async () => {
+    mockTemplateGetMany.mockResolvedValue(mockTemplatesResponse);
+
+    const tool = listTemplatesTool(mockConfig);
+    await tool({ ...mockArgs, pageNext: 'some-cursor' });
+
+    expect(mockTemplateGetMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ pageNext: 'some-cursor' }),
+      }),
+    );
+  });
+
+  it('handles errors', async () => {
+    mockTemplateGetMany.mockRejectedValue(new Error('boom'));
+
+    const tool = listTemplatesTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error listing templates: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/listTemplates.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/listTemplates.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { summarizeData } from '../../../utils/summarizer.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const ListTemplatesToolParams = BaseToolSchema.extend({
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of templates to return (max 10)'),
+  pageNext: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the next page of results'),
+  pagePrev: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the previous page of results'),
+  order: z
+    .string()
+    .optional()
+    .describe('Order templates by this field (e.g. sys.createdAt)'),
+});
+
+type Params = z.infer<typeof ListTemplatesToolParams>;
+
+export function listTemplatesTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const templates = await contentfulClient.template.getMany({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      query: {
+        limit: Math.min(args.limit || 10, 10),
+        ...(args.pageNext && { pageNext: args.pageNext }),
+        ...(args.pagePrev && { pagePrev: args.pagePrev }),
+        ...(args.order && { order: args.order }),
+      } as unknown as Parameters<
+        typeof contentfulClient.template.getMany
+      >[0]['query'],
+    });
+
+    const summarized = summarizeData(templates, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more templates, ask me to retrieve the next page using the pageNext cursor.',
+    });
+
+    return createSuccessResponse('Templates retrieved successfully', {
+      templates: summarized,
+      total: templates.total,
+      limit: templates.limit,
+      pages: templates.pages,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error listing templates');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/mockClient.ts
@@ -1,0 +1,120 @@
+import { vi } from 'vitest';
+
+/**
+ * Shared mock objects for Template tests.
+ * Mirrors the component-types mockClient pattern, adapted to the ExO
+ * template plain client API.
+ */
+const {
+  mockTemplateGet,
+  mockTemplateGetMany,
+  mockTemplateCreate,
+  mockTemplateUpsert,
+  mockTemplateDelete,
+  mockTemplatePublish,
+  mockTemplateUnpublish,
+  mockCreateToolClient,
+} = vi.hoisted(() => {
+  return {
+    mockTemplateGet: vi.fn(),
+    mockTemplateGetMany: vi.fn(),
+    mockTemplateCreate: vi.fn(),
+    mockTemplateUpsert: vi.fn(),
+    mockTemplateDelete: vi.fn(),
+    mockTemplatePublish: vi.fn(),
+    mockTemplateUnpublish: vi.fn(),
+    mockCreateToolClient: vi.fn(() => {
+      return {
+        template: {
+          get: mockTemplateGet,
+          getMany: mockTemplateGetMany,
+          create: mockTemplateCreate,
+          upsert: mockTemplateUpsert,
+          delete: mockTemplateDelete,
+          publish: mockTemplatePublish,
+          unpublish: mockTemplateUnpublish,
+        },
+      };
+    }),
+  };
+});
+
+vi.mock('../../../utils/tools.js', async (importOriginal) => {
+  const org = await importOriginal<typeof import('../../../utils/tools.js')>();
+  return {
+    ...org,
+    createToolClient: mockCreateToolClient,
+  };
+});
+
+export {
+  mockTemplateGet,
+  mockTemplateGetMany,
+  mockTemplateCreate,
+  mockTemplateUpsert,
+  mockTemplateDelete,
+  mockTemplatePublish,
+  mockTemplateUnpublish,
+  mockCreateToolClient,
+};
+
+/**
+ * Standard mock Template object used across tests.
+ */
+export const mockTemplate = {
+  sys: {
+    id: 'test-template-id',
+    type: 'Template' as const,
+    version: 1,
+    space: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Space' as const,
+        id: 'test-space-id',
+      },
+    },
+    environment: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Environment' as const,
+        id: 'test-environment',
+      },
+    },
+    createdAt: '2023-01-01T00:00:00Z',
+    createdBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } },
+    updatedAt: '2023-01-01T00:00:00Z',
+    updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'user-1' } },
+  },
+  name: 'Test Template',
+  description: 'A test template for unit tests',
+  viewports: [],
+  contentProperties: [],
+  designProperties: [],
+};
+
+/**
+ * Standard test arguments for template operations.
+ */
+export const mockArgs = {
+  spaceId: 'test-space-id',
+  environmentId: 'test-environment',
+  templateId: 'test-template-id',
+};
+
+/**
+ * Mock cursor-paginated list response.
+ */
+export const mockTemplatesResponse = {
+  sys: { type: 'Array' as const },
+  total: 2,
+  limit: 10,
+  items: [
+    mockTemplate,
+    {
+      ...mockTemplate,
+      sys: { ...mockTemplate.sys, id: 'another-template' },
+      name: 'Another Template',
+    },
+  ],
+  pages: { next: 'next-cursor-token' },
+};

--- a/packages/mcp-tools/src/tools/exo/templates/publishTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/publishTemplate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockTemplateGet,
+  mockTemplatePublish,
+  mockTemplate,
+  mockArgs,
+} from './mockClient.js';
+import { publishTemplateTool } from './publishTemplate.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('publishTemplate', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then publishes with it', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+    mockTemplatePublish.mockResolvedValue(mockTemplate);
+
+    const tool = publishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockTemplateGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    expect(mockTemplatePublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+      version: mockTemplate.sys.version,
+    });
+    expect(result.content[0].text).toContain('Template published successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate); // sys.version === 1
+
+    const tool = publishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockTemplatePublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = publishTemplateTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockTemplateGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockTemplateGet.mockRejectedValue(new Error('boom'));
+    const tool = publishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error publishing template: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/publishTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/publishTemplate.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const PublishTemplateToolParams = BaseToolSchema.extend({
+  templateId: z.string().describe('The ID of the template to publish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The template's sys.version as returned by get_template. " +
+        'You must call get_template first to read the current state and version. ' +
+        'The publish is rejected if this does not match the current version, which means ' +
+        'the template changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof PublishTemplateToolParams>;
+
+export function publishTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      templateId: args.templateId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the publish endpoint requires the current version.
+    const current = await contentfulClient.template.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the template has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the template with get_template and retry with the latest sys.version.`,
+      );
+    }
+
+    const template = await contentfulClient.template.publish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Template published successfully', {
+      template,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error publishing template');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/register.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/register.ts
@@ -1,0 +1,130 @@
+import {
+  getTemplateTool,
+  GetTemplateToolParams,
+} from './getTemplate.js';
+import {
+  listTemplatesTool,
+  ListTemplatesToolParams,
+} from './listTemplates.js';
+import {
+  createTemplateTool,
+  CreateTemplateToolParams,
+} from './createTemplate.js';
+import {
+  upsertTemplateTool,
+  UpsertTemplateToolParams,
+} from './upsertTemplate.js';
+import {
+  deleteTemplateTool,
+  DeleteTemplateToolParams,
+} from './deleteTemplate.js';
+import {
+  publishTemplateTool,
+  PublishTemplateToolParams,
+} from './publishTemplate.js';
+import {
+  unpublishTemplateTool,
+  UnpublishTemplateToolParams,
+} from './unpublishTemplate.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export function createTemplateTools(config: ContentfulConfig) {
+  const getTemplate = getTemplateTool(config);
+  const listTemplates = listTemplatesTool(config);
+  const createTemplate = createTemplateTool(config);
+  const upsertTemplate = upsertTemplateTool(config);
+  const deleteTemplate = deleteTemplateTool(config);
+  const publishTemplate = publishTemplateTool(config);
+  const unpublishTemplate = unpublishTemplateTool(config);
+
+  return {
+    getTemplate: {
+      title: 'get_template',
+      description:
+        'Get details about a specific ExO template (a layout definition that backs template-based Experiences).',
+      inputParams: GetTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getTemplate,
+    },
+    listTemplates: {
+      title: 'list_templates',
+      description:
+        'List ExO templates in a space and environment. Returns a maximum of 10 items per request; use the pageNext cursor (returned in pages.next) to paginate.',
+      inputParams: ListTemplatesToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: listTemplates,
+    },
+    createTemplate: {
+      title: 'create_template',
+      description: 'Create a new ExO template.',
+      inputParams: CreateTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: createTemplate,
+    },
+    upsertTemplate: {
+      title: 'upsert_template',
+      description:
+        'Update an existing ExO template. You MUST call get_template first to read the current state, then pass the sys.version you received as the version parameter. The handler merges your updates with the existing template fields, so you only need to provide the fields you want to change. If the version is stale (the template changed since you read it), the update is rejected and you must re-fetch with get_template.',
+      inputParams: UpsertTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: upsertTemplate,
+    },
+    deleteTemplate: {
+      title: 'delete_template',
+      description:
+        'Delete an ExO template. Two-phase: the first call (without confirm/confirmToken) returns a preview and a confirmToken. To complete the deletion, call again with the same templateId, confirm: true, and the confirmToken from the preview.',
+      inputParams: DeleteTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: deleteTemplate,
+    },
+    publishTemplate: {
+      title: 'publish_template',
+      description:
+        'Publish an ExO template. You MUST call get_template first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_template.',
+      inputParams: PublishTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: publishTemplate,
+    },
+    unpublishTemplate: {
+      title: 'unpublish_template',
+      description:
+        'Unpublish an ExO template. You MUST call get_template first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_template.',
+      inputParams: UnpublishTemplateToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: unpublishTemplate,
+    },
+  };
+}

--- a/packages/mcp-tools/src/tools/exo/templates/unpublishTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/unpublishTemplate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockTemplateGet,
+  mockTemplateUnpublish,
+  mockTemplate,
+  mockArgs,
+} from './mockClient.js';
+import { unpublishTemplateTool } from './unpublishTemplate.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('unpublishTemplate', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then unpublishes with it', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+    mockTemplateUnpublish.mockResolvedValue(mockTemplate);
+
+    const tool = unpublishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockTemplateGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    expect(mockTemplateUnpublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+      version: mockTemplate.sys.version,
+    });
+    expect(result.content[0].text).toContain('Template unpublished successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate); // sys.version === 1
+
+    const tool = unpublishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockTemplateUnpublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = unpublishTemplateTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockTemplateGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockTemplateGet.mockRejectedValue(new Error('boom'));
+    const tool = unpublishTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error unpublishing template: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/unpublishTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/unpublishTemplate.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UnpublishTemplateToolParams = BaseToolSchema.extend({
+  templateId: z.string().describe('The ID of the template to unpublish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The template's sys.version as returned by get_template. " +
+        'You must call get_template first to read the current state and version. ' +
+        'The unpublish is rejected if this does not match the current version, which means ' +
+        'the template changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof UnpublishTemplateToolParams>;
+
+export function unpublishTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      templateId: args.templateId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the unpublish endpoint requires the current version.
+    const current = await contentfulClient.template.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the template has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the template with get_template and retry with the latest sys.version.`,
+      );
+    }
+
+    const template = await contentfulClient.template.unpublish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Template unpublished successfully', {
+      template,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error unpublishing template');
+}

--- a/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.test.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockTemplateGet,
+  mockTemplateUpsert,
+  mockTemplate,
+  mockArgs,
+} from './mockClient.js';
+import { upsertTemplateTool } from './upsertTemplate.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('upsertTemplate', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current template before updating (read-before-write)', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate);
+    mockTemplateUpsert.mockResolvedValue({ ...mockTemplate, name: 'Renamed' });
+
+    const tool = upsertTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1, name: 'Renamed' });
+
+    expect(mockTemplateGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    const [params, body] = mockTemplateUpsert.mock.calls[0];
+    expect(params).toEqual({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      templateId: mockArgs.templateId,
+    });
+    expect(body.sys).toEqual({
+      id: mockTemplate.sys.id,
+      type: 'Template',
+      version: mockTemplate.sys.version,
+    });
+    expect(body.name).toBe('Renamed');
+    expect(body.description).toBe(mockTemplate.description);
+    expect(result.content[0].text).toContain('Template updated successfully');
+  });
+
+  it('preserves unspecified fields from the existing template', async () => {
+    mockTemplateGet.mockResolvedValue({
+      ...mockTemplate,
+      designProperties: [{ id: 'color', name: 'Color', type: 'String' }],
+    });
+    mockTemplateUpsert.mockResolvedValue(mockTemplate);
+
+    const tool = upsertTemplateTool(mockConfig);
+    await tool({ ...mockArgs, version: 1, name: 'Renamed' });
+
+    const [, body] = mockTemplateUpsert.mock.calls[0];
+    expect(body.designProperties).toEqual([
+      { id: 'color', name: 'Color', type: 'String' },
+    ]);
+  });
+
+  it('preserves dataAssemblies from the existing template', async () => {
+    const dataAssemblies = [
+      { sys: { id: 'da-1', type: 'Link', linkType: 'DataAssembly' } },
+    ];
+    mockTemplateGet.mockResolvedValue({ ...mockTemplate, dataAssemblies });
+    mockTemplateUpsert.mockResolvedValue(mockTemplate);
+
+    const tool = upsertTemplateTool(mockConfig);
+    await tool({ ...mockArgs, version: 1, name: 'Renamed' });
+
+    const [, body] = mockTemplateUpsert.mock.calls[0];
+    expect(body.dataAssemblies).toEqual(dataAssemblies);
+  });
+
+  it('rejects a stale version', async () => {
+    mockTemplateGet.mockResolvedValue(mockTemplate); // sys.version === 1
+
+    const tool = upsertTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999, name: 'New Name' });
+
+    expect(mockTemplateUpsert).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = upsertTemplateTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1, name: 'New Name' });
+    expect(mockTemplateGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockTemplateGet.mockRejectedValue(new Error('not found'));
+
+    const tool = upsertTemplateTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1, name: 'Renamed' });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error updating template: not found' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import {
+  ViewportSchema,
+  ContentPropertySchema,
+  DesignPropertySchema,
+  SlotDefinitionSchema,
+  TreeNodeSchema,
+  ComponentTypeMetadataSchema,
+} from '../../../types/componentTypeSchemas.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UpsertTemplateToolParams = BaseToolSchema.extend({
+  templateId: z.string().describe('The ID of the template to update'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The template's sys.version as returned by get_template. " +
+        'You must call get_template first to read the current state and version. ' +
+        'The update is rejected if this does not match the current version, which means ' +
+        'the template changed since you read it.',
+    ),
+  name: z.string().optional().describe('The name of the template'),
+  description: z.string().optional().describe('Description of the template'),
+  viewports: z
+    .array(ViewportSchema)
+    .optional()
+    .describe('Viewport definitions; replaces existing viewports if provided'),
+  contentProperties: z
+    .array(ContentPropertySchema)
+    .optional()
+    .describe('Content property definitions; replaces existing if provided'),
+  designProperties: z
+    .array(DesignPropertySchema)
+    .optional()
+    .describe('Design property definitions; replaces existing if provided'),
+  componentTree: z
+    .array(TreeNodeSchema)
+    .optional()
+    .describe('Component tree node definitions; replaces existing if provided'),
+  slots: z
+    .array(SlotDefinitionSchema)
+    .optional()
+    .describe('Slot definitions; replaces existing if provided'),
+  metadata: ComponentTypeMetadataSchema.optional().describe(
+    'ExO metadata (tags, concepts); replaces existing if provided',
+  ),
+});
+
+type Params = z.infer<typeof UpsertTemplateToolParams>;
+
+export function upsertTemplateTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      templateId: args.templateId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: fetch current state to obtain sys.version and to
+    // preserve fields the caller did not supply.
+    const current = await contentfulClient.template.get(params);
+
+    // Enforce read-before-write: the caller must supply the version it read.
+    // Reject stale writes so concurrent edits are not silently overwritten.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the template has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the template with get_template and retry the update with the latest sys.version.`,
+      );
+    }
+
+    const template = await contentfulClient.template.upsert(params, {
+      sys: {
+        id: current.sys.id,
+        type: 'Template',
+        version: current.sys.version,
+      },
+      name: args.name ?? current.name,
+      description: args.description ?? current.description,
+      viewports: args.viewports ?? current.viewports,
+      contentProperties: args.contentProperties ?? current.contentProperties,
+      designProperties: args.designProperties ?? current.designProperties,
+      ...((args.componentTree ?? current.componentTree)
+        ? { componentTree: args.componentTree ?? current.componentTree }
+        : {}),
+      ...((args.slots ?? current.slots)
+        ? { slots: args.slots ?? current.slots }
+        : {}),
+      ...((args.metadata ?? current.metadata)
+        ? { metadata: args.metadata ?? current.metadata }
+        : {}),
+      ...(current.dataAssemblies
+        ? { dataAssemblies: current.dataAssemblies }
+        : {}),
+    } as Parameters<typeof contentfulClient.template.upsert>[1]);
+
+    return createSuccessResponse('Template updated successfully', {
+      template,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error updating template');
+}

--- a/packages/mcp-tools/src/utils/confirmation.ts
+++ b/packages/mcp-tools/src/utils/confirmation.ts
@@ -9,7 +9,8 @@ export type DestructiveResource =
   | 'locale'
   | 'concept'
   | 'conceptScheme'
-  | 'componentType';
+  | 'componentType'
+  | 'template';
 
 export const CONFIRMATION_MESSAGE_PREFIX = 'Confirmation required to delete';
 
@@ -47,6 +48,7 @@ const RESOURCE_DISPLAY_NAME: Record<DestructiveResource, string> = {
   concept: 'concept',
   conceptScheme: 'concept scheme',
   componentType: 'component type',
+  template: 'template',
 };
 
 /**


### PR DESCRIPTION
[AIS-77](https://contentful.atlassian.net/browse/AIS-77)

## Summary
- Implements 7 MCP tools for the ExO Template entity: `get_template`, `list_templates`, `create_template`, `upsert_template`, `delete_template`, `publish_template`, `unpublish_template`
- Follows the established ComponentType pattern (read-before-write, version conflict checks, two-phase confirmation for delete, protected environment guards)
- Adds `'template'` to `DestructiveResource` union in `confirmation.ts` and wires tools into `ContentfulMcpTools` and the server's tool registry

## Test plan
- [x] 526 unit tests pass in `mcp-tools`, 8 pass in `mcp-server`
- [x] Smoke tested all 7 tools against live `exo` environment (create → get → list → upsert → publish → unpublish → delete)
- [ ] Verify tools appear in MCP tool list on remote server after deploy

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-77]: https://contentful.atlassian.net/browse/AIS-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ