### PR TITLE
ci: add branch-triggered prerelease publishing for mcp-tools

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -95,11 +95,14 @@ jobs:
 
       - name: NX Prerelease
         # Top-level `nx release` (not the `version` subcommand) so the existing
-        # top-level `release.git` config in nx.json is honored: it commits, tags,
-        # and pushes the prerelease back to `next`, and creates a GitHub Release —
-        # exactly as the fleet does for prerelease channels. Releases all workspace
-        # packages together (see header) so mcp-server isn't left as a stable
-        # version pinned to a prerelease mcp-tools.
-        run: npx nx release prerelease --preid next -y
+        # top-level `release.git` config in nx.json is honored: it commits and
+        # tags the prerelease, and creates a GitHub Release — exactly as the
+        # fleet does for prerelease channels. `--push` is required explicitly:
+        # nx.json's release.git has no `push` field, which defaults to false, so
+        # without this flag the commit/tag stay local to the runner and the next
+        # push to `next` can't resolve the current version from git tags.
+        # Releases all workspace packages together (see header) so mcp-server
+        # isn't left as a stable version pinned to a prerelease mcp-tools.
+        run: npx nx release prerelease --preid next --push -y
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 name: prerelease
 
-# Publishes prerelease builds of the workspace packages (currently just
-# @contentful/mcp-tools) to GitHub Packages under the `next` dist-tag.
+# Publishes prerelease builds of the workspace packages (@contentful/mcp-tools
+# and @contentful/mcp-server) to GitHub Packages under the `next` dist-tag.
 #
 # Model: branch-triggered, mirroring the SDK fleet (e.g. contentful-management.js
 # publishes prereleases by pushing to its `beta`/`canary`/`dev` branches). Here a
@@ -9,8 +9,15 @@ name: prerelease
 # resolves the current version from the latest git tag, so each push to `next`
 # increments the prerelease counter (…-next.0 → …-next.1 → …).
 #
+# Both packages are released together (not scoped to mcp-tools): mcp-server
+# depends on mcp-tools, so scoping the release would leave mcp-server with a
+# STABLE bump pinned to a prerelease dependency. Releasing both makes mcp-server
+# a prerelease too (…-next.N), keeping versions self-consistent. This is safe for
+# the stable release line because nx's releaseTag.strictPreid (default true)
+# makes the stable path (`nx release` with no --preid) ignore `-next` tags.
+#
 # The `next` dist-tag is set via ~/.npmrc so `nx release` publishes under it and
-# never moves `latest`. Consumers install with `@contentful/mcp-tools@next`.
+# never moves `latest`. Consumers install with `@contentful/<pkg>@next`.
 
 on:
   push:
@@ -90,7 +97,9 @@ jobs:
         # Top-level `nx release` (not the `version` subcommand) so the existing
         # top-level `release.git` config in nx.json is honored: it commits, tags,
         # and pushes the prerelease back to `next`, and creates a GitHub Release —
