### PR TITLE
feat(exo): pin ExO tool schemas to canonical CMA types

### DIFF
--- a/packages/mcp-tools/src/tools/exo/component-types/createComponentType.ts
+++ b/packages/mcp-tools/src/tools/exo/component-types/createComponentType.ts
@@ -14,7 +14,7 @@ import {
   DesignPropertySchema,
   SlotDefinitionSchema,
   TreeNodeSchema,
-  ComponentTypeMetadataSchema,
+  ExoMetadataSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -38,7 +38,7 @@ export const CreateComponentTypeToolParams = BaseToolSchema.extend({
     .array(SlotDefinitionSchema)
     .optional()
     .describe('Optional slot definitions'),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExoMetadataSchema.optional().describe(
     'Optional ExO metadata (tags, concepts)',
   ),
 });
@@ -65,7 +65,7 @@ export function createComponentTypeTool(config: ContentfulConfig) {
         ...(args.componentTree && { componentTree: args.componentTree }),
         ...(args.slots && { slots: args.slots }),
         ...(args.metadata && { metadata: args.metadata }),
-      } as Parameters<typeof contentfulClient.componentType.create>[1],
+      },
     );
 
     return createSuccessResponse('Component type created successfully', {

--- a/packages/mcp-tools/src/tools/exo/component-types/upsertComponentType.ts
+++ b/packages/mcp-tools/src/tools/exo/component-types/upsertComponentType.ts
@@ -14,7 +14,7 @@ import {
   DesignPropertySchema,
   SlotDefinitionSchema,
   TreeNodeSchema,
-  ComponentTypeMetadataSchema,
+  ExoMetadataSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -55,7 +55,7 @@ export const UpsertComponentTypeToolParams = BaseToolSchema.extend({
     .array(SlotDefinitionSchema)
     .optional()
     .describe('Slot definitions; replaces existing if provided'),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExoMetadataSchema.optional().describe(
     'ExO metadata (tags, concepts); replaces existing if provided',
   ),
 });
@@ -114,7 +114,7 @@ export function upsertComponentTypeTool(config: ContentfulConfig) {
       ...(current.dataAssemblies
         ? { dataAssemblies: current.dataAssemblies }
         : {}),
-    } as Parameters<typeof contentfulClient.componentType.upsert>[1]);
+    });
 
     return createSuccessResponse('Component type updated successfully', {
       componentType,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
@@ -8,33 +8,35 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
+import {
+  DataAssemblyParameterConfigSchema,
+  DataAssemblyResolverConfigSchema,
+  DataAssemblyReturnMappingConfigSchema,
+  DataAssemblyDataTypeFieldSchema,
+  DataAssemblyMetadataSchema,
+} from '../../../types/dataAssemblySchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const CreateDataAssemblyToolParams = BaseToolSchema.extend({
   name: z.string().describe('The name of the data assembly'),
   description: z.string().describe('Description of the data assembly'),
-  parameters: z
-    .record(z.unknown())
-    .describe('Parameter definitions keyed by parameter name (may be empty object)'),
-  resolvers: z
-    .record(z.unknown())
-    .describe('Resolver definitions keyed by resolver name (may be empty object)'),
-  return: z
-    .record(z.unknown())
-    .describe('Return mapping configuration specifying how to map resolved data'),
+  parameters: DataAssemblyParameterConfigSchema.describe(
+    'Parameter definitions keyed by parameter name (may be empty object)',
+  ),
+  resolvers: DataAssemblyResolverConfigSchema.describe(
+    'Resolver definitions keyed by resolver name (may be empty object)',
+  ),
+  return: DataAssemblyReturnMappingConfigSchema.describe(
+    'Return mapping configuration specifying how to map resolved data',
+  ),
   dataType: z
-    .array(z.unknown())
+    .array(DataAssemblyDataTypeFieldSchema)
     .describe('Data type field definitions for this data assembly (may be empty array)'),
   variant: z
     .string()
     .optional()
     .describe('Optional variant identifier for this data assembly'),
-  metadata: z
-    .object({
-      tags: z.array(z.unknown()).optional(),
-    })
-    .optional()
-    .describe('Optional metadata (tags)'),
+  metadata: DataAssemblyMetadataSchema.optional().describe('Optional metadata (tags)'),
 });
 
 type Params = z.infer<typeof CreateDataAssemblyToolParams>;
@@ -53,15 +55,15 @@ export function createDataAssemblyTool(config: ContentfulConfig) {
       {
         sys: {
           type: 'DataAssembly',
-          dataType: args.dataType as Parameters<typeof contentfulClient.dataAssembly.create>[1]['sys']['dataType'],
+          dataType: args.dataType,
           ...(args.variant && { variant: args.variant }),
         },
         name: args.name,
         description: args.description,
-        parameters: args.parameters as Parameters<typeof contentfulClient.dataAssembly.create>[1]['parameters'],
-        resolvers: args.resolvers as Parameters<typeof contentfulClient.dataAssembly.create>[1]['resolvers'],
-        return: args.return as Parameters<typeof contentfulClient.dataAssembly.create>[1]['return'],
-        metadata: (args.metadata ?? { tags: [] }) as Parameters<typeof contentfulClient.dataAssembly.create>[1]['metadata'],
+        parameters: args.parameters,
+        resolvers: args.resolvers,
+        return: args.return,
+        metadata: args.metadata ?? { tags: [] },
       },
     );
 

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
@@ -8,6 +8,13 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
+import {
+  DataAssemblyParameterConfigSchema,
+  DataAssemblyResolverConfigSchema,
+  DataAssemblyReturnMappingConfigSchema,
+  DataAssemblyDataTypeFieldSchema,
+  DataAssemblyMetadataSchema,
+} from '../../../types/dataAssemblySchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const UpdateDataAssemblyToolParams = BaseToolSchema.extend({
@@ -22,32 +29,26 @@ export const UpdateDataAssemblyToolParams = BaseToolSchema.extend({
     ),
   name: z.string().optional().describe('The name of the data assembly'),
   description: z.string().optional().describe('Description of the data assembly'),
-  parameters: z
-    .record(z.unknown())
-    .optional()
-    .describe('Parameter definitions; replaces existing if provided'),
-  resolvers: z
-    .record(z.unknown())
-    .optional()
-    .describe('Resolver definitions; replaces existing if provided'),
-  return: z
-    .record(z.unknown())
-    .optional()
-    .describe('Return mapping configuration; replaces existing if provided'),
+  parameters: DataAssemblyParameterConfigSchema.optional().describe(
+    'Parameter definitions; replaces existing if provided',
+  ),
+  resolvers: DataAssemblyResolverConfigSchema.optional().describe(
+    'Resolver definitions; replaces existing if provided',
+  ),
+  return: DataAssemblyReturnMappingConfigSchema.optional().describe(
+    'Return mapping configuration; replaces existing if provided',
+  ),
   dataType: z
-    .array(z.unknown())
+    .array(DataAssemblyDataTypeFieldSchema)
     .optional()
     .describe('Data type field definitions; replaces existing if provided'),
   variant: z
     .string()
     .optional()
     .describe('Optional variant identifier; replaces existing if provided'),
-  metadata: z
-    .object({
-      tags: z.array(z.unknown()).optional(),
-    })
-    .optional()
-    .describe('Metadata (tags); replaces existing if provided'),
+  metadata: DataAssemblyMetadataSchema.optional().describe(
+    'Metadata (tags); replaces existing if provided',
+  ),
 });
 
 type Params = z.infer<typeof UpdateDataAssemblyToolParams>;
