### PR TITLE
refactor: make searching guidance entity-agnostic for ExO envs

### DIFF
--- a/packages/mcp-tools/src/tools/context/instructions.ts
+++ b/packages/mcp-tools/src/tools/context/instructions.ts
@@ -16,10 +16,10 @@ export const CORE_INVARIANTS = `# Core operating rules
 
 export const SEARCHING_GUIDANCE = `# Searching for content
 
-- **Content-type first.** When users ask about specific content ("pricing page", "blog posts"), call \`list_content_types\` / \`get_content_type\` to discover the correct type before searching. This prevents wasted queries on wrong field names.
-- **Then search.** Use \`search_entries\` with the correct content type and field names. Use \`semantic_search\` when the user's request is conceptual rather than an exact field match.
+- **Schema first.** When users ask about specific content, discover the relevant schema before searching: list the environment's available types and inspect a type's fields so you query on real field names. This prevents wasted queries. Use whichever primitives the environment exposes — classic content types and entries, or Experience Orchestration component types and experiences.
+- **Then search.** Query using the correct type and field names. Prefer semantic search when the request is conceptual rather than an exact field match.
 - **Retry thoughtfully.** If a query returns no results, retry 2-3 times: relax filters, use more general terms, or check for typos in field names.
-- **Multi-step reference queries.** For requests like "blog posts by Magnus", first inspect the content type to confirm the reference field, then query for the referenced entry (the author) to get its ID, then query the primary content filtering on that ID. If several entities match, show them all and ask.`;
+- **Multi-step reference queries.** For requests that span references (e.g. "posts by Magnus"), first inspect the schema to confirm the reference field, then query for the referenced item to get its ID, then filter the primary query on that ID. If several items match, show them all and ask.`;
 
 export const CONVENTIONS_GUIDANCE = `# Response and workflow conventions
 


### PR DESCRIPTION
## Summary
- Reframe `SEARCHING_GUIDANCE` in the shared MCP context corpus from classic-specific wording (`list_content_types` / `get_content_type` / `search_entries`, "referenced entry (the author)") to schema- and entity-agnostic phrasing.
- The section now explicitly names both primitive families — classic content types & entries **and** Experience Orchestration component types & experiences — so the guidance doesn't mislead an agent operating in an ExO-only environment.
- Mirrors the same change made on the remote MCP server (`contentful/remote-mcp-server#87`), keeping the two servers' searching guidance aligned.

## Why
`get_initial_context` returns this corpus verbatim on every session. In an ExO environment the classic-only framing ("call `search_entries`", "content-type first") points the agent at the wrong primitives. Making it entity-agnostic keeps the guidance correct regardless of whether the environment uses classic content modeling or ExO.

## Test plan
- [x] `packages/mcp-tools` `instructions.test.ts` passes (3/3) — corpus guard still green; the fiction/load-bearing-fact assertions live in `CORE_INVARIANTS`, unaffected by the searching-verb changes
- [ ] Reviewer sanity-check the reworded section reads clearly for both classic and ExO users

> Note: based off `feat/exo` (where the split instruction constants live — `main` still has the monolithic `MCP_INSTRUCTIONS`), so this targets `feat/exo` rather than `main`.

Generated with [Claude Code](https://claude.com/claude-code)