### PR TITLE
feat(exo): implement DataAssembly CRUD MCP tools [AIS-75]

### DIFF
--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -77,6 +77,7 @@ describe('registerAllTools', () => {
       mcpTools.getAiActionTools(),
       mcpTools.getAssetTools(),
       mcpTools.getComponentTypeTools(),
+      mcpTools.getDataAssemblyTools(),
       mcpTools.getExperienceTools(),
       mcpTools.getTemplateTools(),
       mcpTools.getContentTypeTools(),

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -57,6 +57,7 @@ export function registerAllTools(server: McpServer): void {
   const editorInterfaceTools = tools.getEditorInterfaceTools();
   const entryTools = tools.getEntryTools();
   const environmentTools = tools.getEnvironmentTools();
+  const dataAssemblyTools = tools.getDataAssemblyTools();
   const fragmentTools = tools.getFragmentTools();
   const localeTools = tools.getLocaleTools();
   const orgTools = tools.getOrgTools();
@@ -69,6 +70,7 @@ export function registerAllTools(server: McpServer): void {
     aiActionTools,
     assetTools,
     componentTypeTools,
+    dataAssemblyTools,
     experienceTools,
     templateTools,
     contentTypeTools,

--- a/packages/mcp-tools/src/ContentfulMcpTools.ts
+++ b/packages/mcp-tools/src/ContentfulMcpTools.ts
@@ -16,6 +16,7 @@ import { createComponentTypeTools } from './tools/exo/component-types/register.j
 import { createFragmentTools } from './tools/exo/fragments/register.js';
 import { createTemplateTools } from './tools/exo/templates/register.js';
 import { createExperienceTools } from './tools/exo/experiences/register.js';
+import { createDataAssemblyTools } from './tools/exo/data-assemblies/register.js';
 
 /**
  * Main class for Contentful MCP Tools
@@ -155,6 +156,13 @@ export class ContentfulMcpTools {
    */
   getFragmentTools() {
     return createFragmentTools(this.config);
+  }
+
+  /**
+   * Get ExO data assembly tools
+   */
+  getDataAssemblyTools() {
+    return createDataAssemblyTools(this.config);
   }
 
   /**

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockDataAssemblyCreate, mockDataAssembly } from './mockClient.js';
+import { createDataAssemblyTool } from './createDataAssembly.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('createDataAssembly', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+    name: 'Test Data Assembly',
+    description: 'A test data assembly',
+    parameters: {},
+    resolvers: {},
+    return: {},
+    dataType: [],
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a data assembly successfully', async () => {
+    mockDataAssemblyCreate.mockResolvedValue(mockDataAssembly);
+
+    const tool = createDataAssemblyTool(mockConfig);
+    const result = await tool(baseArgs);
+
+    expect(mockDataAssemblyCreate).toHaveBeenCalledWith(
+      { spaceId: baseArgs.spaceId, environmentId: baseArgs.environmentId },
+      expect.objectContaining({
+        sys: expect.objectContaining({ type: 'DataAssembly', dataType: [] }),
+        name: baseArgs.name,
+        description: baseArgs.description,
+        parameters: {},
+        resolvers: {},
+        return: {},
+      }),
+    );
+    expect(result.content[0].text).toContain('Data assembly created successfully');
+  });
+
+  it('rejects creates in a protected environment', async () => {
+    const tool = createDataAssemblyTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(baseArgs);
+    expect(mockDataAssemblyCreate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyCreate.mockRejectedValue(new Error('boom'));
+    const tool = createDataAssemblyTool(mockConfig);
+    const result = await tool(baseArgs);
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error creating data assembly: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
@@ -20,7 +20,7 @@ export const CreateDataAssemblyToolParams = BaseToolSchema.extend({
     .record(z.unknown())
     .describe('Resolver definitions keyed by resolver name (may be empty object)'),
   return: z
-    .unknown()
+    .record(z.unknown())
     .describe('Return mapping configuration specifying how to map resolved data'),
   dataType: z
     .array(z.unknown())

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const CreateDataAssemblyToolParams = BaseToolSchema.extend({
+  name: z.string().describe('The name of the data assembly'),
+  description: z.string().describe('Description of the data assembly'),
+  parameters: z
+    .record(z.unknown())
+    .describe('Parameter definitions keyed by parameter name (may be empty object)'),
+  resolvers: z
+    .record(z.unknown())
+    .describe('Resolver definitions keyed by resolver name (may be empty object)'),
+  return: z
+    .unknown()
+    .describe('Return mapping configuration specifying how to map resolved data'),
+  dataType: z
+    .array(z.unknown())
+    .describe('Data type field definitions for this data assembly (may be empty array)'),
+  variant: z
+    .string()
+    .optional()
+    .describe('Optional variant identifier for this data assembly'),
+  metadata: z
+    .object({
+      tags: z.array(z.unknown()).optional(),
+    })
+    .optional()
+    .describe('Optional metadata (tags)'),
+});
+
+type Params = z.infer<typeof CreateDataAssemblyToolParams>;
+
+export function createDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const contentfulClient = createToolClient(config, args);
+
+    const dataAssembly = await contentfulClient.dataAssembly.create(
+      { spaceId: args.spaceId, environmentId: args.environmentId },
+      {
+        sys: {
+          type: 'DataAssembly',
+          dataType: args.dataType as Parameters<typeof contentfulClient.dataAssembly.create>[1]['sys']['dataType'],
+          ...(args.variant && { variant: args.variant }),
+        },
+        name: args.name,
+        description: args.description,
+        parameters: args.parameters as Parameters<typeof contentfulClient.dataAssembly.create>[1]['parameters'],
+        resolvers: args.resolvers as Parameters<typeof contentfulClient.dataAssembly.create>[1]['resolvers'],
+        return: args.return as Parameters<typeof contentfulClient.dataAssembly.create>[1]['return'],
+        metadata: (args.metadata ?? { tags: [] }) as Parameters<typeof contentfulClient.dataAssembly.create>[1]['metadata'],
+      },
+    );
+
+    return createSuccessResponse('Data assembly created successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error creating data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockDataAssemblyGet,
+  mockDataAssemblyDelete,
+  mockDataAssembly,
+  mockArgs,
+} from './mockClient.js';
+import { deleteDataAssemblyTool } from './deleteDataAssembly.js';
+import { buildConfirmToken } from '../../../utils/confirmation.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('deleteDataAssembly', () => {
+  const mockConfig = createMockConfig();
+  const validToken = buildConfirmToken(
+    'dataAssembly',
+    mockArgs.dataAssemblyId,
+    mockDataAssembly.sys.version,
+  );
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a confirmation preview when confirm is missing', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+
+    const tool = deleteDataAssemblyTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockDataAssemblyDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+    expect(result.content[0].text).toContain(validToken);
+  });
+
+  it('returns a preview when the confirmToken is wrong', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+
+    const tool = deleteDataAssemblyTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      confirm: true,
+      confirmToken: 'wrong',
+    });
+
+    expect(mockDataAssemblyDelete).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Confirmation required to delete');
+  });
+
+  it('deletes when confirm is true and the token matches', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+    mockDataAssemblyDelete.mockResolvedValue(undefined);
+
+    const tool = deleteDataAssemblyTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      confirm: true,
+      confirmToken: validToken,
+    });
+
+    expect(mockDataAssemblyDelete).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+    expect(result.content[0].text).toContain('Data assembly deleted successfully');
+  });
+
+  it('rejects deletes in a protected environment', async () => {
+    const tool = deleteDataAssemblyTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool(mockArgs);
+    expect(mockDataAssemblyGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import {
+  buildConfirmToken,
+  buildConfirmationPreview,
+  CONFIRMATION_MESSAGE_PREFIX,
+} from '../../../utils/confirmation.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const DeleteDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the data assembly to delete'),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true on the second call to actually perform the deletion. Required together with confirmToken.',
+    ),
+  confirmToken: z
+    .string()
+    .optional()
+    .describe(
+      'Token returned by the preview call; must be supplied with confirm: true.',
+    ),
+});
+
+type Params = z.infer<typeof DeleteDataAssemblyToolParams>;
+
+export function deleteDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+    const dataAssembly = await contentfulClient.dataAssembly.get(params);
+
+    const expectedToken = buildConfirmToken(
+      'dataAssembly',
+      args.dataAssemblyId,
+      dataAssembly.sys.version,
+    );
+    if (args.confirm !== true || args.confirmToken !== expectedToken) {
+      return createSuccessResponse(
+        `${CONFIRMATION_MESSAGE_PREFIX} data assembly`,
+        buildConfirmationPreview(
+          'dataAssembly',
+          args.dataAssemblyId,
+          { dataAssembly },
+          expectedToken,
+        ),
+      );
+    }
+
+    await contentfulClient.dataAssembly.delete(params);
+
+    return createSuccessResponse('Data assembly deleted successfully', {
+      dataAssemblyId: args.dataAssemblyId,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error deleting data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mockDataAssemblyGet, mockDataAssembly, mockArgs } from './mockClient.js';
+import { getDataAssemblyTool } from './getDataAssembly.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('getDataAssembly', () => {
+  const mockConfig = createMockConfig();
+
+  it('retrieves a data assembly successfully', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+
+    const tool = getDataAssemblyTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    const expectedResponse = formatResponse('Data assembly retrieved successfully', {
+      dataAssembly: mockDataAssembly,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockDataAssemblyGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+  });
+
+  it('handles errors when the data assembly is not found', async () => {
+    mockDataAssemblyGet.mockRejectedValue(new Error('Data assembly not found'));
+
+    const tool = getDataAssemblyTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving data assembly: Data assembly not found',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const GetDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the data assembly to retrieve'),
+});
+
+type Params = z.infer<typeof GetDataAssemblyToolParams>;
+
+export function getDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const dataAssembly = await contentfulClient.dataAssembly.get({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    });
+
+    return createSuccessResponse('Data assembly retrieved successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mockDataAssemblyGetPublished, mockDataAssembly, mockArgs } from './mockClient.js';
+import { getPublishedDataAssemblyTool } from './getPublishedDataAssembly.js';
+import { formatResponse } from '../../../utils/formatters.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('getPublishedDataAssembly', () => {
+  const mockConfig = createMockConfig();
+
+  it('retrieves a published data assembly successfully', async () => {
+    mockDataAssemblyGetPublished.mockResolvedValue(mockDataAssembly);
+
+    const tool = getPublishedDataAssemblyTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    const expectedResponse = formatResponse('Published data assembly retrieved successfully', {
+      dataAssembly: mockDataAssembly,
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+    expect(mockDataAssemblyGetPublished).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+  });
+
+  it('handles errors when the published data assembly is not found', async () => {
+    mockDataAssemblyGetPublished.mockRejectedValue(new Error('Not found'));
+
+    const tool = getPublishedDataAssemblyTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving published data assembly: Not found',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const GetPublishedDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the published data assembly to retrieve'),
+});
+
+type Params = z.infer<typeof GetPublishedDataAssemblyToolParams>;
+
+export function getPublishedDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const dataAssembly = await contentfulClient.dataAssembly.getPublished({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    });
+
+    return createSuccessResponse('Published data assembly retrieved successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving published data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.test.ts
@@ -50,11 +50,11 @@ describe('listDataAssemblies', () => {
     });
   });
 
-  it('forwards sys.id[in] filter', async () => {
+  it('forwards sysIdIn filter', async () => {
     mockDataAssemblyGetMany.mockResolvedValue(mockDataAssembliesResponse);
 
     const tool = listDataAssembliesTool(mockConfig);
-    await tool({ ...baseArgs, 'sys.id[in]': 'id1,id2' });
+    await tool({ ...baseArgs, sysIdIn: 'id1,id2' });
 
     expect(mockDataAssemblyGetMany).toHaveBeenCalledWith({
       spaceId: baseArgs.spaceId,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { mockDataAssemblyGetMany, mockDataAssembliesResponse } from './mockClient.js';
+import { listDataAssembliesTool } from './listDataAssemblies.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('listDataAssemblies', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+  };
+
+  it('lists data assemblies and clamps limit to 10', async () => {
+    mockDataAssemblyGetMany.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listDataAssembliesTool(mockConfig);
+    const result = await tool({ ...baseArgs, limit: 50 });
+
+    expect(mockDataAssemblyGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10 },
+    });
+    expect(result.content[0].text).toContain('Data assemblies retrieved successfully');
+  });
+
+  it('forwards cursor params', async () => {
+    mockDataAssemblyGetMany.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listDataAssembliesTool(mockConfig);
+    await tool({ ...baseArgs, pageNext: 'cursor-1' });
+
+    expect(mockDataAssemblyGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, pageNext: 'cursor-1' },
+    });
+  });
+
+  it('forwards pagePrev cursor param', async () => {
+    mockDataAssemblyGetMany.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listDataAssembliesTool(mockConfig);
+    await tool({ ...baseArgs, pagePrev: 'cursor-back' });
+
+    expect(mockDataAssemblyGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, pagePrev: 'cursor-back' },
+    });
+  });
+
+  it('forwards sys.id[in] filter', async () => {
+    mockDataAssemblyGetMany.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listDataAssembliesTool(mockConfig);
+    await tool({ ...baseArgs, 'sys.id[in]': 'id1,id2' });
+
+    expect(mockDataAssemblyGetMany).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, 'sys.id[in]': 'id1,id2' },
+    });
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyGetMany.mockRejectedValue(new Error('boom'));
+
+    const tool = listDataAssembliesTool(mockConfig);
+    const result = await tool(baseArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error listing data assemblies: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
@@ -20,7 +20,7 @@ export const ListDataAssembliesToolParams = BaseToolSchema.extend({
     .string()
     .optional()
     .describe('Cursor token to fetch the previous page of results'),
-  'sys.id[in]': z
+  sysIdIn: z
     .string()
     .optional()
     .describe('Comma-separated list of data assembly IDs to filter by'),
@@ -39,7 +39,7 @@ export function listDataAssembliesTool(config: ContentfulConfig) {
         limit: Math.min(args.limit || 10, 10),
         ...(args.pageNext && { pageNext: args.pageNext }),
         ...(args.pagePrev && { pagePrev: args.pagePrev }),
-        ...(args['sys.id[in]'] && { 'sys.id[in]': args['sys.id[in]'] }),
+        ...(args.sysIdIn && { 'sys.id[in]': args.sysIdIn }),
       } as unknown as Parameters<typeof contentfulClient.dataAssembly.getMany>[0]['query'],
     });
 

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { summarizeData } from '../../../utils/summarizer.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const ListDataAssembliesToolParams = BaseToolSchema.extend({
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of data assemblies to return (max 10)'),
+  pageNext: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the next page of results'),
+  pagePrev: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the previous page of results'),
+  'sys.id[in]': z
+    .string()
+    .optional()
+    .describe('Comma-separated list of data assembly IDs to filter by'),
+});
+
+type Params = z.infer<typeof ListDataAssembliesToolParams>;
+
+export function listDataAssembliesTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const dataAssemblies = await contentfulClient.dataAssembly.getMany({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      query: {
+        limit: Math.min(args.limit || 10, 10),
+        ...(args.pageNext && { pageNext: args.pageNext }),
+        ...(args.pagePrev && { pagePrev: args.pagePrev }),
+        ...(args['sys.id[in]'] && { 'sys.id[in]': args['sys.id[in]'] }),
+      } as unknown as Parameters<typeof contentfulClient.dataAssembly.getMany>[0]['query'],
+    });
+
+    const summarized = summarizeData(dataAssemblies, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more data assemblies, ask me to retrieve the next page using the pageNext cursor.',
+    });
+
+    return createSuccessResponse('Data assemblies retrieved successfully', {
+      dataAssemblies: summarized,
+      total: dataAssemblies.total,
+      pages: dataAssemblies.pages,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error listing data assemblies');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mockDataAssemblyGetManyPublished, mockDataAssembliesResponse } from './mockClient.js';
+import { listPublishedDataAssembliesTool } from './listPublishedDataAssemblies.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('listPublishedDataAssemblies', () => {
+  const mockConfig = createMockConfig();
+  const baseArgs = {
+    spaceId: 'test-space-id',
+    environmentId: 'test-environment',
+  };
+
+  it('lists published data assemblies and clamps limit to 10', async () => {
+    mockDataAssemblyGetManyPublished.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listPublishedDataAssembliesTool(mockConfig);
+    const result = await tool({ ...baseArgs, limit: 50 });
+
+    expect(mockDataAssemblyGetManyPublished).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10 },
+    });
+    expect(result.content[0].text).toContain('Published data assemblies retrieved successfully');
+  });
+
+  it('forwards cursor params', async () => {
+    mockDataAssemblyGetManyPublished.mockResolvedValue(mockDataAssembliesResponse);
+
+    const tool = listPublishedDataAssembliesTool(mockConfig);
+    await tool({ ...baseArgs, pageNext: 'cursor-1' });
+
+    expect(mockDataAssemblyGetManyPublished).toHaveBeenCalledWith({
+      spaceId: baseArgs.spaceId,
+      environmentId: baseArgs.environmentId,
+      query: { limit: 10, pageNext: 'cursor-1' },
+    });
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyGetManyPublished.mockRejectedValue(new Error('boom'));
+
+    const tool = listPublishedDataAssembliesTool(mockConfig);
+    const result = await tool(baseArgs);
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error listing published data assemblies: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
@@ -20,7 +20,7 @@ export const ListPublishedDataAssembliesToolParams = BaseToolSchema.extend({
     .string()
     .optional()
     .describe('Cursor token to fetch the previous page of results'),
-  'sys.id[in]': z
+  sysIdIn: z
     .string()
     .optional()
     .describe('Comma-separated list of data assembly IDs to filter by'),
@@ -39,7 +39,7 @@ export function listPublishedDataAssembliesTool(config: ContentfulConfig) {
         limit: Math.min(args.limit || 10, 10),
         ...(args.pageNext && { pageNext: args.pageNext }),
         ...(args.pagePrev && { pagePrev: args.pagePrev }),
-        ...(args['sys.id[in]'] && { 'sys.id[in]': args['sys.id[in]'] }),
+        ...(args.sysIdIn && { 'sys.id[in]': args.sysIdIn }),
       } as unknown as Parameters<typeof contentfulClient.dataAssembly.getManyPublished>[0]['query'],
     });
 

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { summarizeData } from '../../../utils/summarizer.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const ListPublishedDataAssembliesToolParams = BaseToolSchema.extend({
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of published data assemblies to return (max 10)'),
+  pageNext: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the next page of results'),
+  pagePrev: z
+    .string()
+    .optional()
+    .describe('Cursor token to fetch the previous page of results'),
+  'sys.id[in]': z
+    .string()
+    .optional()
+    .describe('Comma-separated list of data assembly IDs to filter by'),
+});
+
+type Params = z.infer<typeof ListPublishedDataAssembliesToolParams>;
+
+export function listPublishedDataAssembliesTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const contentfulClient = createToolClient(config, args);
+
+    const dataAssemblies = await contentfulClient.dataAssembly.getManyPublished({
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      query: {
+        limit: Math.min(args.limit || 10, 10),
+        ...(args.pageNext && { pageNext: args.pageNext }),
+        ...(args.pagePrev && { pagePrev: args.pagePrev }),
+        ...(args['sys.id[in]'] && { 'sys.id[in]': args['sys.id[in]'] }),
+      } as unknown as Parameters<typeof contentfulClient.dataAssembly.getManyPublished>[0]['query'],
+    });
+
+    const summarized = summarizeData(dataAssemblies, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more published data assemblies, ask me to retrieve the next page using the pageNext cursor.',
+    });
+
+    return createSuccessResponse('Published data assemblies retrieved successfully', {
+      dataAssemblies: summarized,
+      total: dataAssemblies.total,
+      pages: dataAssemblies.pages,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error listing published data assemblies');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/mockClient.ts
@@ -1,0 +1,123 @@
+import { vi } from 'vitest';
+
+const {
+  mockDataAssemblyGet,
+  mockDataAssemblyGetMany,
+  mockDataAssemblyGetPublished,
+  mockDataAssemblyGetManyPublished,
+  mockDataAssemblyCreate,
+  mockDataAssemblyUpdate,
+  mockDataAssemblyDelete,
+  mockDataAssemblyPublish,
+  mockDataAssemblyUnpublish,
+  mockCreateToolClient,
+} = vi.hoisted(() => {
+  return {
+    mockDataAssemblyGet: vi.fn(),
+    mockDataAssemblyGetMany: vi.fn(),
+    mockDataAssemblyGetPublished: vi.fn(),
+    mockDataAssemblyGetManyPublished: vi.fn(),
+    mockDataAssemblyCreate: vi.fn(),
+    mockDataAssemblyUpdate: vi.fn(),
+    mockDataAssemblyDelete: vi.fn(),
+    mockDataAssemblyPublish: vi.fn(),
+    mockDataAssemblyUnpublish: vi.fn(),
+    mockCreateToolClient: vi.fn(() => {
+      return {
+        dataAssembly: {
+          get: mockDataAssemblyGet,
+          getMany: mockDataAssemblyGetMany,
+          getPublished: mockDataAssemblyGetPublished,
+          getManyPublished: mockDataAssemblyGetManyPublished,
+          create: mockDataAssemblyCreate,
+          update: mockDataAssemblyUpdate,
+          delete: mockDataAssemblyDelete,
+          publish: mockDataAssemblyPublish,
+          unpublish: mockDataAssemblyUnpublish,
+        },
+      };
+    }),
+  };
+});
+
+vi.mock('../../../utils/tools.js', async (importOriginal) => {
+  const org = await importOriginal<typeof import('../../../utils/tools.js')>();
+  return {
+    ...org,
+    createToolClient: mockCreateToolClient,
+  };
+});
+
+export {
+  mockDataAssemblyGet,
+  mockDataAssemblyGetMany,
+  mockDataAssemblyGetPublished,
+  mockDataAssemblyGetManyPublished,
+  mockDataAssemblyCreate,
+  mockDataAssemblyUpdate,
+  mockDataAssemblyDelete,
+  mockDataAssemblyPublish,
+  mockDataAssemblyUnpublish,
+  mockCreateToolClient,
+};
+
+/**
+ * Standard mock DataAssembly object used across tests.
+ */
+export const mockDataAssembly = {
+  sys: {
+    id: 'test-data-assembly-id',
+    type: 'DataAssembly' as const,
+    version: 1,
+    dataType: [],
+    space: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Space' as const,
+        id: 'test-space-id',
+      },
+    },
+    environment: {
+      sys: {
+        type: 'Link' as const,
+        linkType: 'Environment' as const,
+        id: 'test-environment',
+      },
+    },
+    createdAt: '2023-01-01T00:00:00Z',
+    createdBy: { sys: { type: 'Link' as const, linkType: 'User' as const, id: 'user-1' } },
+    updatedAt: '2023-01-01T00:00:00Z',
+  },
+  name: 'Test Data Assembly',
+  description: 'A test data assembly for unit tests',
+  metadata: { tags: [] },
+  parameters: {},
+  resolvers: {},
+  return: {},
+};
+
+/**
+ * Standard test arguments for data assembly operations.
+ */
+export const mockArgs = {
+  spaceId: 'test-space-id',
+  environmentId: 'test-environment',
+  dataAssemblyId: 'test-data-assembly-id',
+};
+
+/**
+ * Mock cursor-paginated list response.
+ */
+export const mockDataAssembliesResponse = {
+  sys: { type: 'Array' as const },
+  total: 2,
+  items: [
+    mockDataAssembly,
+    {
+      ...mockDataAssembly,
+      sys: { ...mockDataAssembly.sys, id: 'another-data-assembly' },
+      name: 'Another Data Assembly',
+    },
+  ],
+  pages: { next: 'next-cursor-token' },
+};

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockDataAssemblyGet,
+  mockDataAssemblyPublish,
+  mockDataAssembly,
+  mockArgs,
+} from './mockClient.js';
+import { publishDataAssemblyTool } from './publishDataAssembly.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('publishDataAssembly', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then publishes with it', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+    mockDataAssemblyPublish.mockResolvedValue(mockDataAssembly);
+
+    const tool = publishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockDataAssemblyGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+    expect(mockDataAssemblyPublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+      version: mockDataAssembly.sys.version,
+    });
+    expect(result.content[0].text).toContain('Data assembly published successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly); // sys.version === 1
+
+    const tool = publishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockDataAssemblyPublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = publishDataAssemblyTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockDataAssemblyGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyGet.mockRejectedValue(new Error('boom'));
+    const tool = publishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error publishing data assembly: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const PublishDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the data assembly to publish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The data assembly's sys.version as returned by get_data_assembly. " +
+        'You must call get_data_assembly first to read the current state and version. ' +
+        'The publish is rejected if this does not match the current version, which means ' +
+        'the data assembly changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof PublishDataAssemblyToolParams>;
+
+export function publishDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the publish endpoint requires the current version.
+    const current = await contentfulClient.dataAssembly.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the data assembly has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the data assembly with get_data_assembly and retry with the latest sys.version.`,
+      );
+    }
+
+    const dataAssembly = await contentfulClient.dataAssembly.publish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Data assembly published successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error publishing data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/register.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/register.ts
@@ -1,0 +1,164 @@
+import {
+  getDataAssemblyTool,
+  GetDataAssemblyToolParams,
+} from './getDataAssembly.js';
+import {
+  getPublishedDataAssemblyTool,
+  GetPublishedDataAssemblyToolParams,
+} from './getPublishedDataAssembly.js';
+import {
+  listDataAssembliesTool,
+  ListDataAssembliesToolParams,
+} from './listDataAssemblies.js';
+import {
+  listPublishedDataAssembliesTool,
+  ListPublishedDataAssembliesToolParams,
+} from './listPublishedDataAssemblies.js';
+import {
+  createDataAssemblyTool,
+  CreateDataAssemblyToolParams,
+} from './createDataAssembly.js';
+import {
+  updateDataAssemblyTool,
+  UpdateDataAssemblyToolParams,
+} from './updateDataAssembly.js';
+import {
+  deleteDataAssemblyTool,
+  DeleteDataAssemblyToolParams,
+} from './deleteDataAssembly.js';
+import {
+  publishDataAssemblyTool,
+  PublishDataAssemblyToolParams,
+} from './publishDataAssembly.js';
+import {
+  unpublishDataAssemblyTool,
+  UnpublishDataAssemblyToolParams,
+} from './unpublishDataAssembly.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export function createDataAssemblyTools(config: ContentfulConfig) {
+  const getDataAssembly = getDataAssemblyTool(config);
+  const getPublishedDataAssembly = getPublishedDataAssemblyTool(config);
+  const listDataAssemblies = listDataAssembliesTool(config);
+  const listPublishedDataAssemblies = listPublishedDataAssembliesTool(config);
+  const createDataAssembly = createDataAssemblyTool(config);
+  const updateDataAssembly = updateDataAssemblyTool(config);
+  const deleteDataAssembly = deleteDataAssemblyTool(config);
+  const publishDataAssembly = publishDataAssemblyTool(config);
+  const unpublishDataAssembly = unpublishDataAssemblyTool(config);
+
+  return {
+    getDataAssembly: {
+      title: 'get_data_assembly',
+      description:
+        'Get details about a specific ExO DataAssembly (a smart data recipe that specifies how to fetch and reshape data for a component or page in a single operation).',
+      inputParams: GetDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getDataAssembly,
+    },
+    getPublishedDataAssembly: {
+      title: 'get_published_data_assembly',
+      description:
+        'Get details about a specific published ExO DataAssembly by ID.',
+      inputParams: GetPublishedDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getPublishedDataAssembly,
+    },
+    listDataAssemblies: {
+      title: 'list_data_assemblies',
+      description:
+        'List ExO DataAssemblies in a space and environment. Returns a maximum of 10 items per request; use the pageNext cursor (returned in pages.next) to paginate.',
+      inputParams: ListDataAssembliesToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: listDataAssemblies,
+    },
+    listPublishedDataAssemblies: {
+      title: 'list_published_data_assemblies',
+      description:
+        'List published ExO DataAssemblies in a space and environment. Returns a maximum of 10 items per request; use the pageNext cursor (returned in pages.next) to paginate.',
+      inputParams: ListPublishedDataAssembliesToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: listPublishedDataAssemblies,
+    },
+    createDataAssembly: {
+      title: 'create_data_assembly',
+      description: 'Create a new ExO DataAssembly.',
+      inputParams: CreateDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: createDataAssembly,
+    },
+    updateDataAssembly: {
+      title: 'update_data_assembly',
+      description:
+        'Update an existing ExO DataAssembly. You MUST call get_data_assembly first to read the current state, then pass the sys.version you received as the version parameter. The handler merges your updates with the existing data assembly fields, so you only need to provide the fields you want to change. If the version is stale (the data assembly changed since you read it), the update is rejected and you must re-fetch with get_data_assembly.',
+      inputParams: UpdateDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: updateDataAssembly,
+    },
+    deleteDataAssembly: {
+      title: 'delete_data_assembly',
+      description:
+        'Delete an ExO DataAssembly. Two-phase: the first call (without confirm/confirmToken) returns a preview and a confirmToken. To complete the deletion, call again with the same dataAssemblyId, confirm: true, and the confirmToken from the preview.',
+      inputParams: DeleteDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      tool: deleteDataAssembly,
+    },
+    publishDataAssembly: {
+      title: 'publish_data_assembly',
+      description:
+        'Publish an ExO DataAssembly. You MUST call get_data_assembly first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_data_assembly.',
+      inputParams: PublishDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: publishDataAssembly,
+    },
+    unpublishDataAssembly: {
+      title: 'unpublish_data_assembly',
+      description:
+        'Unpublish an ExO DataAssembly. You MUST call get_data_assembly first and pass the returned sys.version as the version parameter. If the version is stale the operation is rejected and you must re-fetch with get_data_assembly.',
+      inputParams: UnpublishDataAssemblyToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: unpublishDataAssembly,
+    },
+  };
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockDataAssemblyGet,
+  mockDataAssemblyUnpublish,
+  mockDataAssembly,
+  mockArgs,
+} from './mockClient.js';
+import { unpublishDataAssemblyTool } from './unpublishDataAssembly.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('unpublishDataAssembly', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the current version then unpublishes with it', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+    mockDataAssemblyUnpublish.mockResolvedValue(mockDataAssembly);
+
+    const tool = unpublishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+
+    expect(mockDataAssemblyGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+    expect(mockDataAssemblyUnpublish).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+      version: mockDataAssembly.sys.version,
+    });
+    expect(result.content[0].text).toContain('Data assembly unpublished successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly); // sys.version === 1
+
+    const tool = unpublishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockDataAssemblyUnpublish).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = unpublishDataAssemblyTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockDataAssemblyGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyGet.mockRejectedValue(new Error('boom'));
+    const tool = unpublishDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error unpublishing data assembly: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UnpublishDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the data assembly to unpublish'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The data assembly's sys.version as returned by get_data_assembly. " +
+        'You must call get_data_assembly first to read the current state and version. ' +
+        'The unpublish is rejected if this does not match the current version, which means ' +
+        'the data assembly changed since you read it.',
+    ),
+});
+
+type Params = z.infer<typeof UnpublishDataAssemblyToolParams>;
+
+export function unpublishDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: the unpublish endpoint requires the current version.
+    const current = await contentfulClient.dataAssembly.get(params);
+
+    // Enforce read-before-write: reject if the caller's version is stale.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the data assembly has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the data assembly with get_data_assembly and retry with the latest sys.version.`,
+      );
+    }
+
+    const dataAssembly = await contentfulClient.dataAssembly.unpublish({
+      ...params,
+      version: args.version,
+    });
+
+    return createSuccessResponse('Data assembly unpublished successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error unpublishing data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.test.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockDataAssemblyGet,
+  mockDataAssemblyUpdate,
+  mockDataAssembly,
+  mockArgs,
+} from './mockClient.js';
+import { updateDataAssemblyTool } from './updateDataAssembly.js';
+import { createMockConfig } from '../../../test-helpers/mockConfig.js';
+
+describe('updateDataAssembly', () => {
+  const mockConfig = createMockConfig();
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads before writing and merges fields', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly);
+    mockDataAssemblyUpdate.mockResolvedValue({
+      ...mockDataAssembly,
+      name: 'Updated Data Assembly',
+      sys: { ...mockDataAssembly.sys, version: 2 },
+    });
+
+    const tool = updateDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1, name: 'Updated Data Assembly' });
+
+    expect(mockDataAssemblyGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      dataAssemblyId: mockArgs.dataAssemblyId,
+    });
+    expect(mockDataAssemblyUpdate).toHaveBeenCalledWith(
+      {
+        spaceId: mockArgs.spaceId,
+        environmentId: mockArgs.environmentId,
+        dataAssemblyId: mockArgs.dataAssemblyId,
+      },
+      expect.objectContaining({
+        name: 'Updated Data Assembly',
+        description: mockDataAssembly.description,
+      }),
+    );
+    expect(result.content[0].text).toContain('Data assembly updated successfully');
+  });
+
+  it('rejects a stale version', async () => {
+    mockDataAssemblyGet.mockResolvedValue(mockDataAssembly); // sys.version === 1
+
+    const tool = updateDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 999 });
+
+    expect(mockDataAssemblyUpdate).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Version conflict');
+  });
+
+  it('rejects writes to a protected environment', async () => {
+    const tool = updateDataAssemblyTool(
+      createMockConfig({ protectedEnvironments: ['test-environment'] }),
+    );
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(mockDataAssemblyGet).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('is protected');
+  });
+
+  it('handles errors', async () => {
+    mockDataAssemblyGet.mockRejectedValue(new Error('boom'));
+    const tool = updateDataAssemblyTool(mockConfig);
+    const result = await tool({ ...mockArgs, version: 1 });
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error updating data assembly: boom' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../../utils/tools.js';
+import type { ContentfulConfig } from '../../../config/types.js';
+
+export const UpdateDataAssemblyToolParams = BaseToolSchema.extend({
+  dataAssemblyId: z.string().describe('The ID of the data assembly to update'),
+  version: z
+    .number()
+    .describe(
+      "REQUIRED. The data assembly's sys.version as returned by get_data_assembly. " +
+        'You must call get_data_assembly first to read the current state and version. ' +
+        'The update is rejected if this does not match the current version, which means ' +
+        'the data assembly changed since you read it.',
+    ),
+  name: z.string().optional().describe('The name of the data assembly'),
+  description: z.string().optional().describe('Description of the data assembly'),
+  parameters: z
+    .record(z.unknown())
+    .optional()
+    .describe('Parameter definitions; replaces existing if provided'),
+  resolvers: z
+    .record(z.unknown())
+    .optional()
+    .describe('Resolver definitions; replaces existing if provided'),
+  return: z
+    .unknown()
+    .optional()
+    .describe('Return mapping configuration; replaces existing if provided'),
+  dataType: z
+    .array(z.unknown())
+    .optional()
+    .describe('Data type field definitions; replaces existing if provided'),
+  variant: z
+    .string()
+    .optional()
+    .describe('Optional variant identifier; replaces existing if provided'),
+  metadata: z
+    .object({
+      tags: z.array(z.unknown()).optional(),
+    })
+    .optional()
+    .describe('Metadata (tags); replaces existing if provided'),
+});
+
+type Params = z.infer<typeof UpdateDataAssemblyToolParams>;
+
+export function updateDataAssemblyTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      dataAssemblyId: args.dataAssemblyId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Read before write: fetch current state to preserve fields the caller did not supply.
+    const current = await contentfulClient.dataAssembly.get(params);
+
+    // Enforce read-before-write: the caller must supply the version it read.
+    if (args.version !== current.sys.version) {
+      throw new Error(
+        `Version conflict: the data assembly has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${current.sys.version}). ` +
+          `Re-fetch the data assembly with get_data_assembly and retry the update with the latest sys.version.`,
+      );
+    }
+
+    type UpdatePayload = Parameters<typeof contentfulClient.dataAssembly.update>[1];
+
+    const dataAssembly = await contentfulClient.dataAssembly.update(params, {
+      sys: {
+        id: current.sys.id,
+        type: 'DataAssembly',
+        version: current.sys.version,
+        dataType: (args.dataType ?? current.sys.dataType) as UpdatePayload['sys']['dataType'],
+        ...(args.variant !== undefined
+          ? { variant: args.variant }
+          : current.sys.variant !== undefined
+          ? { variant: current.sys.variant }
+          : {}),
+      },
+      name: args.name ?? current.name,
+      description: args.description ?? current.description,
+      parameters: (args.parameters ?? current.parameters) as UpdatePayload['parameters'],
+      resolvers: (args.resolvers ?? current.resolvers) as UpdatePayload['resolvers'],
+      return: (args.return ?? current.return) as UpdatePayload['return'],
+      metadata: (args.metadata ?? current.metadata) as UpdatePayload['metadata'],
+    });
+
+    return createSuccessResponse('Data assembly updated successfully', {
+      dataAssembly,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error updating data assembly');
+}

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
@@ -31,7 +31,7 @@ export const UpdateDataAssemblyToolParams = BaseToolSchema.extend({
     .optional()
     .describe('Resolver definitions; replaces existing if provided'),
   return: z
-    .unknown()
+    .record(z.unknown())
     .optional()
     .describe('Return mapping configuration; replaces existing if provided'),
   dataType: z

--- a/packages/mcp-tools/src/utils/confirmation.ts
+++ b/packages/mcp-tools/src/utils/confirmation.ts
@@ -12,7 +12,8 @@ export type DestructiveResource =
   | 'componentType'
   | 'experience'
   | 'fragment'
-  | 'template';
+  | 'template'
+  | 'dataAssembly';
 
 export const CONFIRMATION_MESSAGE_PREFIX = 'Confirmation required to delete';
 
@@ -53,6 +54,7 @@ const RESOURCE_DISPLAY_NAME: Record<DestructiveResource, string> = {
   experience: 'experience',
   fragment: 'fragment',
   template: 'template',
+  dataAssembly: 'data assembly',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Implements 9 new MCP tools for the full ExO DataAssembly lifecycle: `create`, `get`, `update`, `delete`, `publish`, `unpublish`, `listDataAssemblies`, `getPublishedDataAssembly`, `listPublishedDataAssemblies`
- Adds `'dataAssembly'` to the `DestructiveResource` union in `confirmation.ts` so deletes are gated behind the two-phase confirm pattern
- Wires `getDataAssemblyTools()` into `ContentfulMcpTools` and `register.ts` alongside the other ExO tool collections
- Bundles a fix for the `return` field schema (`z.unknown()` → `z.record(z.unknown())`) that would have caused every create/update call to 422 due to incorrect string serialization

## Test plan
- [x] Unit tests for all 9 tools (mockClient pattern, consistent with Fragment/Template/Experience)
- [x] Full smoke test on local MCP server: create → get → list → update → publish → get_published → list_published → unpublish → delete — all ops passed
- [x] Build succeeds (`npm run build`)

Generated with [Claude Code](https://claude.com/claude-code)