### PR TITLE
fix: remove invalid --push flag from nx release prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,19 +3,6 @@ name: prerelease
 # Publishes prerelease builds of the workspace packages (@contentful/mcp-tools
 # and @contentful/mcp-server) to GitHub Packages under the `next` dist-tag.
 #
-# Model: branch-triggered, mirroring the SDK fleet (e.g. contentful-management.js
-# publishes prereleases by pushing to its `beta`/`canary`/`dev` branches). Here a
-# push to the long-lived `next` branch cuts a `X.Y.Z-next.N` prerelease. Nx
-# resolves the current version from the latest git tag, so each push to `next`
-# increments the prerelease counter (…-next.0 → …-next.1 → …).
-#
-# Both packages are released together (not scoped to mcp-tools): mcp-server
-# depends on mcp-tools, so scoping the release would leave mcp-server with a
-# STABLE bump pinned to a prerelease dependency. Releasing both makes mcp-server
-# a prerelease too (…-next.N), keeping versions self-consistent. This is safe for
-# the stable release line because nx's releaseTag.strictPreid (default true)
-# makes the stable path (`nx release` with no --preid) ignore `-next` tags.
-#
 # The `next` dist-tag is set via ~/.npmrc so `nx release` publishes under it and
 # never moves `latest`. Consumers install with `@contentful/<pkg>@next`.
 
@@ -94,18 +81,6 @@ jobs:
       - uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # sets NX_BASE, NX_HEAD env vars
 
       - name: NX Prerelease
-        # Top-level `nx release` (not the `version` subcommand) so the existing
-        # top-level `release.git` config in nx.json is honored: it commits and
-        # tags the prerelease, and creates a GitHub Release — exactly as the
-        # fleet does for prerelease channels. The push back to `next` happens
-        # automatically: nx.json's changelog.projectChangelogs.createRelease
-        # forces git push to true internally, since a GitHub Release requires
-        # the tagged commit to exist on the remote. `--push` is not a valid
-        # flag on the top-level `nx release` command (verified via dry-run —
-        # `Unknown argument: push`), which is what broke the first attempt at
-        # this fix. Releases all workspace packages together (see header) so
-        # mcp-server isn't left as a stable version pinned to a prerelease
-        # mcp-tools.
         run: npx nx release prerelease --preid next -y
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -97,12 +97,15 @@ jobs:
         # Top-level `nx release` (not the `version` subcommand) so the existing
         # top-level `release.git` config in nx.json is honored: it commits and
         # tags the prerelease, and creates a GitHub Release — exactly as the
-        # fleet does for prerelease channels. `--push` is required explicitly:
-        # nx.json's release.git has no `push` field, which defaults to false, so
-        # without this flag the commit/tag stay local to the runner and the next
-        # push to `next` can't resolve the current version from git tags.
-        # Releases all workspace packages together (see header) so mcp-server
-        # isn't left as a stable version pinned to a prerelease mcp-tools.
-        run: npx nx release prerelease --preid next --push -y
+        # fleet does for prerelease channels. The push back to `next` happens
+        # automatically: nx.json's changelog.projectChangelogs.createRelease
+        # forces git push to true internally, since a GitHub Release requires
+        # the tagged commit to exist on the remote. `--push` is not a valid
+        # flag on the top-level `nx release` command (verified via dry-run —
+        # `Unknown argument: push`), which is what broke the first attempt at
+        # this fix. Releases all workspace packages together (see header) so
+        # mcp-server isn't left as a stable version pinned to a prerelease
+        # mcp-tools.
+        run: npx nx release prerelease --preid next -y
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Removes the `--push` flag from the `nx release prerelease` invocation in `.github/workflows/prerelease.yml`.

## Why

PR #429 added `--push` to fix a real gap (the prerelease commit/tag needing to reach the remote), but the flag doesn't exist on the top-level `nx release` command — only the `version`/`changelog` subcommands expose `--git-push`. Every push to `next` since #429 merged has failed with:

```
Unknown argument: push
```

Verified via local dry-run against nx 23.0.0 that the push already happens without any flag: `nx.json`'s `changelog.projectChangelogs.createRelease: "github"` forces `git.push` to `true` internally, since creating a GitHub Release requires the tagged commit to exist on the remote. Confirmed the dry-run log shows `NX   Pushing to git remote "origin"` with the flag removed.

Already applied and pushed directly to `next` (the branch this workflow actually triggers on) as commit `aec88d7`, confirmed via a subsequent successful run. This PR carries the same fix into `main` so the file doesn't drift.

## Verification

```
npm_config_tag=next npx nx release prerelease --preid next --dry-run -y
```
→ succeeds, resolves `mcp-tools 0.12.2 → 0.12.3-next.0`, `mcp-server 1.12.3 → 1.12.4-next.0`, and logs `NX Pushing to git remote "origin"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes the GitHub Actions prerelease workflow by removing the invalid `--push` flag from the `nx release prerelease` command. The flag does not exist on the top-level `nx release` command (only on subcommands like `version` and `changelog`), causing the workflow to fail with 'Unknown argument: push' on every run. The git push now happens automatically through the nx.json configuration that forces push when creating GitHub Releases.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the `--push` flag from the `nx release prerelease` command in prerelease.yml, which was causing failures with 'Unknown argument: push' error</li>

<li>Updates the workflow comment to explain that push happens automatically via nx.json's `changelog.projectChangelogs.createRelease: "github"` configuration</li>

<li>Fixes CI/CD pipeline that has been broken since the flag was incorrectly added in a previous PR</li>

</ul>
</details>

</div>