-        # exactly as the fleet does for prerelease channels. Scoped to mcp-tools.
-        run: npx nx release prerelease --preid next --projects mcp-tools -y
+        # exactly as the fleet does for prerelease channels. Releases all workspace
+        # packages together (see header) so mcp-server isn't left as a stable
+        # version pinned to a prerelease mcp-tools.
+        run: npx nx release prerelease --preid next -y
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,96 @@
+name: prerelease
+
+# Publishes prerelease builds of the workspace packages (currently just
+# @contentful/mcp-tools) to GitHub Packages under the `next` dist-tag.
+#
+# Model: branch-triggered, mirroring the SDK fleet (e.g. contentful-management.js
+# publishes prereleases by pushing to its `beta`/`canary`/`dev` branches). Here a
+# push to the long-lived `next` branch cuts a `X.Y.Z-next.N` prerelease. Nx
+# resolves the current version from the latest git tag, so each push to `next`
+# increments the prerelease counter (…-next.0 → …-next.1 → …).
+#
+# The `next` dist-tag is set via ~/.npmrc so `nx release` publishes under it and
+# never moves `latest`. Consumers install with `@contentful/mcp-tools@next`.
+
+on:
+  push:
+    branches:
+      - next
+
+concurrency:
+  group: prerelease-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: 'Retrieve Secrets from Vault'
+        id: vault
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            secret/data/github/github_packages_read GITHUB_PACKAGES_READ_TOKEN | GITHUB_PACKAGES_READ_TOKEN;
+            secret/data/github/github_packages_write GITHUB_PACKAGES_WRITE_TOKEN | GITHUB_PACKAGES_WRITE_TOKEN;
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN ;
+
+      - name: Get User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/contentful-automation[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+
+      - name: Setting up Git User Credentials
+        run: |
+          git config --global user.name 'contentful-automation[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+contentful-automation[bot]@users.noreply.github.com'
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        # Unlike the stable release job, a prerelease run has no build cache to
+        # restore, so build here: nx-release-publish only dependsOn ^build.
+        run: npm run build
+
+      - name: Setup npmrc file
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}" > ~/.npmrc
+          echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          # Publish under the `next` dist-tag so `latest` is never moved by a
+          # prerelease. nx's publish executor reads this via `npm config get tag`.
+          echo "tag=next" >> ~/.npmrc
+
+      - uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # sets NX_BASE, NX_HEAD env vars
+
+      - name: NX Prerelease
+        # Top-level `nx release` (not the `version` subcommand) so the existing
+        # top-level `release.git` config in nx.json is honored: it commits, tags,
+        # and pushes the prerelease back to `next`, and creates a GitHub Release —
+        # exactly as the fleet does for prerelease channels. Scoped to mcp-tools.
+        run: npx nx release prerelease --preid next --projects mcp-tools -y
+        env:
+          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/prerelease.yml` — a branch-triggered workflow that publishes prerelease builds of the workspace packages (`@contentful/mcp-tools` **and** `@contentful/mcp-server`) to GitHub Packages under the **`next`** dist-tag.

Pushing to a long-lived **`next`** branch runs `npx nx release prerelease --preid next -y`, producing `X.Y.Z-next.N` (e.g. `mcp-tools@0.12.3-next.0`, `mcp-server@1.12.4-next.0`). nx resolves each base version from the latest stable git tag, so each push to `next` increments the prerelease counter.

## Why

The remote MCP server needs to install a pre-merge build of `@contentful/mcp-tools` (carrying the newly-exported instruction constants) before a stable release ships from `main`. Today the repo only publishes stable versions on push to `main`, so there's no way to hand a consumer an unreleased build.

## Approach — mirror the SDK fleet, keep our tooling

`contentful-management.js` / `contentful.js` / `contentful-cli` publish prereleases via **semantic-release prerelease branches** (`beta`/`canary`/`dev`), triggered by a branch push, with the prerelease committed + tagged. This PR mirrors that **model** but drives it with the repo's existing **`nx release`** tooling rather than adopting semantic-release.

Key decisions (validated by local dry-run against nx 23.0.0):

- **No script, no `nx.json` change.** The top-level `nx release` command tolerates the existing `release.git` config and does version + publish in one step. (The `nx release version` subcommand and programmatic API both *reject* that config — hence the top-level command.)
- **`latest` is never moved.** nx's publish executor reads the dist-tag from `npm config get tag`; the workflow writes `tag=next` to `~/.npmrc`, so prereleases only ever land under `@next`.
- **Both packages released together (not scoped to mcp-tools).** Because `mcp-server` depends on `mcp-tools`, scoping the release to `mcp-tools` leaves `mcp-server` with a *stable* `1.12.4` bump pinned to the prerelease dependency — a broken, publishable stable version. Releasing both makes `mcp-server` a prerelease too (`1.12.4-next.0`), keeping the graph self-consistent.
- **Safe for the stable line.** `releaseTag.strictPreid` (nx default `true`) makes the stable path (`nx release` with no `--preid`) resolve stable-only tags and ignore the `-next` tags this workflow creates.
- **Prerelease is committed + tagged + GitHub-released** (via `contentful-automation[bot]`), matching the fleet — the tag is what lets the next push auto-increment.

## Verification (dry-run)

Against the `feat/exo-tool-registration` ref (which carries the exported constants):
```
npm_config_tag=next npx nx release prerelease --preid next --dry-run -y
```
→ `mcp-tools` 0.12.2 → **0.12.3-next.0**, `mcp-server` 1.12.3 → **1.12.4-next.0**, both `Would publish ... with tag "next"`; `mcp-tools` tarball includes `dist/index.js` + `dist/index.d.ts`.

Stable path unaffected:
```
npx nx release --dry-run -y   # no --preid → resolves stable bases 0.12.2 / 1.12.3, publishes to latest
```

## Note

The exported instruction constants this unblocks live in PR #428 (`feat/exo-tool-registration`). To cut the first prerelease *with* those exports, branch `next` from a ref that includes them (off `feat/exo-tool-registration`, or off `main` once #428 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the prerelease workflow to release both workspace packages together instead of scoping to mcp-tools alone. The change fixes a version consistency issue where mcp-server would become a stable release while its mcp-tools dependency is a prerelease. Both packages are now published together as prereleases (e.g., mcp-tools@0.12.3-next.0, mcp-server@1.12.4-next.0) under the next dist-tag, which is safe for the stable release line since nx's strictPreid setting ignores -next tags on the stable path.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the `--projects mcp-tools` flag from the NX Prerelease command in prerelease.yml, enabling both @contentful/mcp-tools and @contentful/mcp-server to be released as prereleases together rather than only mcp-tools.</li>

<li>Updates file header comments to document the design decision that both packages must be released together to prevent mcp-server from becoming a stable version pinned to a prerelease dependency.</li>

<li>Adds explanation that the stable release path (nx release with no --preid) remains unaffected because nx's releaseTag.strictPreid setting makes the stable path ignore -next tags.</li>

</ul>
</details>

</div>