@@ -79,14 +80,12 @@ export function updateDataAssemblyTool(config: ContentfulConfig) {
       );
     }
 
-    type UpdatePayload = Parameters<typeof contentfulClient.dataAssembly.update>[1];
-
     const dataAssembly = await contentfulClient.dataAssembly.update(params, {
       sys: {
         id: current.sys.id,
         type: 'DataAssembly',
         version: current.sys.version,
-        dataType: (args.dataType ?? current.sys.dataType) as UpdatePayload['sys']['dataType'],
+        dataType: args.dataType ?? current.sys.dataType,
         ...(args.variant !== undefined
           ? { variant: args.variant }
           : current.sys.variant !== undefined
@@ -95,10 +94,10 @@ export function updateDataAssemblyTool(config: ContentfulConfig) {
       },
       name: args.name ?? current.name,
       description: args.description ?? current.description,
-      parameters: (args.parameters ?? current.parameters) as UpdatePayload['parameters'],
-      resolvers: (args.resolvers ?? current.resolvers) as UpdatePayload['resolvers'],
-      return: (args.return ?? current.return) as UpdatePayload['return'],
-      metadata: (args.metadata ?? current.metadata) as UpdatePayload['metadata'],
+      parameters: args.parameters ?? current.parameters,
+      resolvers: args.resolvers ?? current.resolvers,
+      return: args.return ?? current.return,
+      metadata: args.metadata ?? current.metadata,
     });
 
     return createSuccessResponse('Data assembly updated successfully', {

--- a/packages/mcp-tools/src/tools/exo/experiences/createExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/createExperience.ts
@@ -10,14 +10,17 @@ import {
 } from '../../../utils/tools.js';
 import {
   ViewportSchema,
-  ComponentTypeMetadataSchema,
+  ExperienceMetadataSchema,
+  DimensionedDesignPropertyValueSchema,
+  ExperienceContentBindingsSchema,
+  ExperienceSlotNodeSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
-const ResourceLinkSchema = z.object({
+const TemplateResourceLinkSchema = z.object({
   sys: z.object({
     type: z.literal('ResourceLink'),
-    linkType: z.string().describe('Resource link type (e.g. "Contentful:Template")'),
+    linkType: z.literal('Contentful:Template'),
     urn: z.string().describe('URN of the linked resource'),
   }),
 });
@@ -25,46 +28,28 @@ const ResourceLinkSchema = z.object({
 export const CreateExperienceToolParams = BaseToolSchema.extend({
   name: z.string().describe('The name of the experience'),
   description: z.string().describe('Description of the experience'),
-  template: ResourceLinkSchema.describe(
+  template: TemplateResourceLinkSchema.describe(
     'Resource link to the Template this experience is backed by',
   ),
   viewports: z
     .array(ViewportSchema)
     .describe('Viewport definitions for the experience (may be empty)'),
   designProperties: z
-    .record(z.unknown())
+    .record(z.string(), DimensionedDesignPropertyValueSchema)
     .describe(
       'Design property values keyed by property ID. Each value is a dimensioned map ' +
         '(viewport ID → design value). May be an empty object.',
     ),
-  contentBindings: z
-    .object({
-      sys: z.object({
-        type: z.literal('ResourceLink'),
-        linkType: z.literal('Contentful:DataAssembly'),
-        urn: z.string(),
-      }),
-      parameters: z
-        .record(
-          z.object({
-            sys: z.object({
-              type: z.literal('ResourceLink'),
-              linkType: z.string(),
-              urn: z.string(),
-            }),
-          }),
-        )
-        .describe('Parameter bindings keyed by parameter ID'),
-    })
-    .optional()
-    .describe('Optional content bindings linking this experience to a data assembly'),
+  contentBindings: ExperienceContentBindingsSchema.optional().describe(
+    'Optional content bindings linking this experience to a data assembly',
+  ),
   slots: z
-    .record(z.array(z.unknown()))
+    .record(z.string(), z.array(ExperienceSlotNodeSchema))
     .optional()
     .describe(
       'Optional slot contents keyed by slot ID. Each value is an array of FragmentNode or InlineFragmentNode.',
     ),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExperienceMetadataSchema.optional().describe(
     'Optional ExO metadata (tags, concepts)',
   ),
 });
@@ -91,7 +76,7 @@ export function createExperienceTool(config: ContentfulConfig) {
         ...(args.contentBindings && { contentBindings: args.contentBindings }),
         ...(args.slots && { slots: args.slots }),
         ...(args.metadata && { metadata: args.metadata }),
-      } as Parameters<typeof contentfulClient.experience.create>[1],
+      },
     );
 
     return createSuccessResponse('Experience created successfully', {

--- a/packages/mcp-tools/src/tools/exo/experiences/upsertExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/upsertExperience.ts
@@ -10,7 +10,10 @@ import {
 } from '../../../utils/tools.js';
 import {
   ViewportSchema,
-  ComponentTypeMetadataSchema,
+  ExperienceMetadataSchema,
+  DimensionedDesignPropertyValueSchema,
+  ExperienceContentBindingsSchema,
+  ExperienceSlotNodeSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -31,39 +34,21 @@ export const UpsertExperienceToolParams = BaseToolSchema.extend({
     .optional()
     .describe('Viewport definitions; replaces existing viewports if provided'),
   designProperties: z
-    .record(z.unknown())
+    .record(z.string(), DimensionedDesignPropertyValueSchema)
     .optional()
     .describe(
       'Design property values keyed by property ID; replaces existing if provided',
     ),
-  contentBindings: z
-    .object({
-      sys: z.object({
-        type: z.literal('ResourceLink'),
-        linkType: z.literal('Contentful:DataAssembly'),
-        urn: z.string(),
-      }),
-      parameters: z
-        .record(
-          z.object({
-            sys: z.object({
-              type: z.literal('ResourceLink'),
-              linkType: z.string(),
-              urn: z.string(),
-            }),
-          }),
-        )
-        .describe('Parameter bindings keyed by parameter ID'),
-    })
-    .optional()
-    .describe('Content bindings linking this experience to a data assembly; replaces existing if provided'),
+  contentBindings: ExperienceContentBindingsSchema.optional().describe(
+    'Content bindings linking this experience to a data assembly; replaces existing if provided',
+  ),
   slots: z
-    .record(z.array(z.unknown()))
+    .record(z.string(), z.array(ExperienceSlotNodeSchema))
     .optional()
     .describe(
       'Slot contents keyed by slot ID; replaces existing if provided',
     ),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExperienceMetadataSchema.optional().describe(
     'ExO metadata (tags, concepts); replaces existing if provided',
   ),
 });

--- a/packages/mcp-tools/src/tools/exo/fragments/createFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/createFragment.ts
@@ -8,39 +8,36 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
+import {
+  ViewportSchema,
+  ExperienceMetadataSchema,
+  DimensionedDesignPropertyValueSchema,
+  ExperienceContentBindingsSchema,
+  ExperienceSlotNodeSchema,
+  ComponentTypeResourceLinkSchema,
+} from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const CreateFragmentToolParams = BaseToolSchema.extend({
   name: z.string().describe('The name of the fragment'),
   description: z.string().describe('Description of the fragment'),
-  componentType: z
-    .object({
-      sys: z.object({
-        type: z.literal('ResourceLink'),
-        linkType: z.literal('Contentful:ComponentType'),
-        urn: z.string(),
-      }),
-    })
-    .describe('Resource link to the component type this fragment is based on'),
-  viewports: z.array(z.unknown()).describe('Viewport definitions (may be empty)'),
+  componentType: ComponentTypeResourceLinkSchema.describe(
+    'Resource link to the component type this fragment is based on',
+  ),
+  viewports: z.array(ViewportSchema).describe('Viewport definitions (may be empty)'),
   designProperties: z
-    .record(z.unknown())
+    .record(z.string(), DimensionedDesignPropertyValueSchema)
     .describe('Design property values keyed by property ID (may be empty object)'),
-  contentBindings: z
-    .record(z.unknown())
-    .optional()
-    .describe('Optional content bindings for the fragment'),
+  contentBindings: ExperienceContentBindingsSchema.optional().describe(
+    'Optional content bindings for the fragment',
+  ),
   slots: z
-    .record(z.array(z.unknown()))
+    .record(z.string(), z.array(ExperienceSlotNodeSchema))
     .optional()
     .describe('Optional slot node definitions keyed by slot ID'),
-  metadata: z
-    .object({
-      tags: z.array(z.unknown()).optional(),
-      concepts: z.array(z.unknown()).optional(),
-    })
-    .optional()
-    .describe('Optional ExO metadata (tags, concepts)'),
+  metadata: ExperienceMetadataSchema.optional().describe(
+    'Optional ExO metadata (tags, concepts)',
+  ),
 });
 
 type Params = z.infer<typeof CreateFragmentToolParams>;
@@ -65,7 +62,7 @@ export function createFragmentTool(config: ContentfulConfig) {
         ...(args.contentBindings && { contentBindings: args.contentBindings }),
         ...(args.slots && { slots: args.slots }),
         ...(args.metadata && { metadata: args.metadata }),
-      } as Parameters<typeof contentfulClient.fragment.create>[1],
+      },
     );
 
     return createSuccessResponse('Fragment created successfully', {

--- a/packages/mcp-tools/src/tools/exo/fragments/updateFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/fragments/updateFragment.ts
@@ -8,6 +8,13 @@ import {
   createToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
+import {
+  ViewportSchema,
+  ExperienceMetadataSchema,
+  DimensionedDesignPropertyValueSchema,
+  ExperienceContentBindingsSchema,
+  ExperienceSlotNodeSchema,
+} from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const UpdateFragmentToolParams = BaseToolSchema.extend({
@@ -23,28 +30,23 @@ export const UpdateFragmentToolParams = BaseToolSchema.extend({
   name: z.string().optional().describe('The name of the fragment'),
   description: z.string().optional().describe('Description of the fragment'),
   viewports: z
-    .array(z.unknown())
+    .array(ViewportSchema)
     .optional()
     .describe('Viewport definitions; replaces existing viewports if provided'),
   designProperties: z
-    .record(z.unknown())
+    .record(z.string(), DimensionedDesignPropertyValueSchema)
     .optional()
     .describe('Design property values; replaces existing if provided'),
-  contentBindings: z
-    .record(z.unknown())
-    .optional()
-    .describe('Content bindings; replaces existing if provided'),
+  contentBindings: ExperienceContentBindingsSchema.optional().describe(
+    'Content bindings; replaces existing if provided',
+  ),
   slots: z
-    .record(z.array(z.unknown()))
+    .record(z.string(), z.array(ExperienceSlotNodeSchema))
     .optional()
     .describe('Slot node definitions; replaces existing if provided'),
-  metadata: z
-    .object({
-      tags: z.array(z.unknown()).optional(),
-      concepts: z.array(z.unknown()).optional(),
-    })
-    .optional()
-    .describe('ExO metadata (tags, concepts); replaces existing if provided'),
+  metadata: ExperienceMetadataSchema.optional().describe(
+    'ExO metadata (tags, concepts); replaces existing if provided',
+  ),
 });
 
 type Params = z.infer<typeof UpdateFragmentToolParams>;
@@ -95,7 +97,7 @@ export function updateFragmentTool(config: ContentfulConfig) {
       ...((args.metadata ?? current.metadata)
         ? { metadata: args.metadata ?? current.metadata }
         : {}),
-    } as Parameters<typeof contentfulClient.fragment.upsert>[1]);
+    });
 
     return createSuccessResponse('Fragment updated successfully', {
       fragment,

--- a/packages/mcp-tools/src/tools/exo/templates/createTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/createTemplate.ts
@@ -14,7 +14,7 @@ import {
   DesignPropertySchema,
   SlotDefinitionSchema,
   TreeNodeSchema,
-  ComponentTypeMetadataSchema,
+  ExoMetadataSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -38,7 +38,7 @@ export const CreateTemplateToolParams = BaseToolSchema.extend({
     .array(SlotDefinitionSchema)
     .optional()
     .describe('Optional slot definitions'),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExoMetadataSchema.optional().describe(
     'Optional ExO metadata (tags, concepts)',
   ),
 });
@@ -65,7 +65,7 @@ export function createTemplateTool(config: ContentfulConfig) {
         ...(args.componentTree && { componentTree: args.componentTree }),
         ...(args.slots && { slots: args.slots }),
         ...(args.metadata && { metadata: args.metadata }),
-      } as Parameters<typeof contentfulClient.template.create>[1],
+      },
     );
 
     return createSuccessResponse('Template created successfully', {

--- a/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/templates/upsertTemplate.ts
@@ -14,7 +14,7 @@ import {
   DesignPropertySchema,
   SlotDefinitionSchema,
   TreeNodeSchema,
-  ComponentTypeMetadataSchema,
+  ExoMetadataSchema,
 } from '../../../types/componentTypeSchemas.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -50,7 +50,7 @@ export const UpsertTemplateToolParams = BaseToolSchema.extend({
     .array(SlotDefinitionSchema)
     .optional()
     .describe('Slot definitions; replaces existing if provided'),
-  metadata: ComponentTypeMetadataSchema.optional().describe(
+  metadata: ExoMetadataSchema.optional().describe(
     'ExO metadata (tags, concepts); replaces existing if provided',
   ),
 });
@@ -109,7 +109,7 @@ export function upsertTemplateTool(config: ContentfulConfig) {
       ...(current.dataAssemblies
         ? { dataAssemblies: current.dataAssemblies }
         : {}),
-    } as Parameters<typeof contentfulClient.template.upsert>[1]);
+    });
 
     return createSuccessResponse('Template updated successfully', {
       template,

--- a/packages/mcp-tools/src/types/componentTypeSchemas.ts
+++ b/packages/mcp-tools/src/types/componentTypeSchemas.ts
@@ -1,4 +1,102 @@
 import { z } from 'zod';
+import type { JsonValue, PlainClientAPI } from 'contentful-management';
+
+// CMA.js does not re-export the individual ExO entity Props types
+// (ComponentTypeProps, FragmentProps, etc.) or their nested constituents
+// (ComponentTypeViewport, ComponentTypeDesignProperty, TreeNode, ...) by name
+// from its package root — only the *Collection types make it into the public
+// export surface. To pin these schemas to the canonical shapes anyway, derive
+// them structurally off PlainClientAPI's method signatures, which are exported.
+//
+// Each derived alias is passed through Distribute<T> below, which forces TS to
+// treat it as a distinct nominal type rather than a live indexed-access
+// expression. Without this, combining two indexed-access types derived from the
+// same CMA entity (e.g. ComponentTypeContentProperty + TreeNode, both derived
+// from ComponentTypeEntity) in a single z.object()/extend() call makes tsup's
+// declaration emit fail with TS2742 ("cannot be named without a reference to
+// .../contentful-management/.../entities/component-type.js") — even though
+// each type alone emits fine. Distribute<T> is written as a distributive
+// conditional (`T extends any ? ... : never`) rather than a plain mapped type
+// so it maps over each arm of a union separately, preserving discriminated
+// unions like TreeNode instead of collapsing them to their common keys.
+type Distribute<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;
+
+type ComponentTypeEntity = Awaited<ReturnType<PlainClientAPI['componentType']['get']>>;
+
+export type ComponentTypeViewport = Distribute<ComponentTypeEntity['viewports'][number]>;
+export type ComponentTypeContentProperty = Distribute<
+  ComponentTypeEntity['contentProperties'][number]
+>;
+export type ComponentTypeDesignProperty = Distribute<
+  ComponentTypeEntity['designProperties'][number]
+>;
+export type ComponentTypeSlotDefinition = Distribute<
+  NonNullable<ComponentTypeEntity['slots']>[number]
+>;
+export type TreeNode = Distribute<NonNullable<ComponentTypeEntity['componentTree']>[number]>;
+export type ComponentNode = Extract<TreeNode, { nodeType: 'Component' }>;
+export type FragmentNode = Extract<TreeNode, { nodeType: 'Fragment' }>;
+export type SlotNode = Extract<TreeNode, { nodeType: 'Slot' }>;
+export type ComponentTreeDesignPropertyValue = ComponentNode['designProperties'][string];
+export type ExoMetadataProps = Distribute<NonNullable<ComponentTypeEntity['metadata']>>;
+
+type ExperienceEntity = Awaited<ReturnType<PlainClientAPI['experience']['get']>>;
+export type ExperienceMetadataProps = Distribute<NonNullable<ExperienceEntity['metadata']>>;
+export type ExperienceContentBindings = Distribute<
+  NonNullable<ExperienceEntity['contentBindings']>
+>;
+export type ExperienceSlotNode = Distribute<
+  NonNullable<ExperienceEntity['slots']>[string][number]
+>;
+export type InlineFragmentNode = Extract<ExperienceSlotNode, { nodeType: 'InlineFragment' }>;
+
+// DataTypeDefinition is the bare recursive type ComponentTypeContentProperty extends
+// (id/name/required/defaultValue are added on top) — recover it via the nested
+// Array/Record arms, which reference the bare type for `items`/`fields` values.
+export type DataTypeDefinition = Extract<ComponentTypeContentProperty, { type: 'Array' }>['items'];
+export type PrimitiveDataTypeDefinition = Extract<
+  DataTypeDefinition,
+  { type: 'String' | 'Number' | 'Integer' | 'Boolean' }
+>;
+export type RichTextDataTypeDefinition = Extract<DataTypeDefinition, { type: 'RichText' }>;
+export type ArrayDataTypeDefinition = Extract<DataTypeDefinition, { type: 'Array' }>;
+export type RecordDataTypeDefinition = Extract<DataTypeDefinition, { type: 'Record' }>;
+export type TypeRefDataTypeDefinition = Extract<DataTypeDefinition, { type: 'TypeRef' }>;
+export type LiteralDataTypeDefinition = Extract<DataTypeDefinition, { type: 'Literal' }>;
+export type DiscriminatedUnionDataTypeDefinition = Extract<
+  DataTypeDefinition,
+  { type: 'DiscriminatedUnion' }
+>;
+
+export type StringDesignProperty = Extract<ComponentTypeDesignProperty, { type: 'String' }>;
+export type BooleanDesignProperty = Extract<ComponentTypeDesignProperty, { type: 'Boolean' }>;
+export type TokenBackedDesignProperty = Exclude<
+  ComponentTypeDesignProperty,
+  StringDesignProperty | BooleanDesignProperty
+>;
+
+// ── Resource / entity links ───────────────────────────────────────────────────
+
+const resourceLinkSchema = <T extends string>(linkType: T) =>
+  z.object({
+    sys: z.object({
+      type: z.literal('ResourceLink'),
+      linkType: z.literal(linkType),
+      urn: z.string().describe('URN of the linked resource'),
+    }),
+  });
+
+const linkSchema = <T extends string>(linkType: T) =>
+  z.object({
+    sys: z.object({
+      type: z.literal('Link'),
+      linkType: z.literal(linkType),
+      id: z.string(),
+    }),
+  });
+
+export const ComponentTypeResourceLinkSchema = resourceLinkSchema('Contentful:ComponentType');
+export const FragmentResourceLinkSchema = resourceLinkSchema('Contentful:Fragment');
 
 // ── Viewport ──────────────────────────────────────────────────────────────────
 // Matches CMA.js ComponentTypeViewport
@@ -8,166 +106,349 @@ export const ViewportSchema = z.object({
   query: z.string().describe('CSS media query string'),
   displayName: z.string().describe('Human-readable viewport name'),
   previewSize: z.string().describe('Preview size (e.g. "1024px")'),
-});
+}) satisfies z.ZodType<ComponentTypeViewport>;
+
+// ── Data type definition ──────────────────────────────────────────────────────
+// Matches CMA.js DataTypeDefinition — a discriminated union keyed on `type`.
+// Declared with z.lazy so the recursive Array/Record/DiscriminatedUnion arms
+// can close over the binding before it is fully initialised.
+
+export const DataTypeDefinitionSchema: z.ZodType<DataTypeDefinition> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    z.object({
+      type: z.enum(['String', 'Number', 'Integer', 'Boolean']),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+    }) satisfies z.ZodType<PrimitiveDataTypeDefinition>,
+    z.object({
+      type: z.literal('RichText'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+    }) satisfies z.ZodType<RichTextDataTypeDefinition>,
+    z.object({
+      type: z.literal('Array'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+      items: DataTypeDefinitionSchema,
+    }) satisfies z.ZodType<ArrayDataTypeDefinition>,
+    z.object({
+      type: z.literal('Record'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+      fields: z.record(z.string(), DataTypeDefinitionSchema),
+    }) satisfies z.ZodType<RecordDataTypeDefinition>,
+    z.object({
+      type: z.literal('TypeRef'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+      ref: z.object({
+        sys: z.object({
+          type: z.literal('ResourceLink'),
+          linkType: z.string(),
+          urn: z.string(),
+        }),
+      }),
+    }) satisfies z.ZodType<TypeRefDataTypeDefinition>,
+    z.object({
+      type: z.literal('Literal'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+      value: z.custom<JsonValue>().describe('JSON literal value'),
+      valueType: DataTypeDefinitionSchema,
+    }) satisfies z.ZodType<LiteralDataTypeDefinition>,
+    z.object({
+      type: z.literal('DiscriminatedUnion'),
+      name: z.string().optional(),
+      required: z.boolean().optional(),
+      discriminator: z.string(),
+      members: z.array(DataTypeDefinitionSchema),
+    }) satisfies z.ZodType<DiscriminatedUnionDataTypeDefinition>,
+  ]),
+);
 
 // ── Content property ──────────────────────────────────────────────────────────
-// Matches CMA.js ComponentTypeContentProperty
+// Matches CMA.js ComponentTypeContentProperty = DataTypeDefinition & {id, name, required, defaultValue?}
 
-export const ContentPropertySchema = z.object({
-  id: z.string().describe('Content property identifier'),
-  name: z.string().describe('Human-readable name'),
-  type: z
-    .string()
-    .describe('Property type (e.g. "String", "Number", "Boolean")'),
-  required: z.boolean().describe('Whether the property is required'),
-  defaultValue: z.unknown().optional().describe('Default value'),
-});
+export const ContentPropertySchema = z.intersection(
+  DataTypeDefinitionSchema,
+  z.object({
+    id: z.string().describe('Content property identifier'),
+    name: z.string().describe('Human-readable name'),
+    required: z.boolean().describe('Whether the property is required'),
+    defaultValue: z.unknown().optional().describe('Default value'),
+  }),
+) satisfies z.ZodType<ComponentTypeContentProperty>;
 
 // ── Design property ───────────────────────────────────────────────────────────
-// Matches CMA.js ComponentTypeDesignProperty
+// Matches CMA.js ComponentTypeDesignProperty = StringDesignProperty | BooleanDesignProperty | TokenBackedDesignProperty
 
-const DesignPropertyValidationSchema = z.object({
-  value: z
-    .union([z.string(), z.number(), z.boolean()])
-    .describe('Allowed value'),
-  name: z.string().describe('Display name for the value'),
+const DTCG_DESIGN_PROPERTY_TYPES = [
+  'DTCG.Color',
+  'DTCG.Dimension',
+  'DTCG.FontFamily',
+  'DTCG.FontWeight',
+  'DTCG.Duration',
+  'DTCG.CubicBezier',
+  'DTCG.Number',
+  'DTCG.StrokeStyle',
+  'DTCG.Border',
+  'DTCG.Transition',
+  'DTCG.Shadow',
+  'DTCG.Gradient',
+  'DTCG.Typography',
+] as const;
+
+const DesignPropertyCommonFieldsSchema = z.object({
+  id: z.string().describe('Design property identifier'),
+  name: z.string().describe('Human-readable name'),
   description: z.string().optional().describe('Optional description'),
 });
 
-export const DesignPropertySchema = z.object({
-  id: z.string().describe('Design property identifier'),
-  name: z.string().describe('Human-readable name'),
-  type: z
-    .string()
-    .describe('Property type (e.g. "Symbol", "Number", "Boolean")'),
-  required: z.boolean().describe('Whether the property is required'),
-  description: z.string().optional().describe('Description of the property'),
-  defaultValue: z.unknown().optional().describe('Default value'),
-  validations: z
+const StringDesignPropertySchema = DesignPropertyCommonFieldsSchema.extend({
+  type: z.literal('String'),
+  fallbackValue: z
     .object({
-      in: z
-        .array(DesignPropertyValidationSchema)
-        .describe('Enumerated allowed values'),
+      type: z.literal('ManualDesignValue'),
+      value: z.string(),
     })
     .optional()
-    .describe('Value constraints'),
-  designTokenSet: z
-    .array(z.string())
+    .describe('Manual fallback value for this design property'),
+  validations: z
+    .array(
+      z.object({
+        regexp: z.object({
+          pattern: z.string().describe('Regular expression pattern'),
+        }),
+      }),
+    )
     .optional()
-    .describe('Design token set IDs'),
+    .describe('Regexp validations constraining allowed string values'),
+}) satisfies z.ZodType<StringDesignProperty>;
+
+const BooleanDesignPropertySchema = DesignPropertyCommonFieldsSchema.extend({
+  type: z.literal('Boolean'),
+  fallbackValue: z
+    .object({
+      type: z.literal('ManualDesignValue'),
+      value: z.boolean(),
+    })
+    .optional()
+    .describe('Manual fallback value for this design property'),
+}) satisfies z.ZodType<BooleanDesignProperty>;
+
+const DesignTokenValueSchema = z.object({
+  type: z.literal('DesignToken'),
+  value: z.string().min(1).describe('Design token reference (non-empty)'),
 });
 
+const TokenBackedDesignPropertySchema = DesignPropertyCommonFieldsSchema.extend({
+  type: z.enum(DTCG_DESIGN_PROPERTY_TYPES),
+  fallbackValue: DesignTokenValueSchema.optional().describe(
+    'Design-token-backed fallback value for this design property',
+  ),
+  allowedResources: z
+    .array(
+      z.object({
+        type: z.literal('DesignToken'),
+        value: z.string(),
+        name: z.string().optional(),
+      }),
+    )
+    .optional()
+    .describe('Allowed design token resources'),
+}) satisfies z.ZodType<TokenBackedDesignProperty>;
+
+export const DesignPropertySchema = z.union([
+  StringDesignPropertySchema,
+  BooleanDesignPropertySchema,
+  TokenBackedDesignPropertySchema,
+]) satisfies z.ZodType<ComponentTypeDesignProperty>;
+
+// ── Design property values (used in component tree / experience payloads) ────
+// Matches CMA.js ManualDesignValue | DesignTokenValue, and the pointer/dimensioned wrappers
+
+const ManualDesignValueSchema = z.object({
+  type: z.literal('ManualDesignValue'),
+  value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+export const DesignPropertyValueSchema = z.union([
+  ManualDesignValueSchema,
+  DesignTokenValueSchema,
+]);
+
+// CMA types this as a template-literal type (`$designProperties/${string}`),
+// which z.string() alone can't satisfy at the type level even though it
+// validates the same values at runtime — z.custom<T>() lets us pin the exact
+// branded type while still validating with a plain regex (no z.templateLiteral
+// dependency, which would require zod v4).
+export const DesignPropertyPointerValueSchema = z.custom<`$designProperties/${string}`>(
+  (val) => typeof val === 'string' && /^\$designProperties\//.test(val),
+  { message: 'Must be a "$designProperties/..." pointer' },
+);
+
+export const DimensionedDesignPropertyValueSchema = z.record(
+  z.string(),
+  DesignPropertyValueSchema,
+);
+
+export const ComponentTreeDesignPropertyValueSchema = z.union([
+  DesignPropertyValueSchema,
+  DesignPropertyPointerValueSchema,
+  DimensionedDesignPropertyValueSchema,
+]) satisfies z.ZodType<ComponentTreeDesignPropertyValue>;
+
 // ── Slot definition ───────────────────────────────────────────────────────────
-// Matches CMA.js ComponentTypeSlotDefinition
+// Matches CMA.js ComponentTypeSlotDefinition — allowed children are constrained
+// via allowedResources, not a bare component type ID array.
+
+export const COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE =
+  'crn:contentful:::experience:spaces/$self/environments/$self' as const;
 
 export const SlotDefinitionSchema = z.object({
   id: z.string().describe('Slot identifier'),
   name: z.string().describe('Human-readable name'),
-  componentTypeId: z
-    .array(z.string())
-    .describe('IDs of component types allowed in this slot'),
   required: z.boolean().describe('Whether the slot must be filled'),
-  validations: z.array(z.unknown()).describe('Slot validations'),
-});
+  validations: z
+    .array(
+      z.object({
+        size: z
+          .object({
+            min: z.number().optional(),
+            max: z.number().optional(),
+          })
+          .optional(),
+      }),
+    )
+    .describe('Slot cardinality validations'),
+  allowedResources: z
+    .array(
+      z.object({
+        type: z.literal('Contentful:ComponentType'),
+        source: z.literal(COMPONENT_TYPE_ALLOWED_RESOURCE_SOURCE),
+        allowedTypes: z
+          .array(z.string())
+          .describe('IDs of component types allowed in this slot'),
+      }),
+    )
+    .optional()
+    .describe('Constrains which component types may be placed in this slot'),
+}) satisfies z.ZodType<ComponentTypeSlotDefinition>;
 
 // ── Component tree ────────────────────────────────────────────────────────────
-// Matches CMA.js TreeNode = ComponentNode | ViewNode | SlotNode
-// Both ComponentNodeSchema and TreeNodeSchema use z.lazy so neither
-// callback runs at declaration time, allowing mutual recursion.
+// Matches CMA.js TreeNode = ComponentNode | FragmentNode | SlotNode
+// All three schemas use z.lazy so none of the callbacks run at declaration
+// time, allowing the mutual recursion between TreeNodeSchema and ComponentNodeSchema.
 
-export type ComponentNode = {
-  id: string;
-  nodeType: 'Component';
-  componentTypeId: string;
-  contentProperties: Record<string, unknown>;
-  designProperties: Record<string, unknown>;
-  slots: Record<string, TreeNode[]>;
-  contentBindings?: string;
-};
-
-export type ViewNode = {
-  id: string;
-  nodeType: 'View';
-  viewId: string;
-};
-
-export type SlotNode = {
-  id: string;
-  nodeType: 'Slot';
-  slotId: string;
-};
-
-export type TreeNode = ComponentNode | ViewNode | SlotNode;
-
-const ViewNodeSchema = z.object({
+const FragmentNodeSchema = z.object({
   id: z.string().describe('Node identifier'),
-  nodeType: z.literal('View').describe('Must be "View"'),
-  viewId: z.string().describe('ID of the referenced view'),
-});
+  name: z.string().optional().describe('Optional display name'),
+  nodeType: z.literal('Fragment').describe('Must be "Fragment"'),
+  fragment: FragmentResourceLinkSchema.describe('Resource link to the referenced fragment'),
+}) satisfies z.ZodType<FragmentNode>;
 
 const SlotNodeSchema = z.object({
   id: z.string().describe('Node identifier'),
   nodeType: z.literal('Slot').describe('Must be "Slot"'),
   slotId: z.string().describe('ID of the slot definition to render'),
-});
+}) satisfies z.ZodType<SlotNode>;
 
 // Declared before ComponentNodeSchema so z.lazy inside ComponentNodeSchema
 // can close over the binding. Both use z.lazy so neither callback fires
 // until parse time, by which point both variables are fully initialised.
 export const TreeNodeSchema: z.ZodType<TreeNode> = z.lazy(() =>
-  z.union([ComponentNodeSchema, ViewNodeSchema, SlotNodeSchema]),
+  z.union([ComponentNodeSchema, FragmentNodeSchema, SlotNodeSchema]),
 );
 
 const ComponentNodeSchema: z.ZodType<ComponentNode> = z.lazy(() =>
   z.object({
     id: z.string().describe('Node identifier'),
+    name: z.string().optional().describe('Optional display name'),
     nodeType: z.literal('Component').describe('Must be "Component"'),
-    componentTypeId: z
-      .string()
-      .describe('ID of the component type to render'),
+    componentType: ComponentTypeResourceLinkSchema.describe(
+      'Resource link to the component type to render',
+    ),
     contentProperties: z
-      .record(z.unknown())
+      .union([
+        z.record(z.string(), z.unknown()),
+        z.string().describe('"$contentProperties/..." pointer'),
+      ])
       .describe(
         'Content property bindings — values or "$contentProperties/..." pointers',
       ),
     designProperties: z
-      .record(z.unknown())
+      .record(z.string(), ComponentTreeDesignPropertyValueSchema)
       .describe(
         'Design property values — ManualDesignValue, DesignTokenValue, or "$designProperties/..." pointers',
       ),
     slots: z
-      .record(z.array(TreeNodeSchema))
+      .record(z.string(), z.array(TreeNodeSchema))
       .describe('Child tree nodes keyed by slot ID'),
-    contentBindings: z
-      .string()
-      .optional()
-      .describe('Content bindings reference'),
   }),
 );
 
 // ── Metadata ──────────────────────────────────────────────────────────────────
-// Matches CMA.js MetadataProps (tags: Link<'Tag'>[], concepts?: Link<'TaxonomyConcept'>[])
+// CMA.js has two metadata shapes for ExO entities:
+// - ExoMetadataProps {tags?, concepts?} for ComponentType / Template
+// - ExperienceMetadataProps {tags?, concepts?, name?} for Experience / Fragment
 
-const TagLinkSchema = z.object({
-  sys: z.object({
-    type: z.literal('Link'),
-    linkType: z.literal('Tag'),
-    id: z.string().describe('Tag ID'),
-  }),
-});
+const TagLinkSchema = linkSchema('Tag');
+const ConceptLinkSchema = linkSchema('TaxonomyConcept');
 
-const ConceptLinkSchema = z.object({
-  sys: z.object({
-    type: z.literal('Link'),
-    linkType: z.literal('TaxonomyConcept'),
-    id: z.string().describe('Taxonomy concept ID'),
-  }),
-});
-
-export const ComponentTypeMetadataSchema = z.object({
-  tags: z.array(TagLinkSchema).describe('Tags attached to this component type'),
+export const ExoMetadataSchema = z.object({
+  tags: z.array(TagLinkSchema).optional().describe('Tags attached to this entity'),
   concepts: z
     .array(ConceptLinkSchema)
     .optional()
-    .describe('Taxonomy concepts attached to this component type'),
-});
+    .describe('Taxonomy concepts attached to this entity'),
+}) satisfies z.ZodType<ExoMetadataProps>;
+
+export const ExperienceMetadataSchema = ExoMetadataSchema.extend({
+  name: z.string().optional().describe('Variant label for this metadata entry'),
+}) satisfies z.ZodType<ExperienceMetadataProps>;
+
+// ── Experience content bindings / slots ───────────────────────────────────────
+// Matches CMA.js ExperienceContentBindings and the Experience `slots` map,
+// whose entries are Array<FragmentNode | InlineFragmentNode>.
+
+export const DataAssemblyResourceLinkSchema = resourceLinkSchema('Contentful:DataAssembly');
+
+export const ExperienceContentBindingsSchema = z.object({
+  sys: DataAssemblyResourceLinkSchema.shape.sys,
+  parameters: z
+    .record(
+      z.string(),
+      z.object({
+        sys: z.object({
+          type: z.literal('ResourceLink'),
+          linkType: z.string(),
+          urn: z.string(),
+        }),
+      }),
+    )
+    .describe('Parameter bindings keyed by parameter ID'),
+}) satisfies z.ZodType<ExperienceContentBindings>;
+
+export const InlineFragmentNodeSchema: z.ZodType<InlineFragmentNode> = z.lazy(() =>
+  z.object({
+    id: z.string().describe('Node identifier'),
+    nodeType: z.literal('InlineFragment').describe('Must be "InlineFragment"'),
+    componentType: ComponentTypeResourceLinkSchema.describe(
+      'Resource link to the component type this inline fragment renders',
+    ),
+    designProperties: z
+      .record(z.string(), DimensionedDesignPropertyValueSchema)
+      .describe('Design property values for this inline fragment'),
+    contentBindings: ExperienceContentBindingsSchema.optional().describe(
+      'Optional content bindings linking this inline fragment to a data assembly',
+    ),
+    slots: z
+      .record(z.string(), z.array(ExperienceSlotNodeSchema))
+      .optional()
+      .describe('Child slot contents keyed by slot ID'),
+  }),
+);
+
+export const ExperienceSlotNodeSchema: z.ZodType<ExperienceSlotNode> = z.lazy(() =>
+  z.union([FragmentNodeSchema, InlineFragmentNodeSchema]),
+);

--- a/packages/mcp-tools/src/types/dataAssemblySchemas.ts
+++ b/packages/mcp-tools/src/types/dataAssemblySchemas.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod';
+import type { JsonValue, PlainClientAPI, PointerExpressionValue } from 'contentful-management';
+
+// See componentTypeSchemas.ts for why derived types are wrapped in Distribute<T>
+// (a distributive mapped type) before being used in a z.ZodType<T> annotation —
+// it avoids TS2742 "not portable" declaration-emit failures when combining
+// types derived from the same CMA entity in one z.object()/extend() call.
+type Distribute<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;
+
+type DataAssemblyEntity = Awaited<ReturnType<PlainClientAPI['dataAssembly']['get']>>;
+
+export type DataAssemblyDataTypeField = Distribute<
+  DataAssemblyEntity['sys']['dataType'][number]
+>;
+export type LegacyDataAssemblyDataTypeField = Extract<
+  DataAssemblyDataTypeField,
+  { source?: string; ref?: unknown }
+>;
+export type CanonicalDataAssemblyDataTypeField = Exclude<
+  DataAssemblyDataTypeField,
+  LegacyDataAssemblyDataTypeField
+>;
+
+export type DataAssemblyParameterConfig = Distribute<DataAssemblyEntity['parameters']>;
+export type DataAssemblyResourceLinkParameter = Distribute<
+  DataAssemblyParameterConfig[string]
+>;
+
+export type DataAssemblyResolverConfig = Distribute<DataAssemblyEntity['resolvers']>;
+export type DataAssemblyResolverDefinition = Distribute<DataAssemblyResolverConfig[string]>;
+export type DataAssemblyGraphQLResolver = Extract<
+  DataAssemblyResolverDefinition,
+  { source: 'Contentful:GraphQL' }
+>;
+export type DataAssemblyNestedResolver = Extract<
+  DataAssemblyResolverDefinition,
+  { source: 'Contentful:DataAssembly' }
+>;
+
+export type DataAssemblyMetadata = Distribute<DataAssemblyEntity['metadata']>;
+
+// ── Pointer expressions ───────────────────────────────────────────────────────
+// Matches CMA.js PointerExpressionValue — used by resolver `parameters` and the
+// data assembly `return` mapping. Recursive, so declared with z.lazy.
+
+export const PointerExpressionValueSchema: z.ZodType<PointerExpressionValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.object({
+      $from: z.union([
+        z.string(),
+        z.object({
+          source: z.string(),
+          select: PointerExpressionValueSchema.optional(),
+        }),
+      ]),
+    }),
+    z.object({ $literal: z.custom<JsonValue>() }),
+    z.object({ $object: z.record(z.string(), PointerExpressionValueSchema) }),
+    z.object({
+      $on: z.object({
+        type: z.record(z.string(), PointerExpressionValueSchema),
+        default: PointerExpressionValueSchema.optional(),
+      }),
+    }),
+    z.record(z.string(), PointerExpressionValueSchema),
+  ]),
+);
+
+// ── Data type field ────────────────────────────────────────────────────────────
+// Matches CMA.js DataAssemblyDataTypeField = CanonicalDataAssemblyDataTypeField
+// (DataTypeDefinition & {id, name}) | LegacyDataAssemblyDataTypeField (permissive
+// pre-cutover shape, kept for backward compatibility with existing records).
+
+const CanonicalDataTypeArmSchema = z.object({
+  type: z.enum([
+    'String',
+    'Number',
+    'Integer',
+    'Boolean',
+    'RichText',
+    'Array',
+    'Record',
+    'TypeRef',
+    'Literal',
+    'DiscriminatedUnion',
+  ]),
+  id: z.string().describe('Data type field identifier'),
+  name: z.string().describe('Human-readable name'),
+  required: z.boolean().optional(),
+}).catchall(z.unknown());
+
+const LegacyDataTypeArmSchema = z.object({
+  id: z.string().describe('Data type field identifier'),
+  name: z.string().describe('Human-readable name'),
+  type: z.string(),
+  required: z.boolean().optional(),
+  source: z.string().optional(),
+  ref: z.unknown().optional(),
+}) satisfies z.ZodType<LegacyDataAssemblyDataTypeField>;
+
+export const DataAssemblyDataTypeFieldSchema = z.union([
+  CanonicalDataTypeArmSchema,
+  LegacyDataTypeArmSchema,
+]) satisfies z.ZodType<DataAssemblyDataTypeField>;
+
+// ── Parameters ─────────────────────────────────────────────────────────────────
+// Matches CMA.js DataAssemblyResourceLinkParameter — the only parameter shape
+// CMA currently models (a ResourceLink-typed input constrained to same-space entries).
+
+export const SAME_SPACE_CONTENT_SOURCE =
+  'crn:contentful:::content:spaces/$self/environments/$self' as const;
+
+export const DataAssemblyResourceLinkParameterSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  type: z.literal('ResourceLink'),
+  linkType: z.literal('Contentful:Entry'),
+  allowedResources: z.array(
+    z.object({
+      type: z.literal('Contentful:Entry'),
+      source: z.literal(SAME_SPACE_CONTENT_SOURCE),
+      allowedTypes: z.array(z.string()),
+    }),
+  ),
+}) satisfies z.ZodType<DataAssemblyResourceLinkParameter>;
+
+export const DataAssemblyParameterConfigSchema = z.record(
+  z.string(),
+  DataAssemblyResourceLinkParameterSchema,
+) satisfies z.ZodType<DataAssemblyParameterConfig>;
+
+// ── Resolvers ──────────────────────────────────────────────────────────────────
+// Matches CMA.js DataAssemblyResolverDefinition = GraphQL | NestedDataAssembly resolver
+
+export const DataAssemblyGraphQLResolverSchema = z.object({
+  source: z.literal('Contentful:GraphQL'),
+  query: z.string().describe('GraphQL query string'),
+  parameters: PointerExpressionValueSchema.optional(),
+}) satisfies z.ZodType<DataAssemblyGraphQLResolver>;
+
+export const DataAssemblyNestedResolverSchema = z.object({
+  source: z.literal('Contentful:DataAssembly'),
+  dataAssembly: z.object({
+    sys: z.object({
+      type: z.literal('ResourceLink'),
+      linkType: z.literal('Contentful:DataAssembly'),
+      urn: z.string(),
+    }),
+  }),
+  parameters: PointerExpressionValueSchema.optional(),
+}) satisfies z.ZodType<DataAssemblyNestedResolver>;
+
+export const DataAssemblyResolverDefinitionSchema = z.union([
+  DataAssemblyGraphQLResolverSchema,
+  DataAssemblyNestedResolverSchema,
+]) satisfies z.ZodType<DataAssemblyResolverDefinition>;
+
+export const DataAssemblyResolverConfigSchema = z.record(
+  z.string(),
+  DataAssemblyResolverDefinitionSchema,
+) satisfies z.ZodType<DataAssemblyResolverConfig>;
+
+// ── Return mapping ─────────────────────────────────────────────────────────────
+// Matches CMA.js DataAssemblyReturnMappingConfig = PointerExpressionValue
+
+export const DataAssemblyReturnMappingConfigSchema = PointerExpressionValueSchema;
+
+// ── Metadata ───────────────────────────────────────────────────────────────────
+// Matches CMA.js DataAssemblyCommonProps.metadata = Pick<MetadataProps, 'tags'>
+
+export const DataAssemblyMetadataSchema = z.object({
+  tags: z.array(
+    z.object({
+      sys: z.object({
+        type: z.literal('Link'),
+        linkType: z.literal('Tag'),
+        id: z.string(),
+      }),
+    }),
+  ),
+}) satisfies z.ZodType<DataAssemblyMetadata>;


### PR DESCRIPTION
## Summary
- The Zod schemas for the 5 ExO entity groups (component-types, templates, experiences, fragments, data-assemblies) were hand-written and had drifted from `contentful-management`'s actual types — `componentTree` nodes used a bogus `View` node instead of CMA's `Fragment` arm, `componentType` was a bare string ID instead of a `ResourceLink`, design properties were a flat shape instead of CMA's discriminated union, and several create/upsert call sites papered over the mismatch with `as Parameters<...>[1]` casts
- `contentful-management` doesn't re-export the individual ExO Props types by name from its package root, so each schema type is derived structurally off `PlainClientAPI`'s method signatures instead (via a `Distribute<T>` helper that keeps the derived type nominal for tsup's declaration-emit step)
- Data assemblies previously had no real validation (`parameters`/`resolvers`/`return` were all `z.unknown()`); new `dataAssemblySchemas.ts` models CMA's `PointerExpressionValue` and resolver union (GraphQL | nested data assembly) precisely
- Schemas stay zod v3-compatible — no version bump needed. (An earlier version of this PR bumped zod to v4 as a prerequisite for importing two GitHub-Packages-only schema packages directly; that approach was dropped after discovering those packages have no public-npm publish path, which would have broken `npx`/public-npm installs for external users. This PR instead derives schemas from `contentful-management`, which is already a public dependency.)
- Removes every `as Parameters<...>[1]` cast in the touched create/upsert tool files; the payloads now typecheck against CMA's real method signatures without one

## Test plan
- [x] `nx run mcp-tools:build` — build + DTS generation succeeds
- [x] `nx run mcp-tools:test` — 606/606 tests passing
- [x] `nx run mcp-tools:lint` — clean (0 errors, pre-existing warnings only)
- [x] Runtime `safeParse` sanity checks confirm schemas accept CMA's real shapes (e.g. `Fragment` tree nodes, `ResourceLink` component-type refs, `InlineFragmentNode` in experience slots, GraphQL data-assembly resolvers) and reject the old bogus/loose ones (`View` nodes, bare-string component types, unknown resolver sources)

Generated with [Claude Code](https://claude.com/claude-code)