### PR TITLE
refactor(mcp-tools): make core invariants entity-agnostic, strengthen ExO disposition

### DIFF
--- a/packages/mcp-tools/src/tools/context/getInitialContextTool.ts
+++ b/packages/mcp-tools/src/tools/context/getInitialContextTool.ts
@@ -36,18 +36,17 @@ export function getInitialContextTool(config: ContentfulConfig) {
 
     const exoBlock = config.exoToolsRegistered ? `\n\n${EXO_DISPOSITION}` : '';
 
-    const message =
-      outdent`
+    const message = outdent`
       You are an assistant integrated with Contentful through the Model Context Protocol (MCP). Always call this tool first.
 
       ${sessionFacts}
-
+    ` + exoBlock + `\n\n` + outdent`
       ${CORE_INVARIANTS}
 
       ${SEARCHING_GUIDANCE}
 
       ${CONVENTIONS_GUIDANCE}
-    ` + exoBlock;
+    `;
 
     contextStore.setInitialContextLoaded();
 

--- a/packages/mcp-tools/src/tools/context/instructions.test.ts
+++ b/packages/mcp-tools/src/tools/context/instructions.test.ts
@@ -38,14 +38,10 @@ describe('guidance corpus', () => {
   });
 
   it('states the corrected load-bearing facts', () => {
-    // Real content-type verbs
-    expect(allContent).toContain('list_content_types');
-    expect(allContent).toContain('get_content_type');
     // Real bulk cap
     expect(CORE_INVARIANTS).toContain('10');
     // sys.version edit-safety rule
     expect(allContent).toContain('sys.version');
-    expect(allContent).toContain('update_entry');
   });
 
   it('exposes an ExO disposition nudge that names ExO primitives and an override', () => {

--- a/packages/mcp-tools/src/tools/context/instructions.ts
+++ b/packages/mcp-tools/src/tools/context/instructions.ts
@@ -9,9 +9,9 @@
 
 export const CORE_INVARIANTS = `# Core operating rules
 
-- **Content-type first.** Before finding or editing content, call \`list_content_types\` to see what content types exist, and \`get_content_type\` to inspect a type's fields. This prevents failed queries and reveals the right type (e.g. a \`pricingPage\` type when asked about pricing).
-- **Edit safely.** To modify an entry, call \`get_entry\` first, then pass the returned \`sys.version\` to \`update_entry\`. The version is required and prevents overwriting concurrent changes.
-- **Bulk cap.** The bulk operations \`publish_entry\`, \`unpublish_entry\`, \`archive_entry\`, and \`unarchive_entry\` accept at most 10 IDs per call by default. This cap does not apply to creating or updating entries.
+- **Schema first.** Before creating or finding content, inspect the environment's schema: list available types and inspect their fields. This prevents failed operations and ensures you use the right type and field names.
+- **Edit safely.** Before updating any item, fetch it first to get the current \`sys.version\`, then pass that version to the update call. The version is required and prevents overwriting concurrent changes.
+- **Bulk cap.** Bulk publish/unpublish/archive/unarchive operations accept at most 10 IDs per call by default. This cap does not apply to creating or updating items.
 - **Ask when ambiguous.** If multiple spaces or environments are available, ask the user which to use. Do not guess.`;
 
 export const SEARCHING_GUIDANCE = `# Searching for content
@@ -29,6 +29,6 @@ export const CONVENTIONS_GUIDANCE = `# Response and workflow conventions
 - **Format for readability.** Use markdown for complex data; show the most important fields of an entry first; keep responses concise but complete.
 - **Prefer bulk.** If you would call the same tool many times, check whether it supports multiple IDs and condense into one call (respecting the 10-ID cap on publish-family operations).`;
 
-export const EXO_DISPOSITION = `# Tool disposition: prefer Experience Orchestration
+export const EXO_DISPOSITION = `# Tool disposition: Experience Orchestration by default
 
-Experience Orchestration (ExO) tools are enabled. Prefer ExO primitives — Component Types, Experiences, Templates — over classic content types and entries, unless the user explicitly asks for classic content types or entries instead.`;
+Experience Orchestration (ExO) tools are enabled. Use ExO primitives — Component Types, Experiences, Templates, Fragments, and Data Assemblies — for all content modeling and authoring. Do not create classic content types or entries unless the user explicitly instructs you to. If you are unsure how to model something with ExO, inspect the tool schemas and proceed with ExO.`;


### PR DESCRIPTION
## Summary
- Rewrites `CORE_INVARIANTS` to be entity-agnostic — removes `list_content_types`/`get_entry` tool name specificity in favour of generic schema-first and fetch-before-update language that applies equally to ExO and classic environments
- Moves the `exoBlock` insertion point so it appears between `sessionFacts` and `CORE_INVARIANTS`, giving the ExO disposition higher precedence in the assembled context
- Strengthens `EXO_DISPOSITION` wording: enumerates all ExO primitives, forbids creating classic CTs/entries unless explicitly instructed, and instructs the model to inspect tool schemas when uncertain

## Test plan
- [ ] Run `pnpm --filter mcp-tools test` — all tests pass
- [ ] Verify `getInitialContextTool` snapshot/unit output includes ExO block before the core invariants section when `exoToolsRegistered: true`
- [ ] Smoke test against local MCP server with `ENABLE_EXO_TOOLS=1`: confirm model prefers ExO primitives in a blank-slate session

Generated with [Claude Code](https://claude.com/claude-code)