### PR TITLE
feat: add append_entry_field tool [DX-1295]

### DIFF
--- a/packages/mcp-tools/src/tools/entries/appendEntryField.test.ts
+++ b/packages/mcp-tools/src/tools/entries/appendEntryField.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { appendEntryFieldTool } from './appendEntryField.js';
+import { formatResponse } from '../../utils/formatters.js';
+import {
+  setupMockClient,
+  mockEntryGet,
+  mockEntryUpdate,
+  mockEntry,
+  mockArgs,
+} from './mockClient.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+vi.mock('../../utils/tools.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../utils/tools.js')>();
+  return {
+    ...orig,
+    createToolClient: vi.fn(),
+  };
+});
+
+describe('appendEntryField', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMockClient();
+  });
+
+  // ── Test 1: append to an existing array ──────────────────────────────────
+  it('appends new items to an existing array field', async () => {
+    const existingLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'existing-ref-id' } };
+    const newLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'new-ref-id' } };
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: {
+        references: { 'en-US': [existingLink] },
+      },
+    };
+
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 2 },
+      fields: {
+        references: { 'en-US': [existingLink, newLink] },
+      },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'references',
+      locale: 'en-US',
+      values: [newLink],
+    });
+
+    expect(mockEntryUpdate).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment', entryId: 'test-entry-id' },
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          references: { 'en-US': [existingLink, newLink] },
+        }),
+      }),
+    );
+
+    const expectedResponse = formatResponse('Entry field appended successfully', {
+      updatedEntry: mockUpdatedEntry,
+      appended: [newLink],
+      skipped: [],
+      newLength: 2,
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: expectedResponse }] });
+  });
+
+  // ── Test 2: initialize absent field/locale ───────────────────────────────
+  it('initializes a missing field/locale as an empty array and appends to it', async () => {
+    const newSymbol = 'tag-alpha';
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: {
+        title: { 'en-US': 'My Entry' },
+        // tags field does not exist at all
+      },
+    };
+
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 2 },
+      fields: {
+        title: { 'en-US': 'My Entry' },
+        tags: { 'en-US': [newSymbol] },
+      },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'tags',
+      locale: 'en-US',
+      values: [newSymbol],
+    });
+
+    expect(mockEntryUpdate).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment', entryId: 'test-entry-id' },
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          tags: { 'en-US': [newSymbol] },
+        }),
+      }),
+    );
+
+    const expectedResponse = formatResponse('Entry field appended successfully', {
+      updatedEntry: mockUpdatedEntry,
+      appended: [newSymbol],
+      skipped: [],
+      newLength: 1,
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: expectedResponse }] });
+  });
+
+  // ── Test 3: dedupe skips items already present ───────────────────────────
+  it('skips items that are already present in the array (dedupe by sys.id)', async () => {
+    const existingLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'already-here' } };
+    const newLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'brand-new' } };
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: {
+        references: { 'en-US': [existingLink] },
+      },
+    };
+
+    // After the call the array has only two items: the existing one + brand-new
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 2 },
+      fields: {
+        references: { 'en-US': [existingLink, newLink] },
+      },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'references',
+      locale: 'en-US',
+      values: [existingLink, newLink], // existingLink is a duplicate
+    });
+
+    // update must have been called with the de-duped array only
+    expect(mockEntryUpdate).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment', entryId: 'test-entry-id' },
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          references: { 'en-US': [existingLink, newLink] },
+        }),
+      }),
+    );
+
+    const expectedResponse = formatResponse('Entry field appended successfully', {
+      updatedEntry: mockUpdatedEntry,
+      appended: [newLink],
+      skipped: [existingLink],
+      newLength: 2,
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: expectedResponse }] });
+  });
+
+  // ── Test 4: dedupe for ResourceLinks by sys.urn ──────────────────────────
+  it('skips ResourceLink items that are already present (dedupe by sys.urn)', async () => {
+    const existingRL = {
+      sys: { type: 'ResourceLink' as const, linkType: 'Contentful:Entry', urn: 'crn:contentful:::content/spaces/s/entries/already-rl' },
+    };
+    const newRL = {
+      sys: { type: 'ResourceLink' as const, linkType: 'Contentful:Entry', urn: 'crn:contentful:::content/spaces/s/entries/new-rl' },
+    };
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: { crossSpaceRefs: { 'en-US': [existingRL] } },
+    };
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 2 },
+      fields: { crossSpaceRefs: { 'en-US': [existingRL, newRL] } },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'crossSpaceRefs',
+      locale: 'en-US',
+      values: [existingRL, newRL],
+    });
+
+    const expectedResponse = formatResponse('Entry field appended successfully', {
+      updatedEntry: mockUpdatedEntry,
+      appended: [newRL],
+      skipped: [existingRL],
+      newLength: 2,
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: expectedResponse }] });
+  });
+
+  // ── Test 5: version conflict when a stale version is passed ─────────────
+  it('returns a version conflict error when the supplied version is stale', async () => {
+    const mockExistingEntry = {
+      ...mockEntry,
+      sys: { ...mockEntry.sys, version: 5 }, // server is at v5
+      fields: { tags: { 'en-US': ['existing-tag'] } },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'tags',
+      locale: 'en-US',
+      values: ['new-tag'],
+      version: 2, // caller read at v2, server is now v5
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error appending entry field: Version conflict: the entry has changed since you read it (your version: 2, current version: 5). Re-fetch the entry with get_entry and retry with the latest version.',
+        },
+      ],
+    });
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── Test 6: non-array field error ────────────────────────────────────────
+  it('returns an error when the target field/locale is not an array', async () => {
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: {
+        title: { 'en-US': 'A plain string, not an array' },
+      },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'title',
+      locale: 'en-US',
+      values: ['oops'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error appending entry field: Field "title" locale "en-US" is not an array (got string). append_entry_field only works on Array of Symbols, Array of Links, and Array of ResourceLinks fields.',
+        },
+      ],
+    });
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── Test 7: multi-locale isolation ──────────────────────────────────────
+  it('leaves other locales within the same field untouched', async () => {
+    const existingLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'existing-ref' } };
+    const newLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'new-ref' } };
+    const deLocaleLink = { sys: { type: 'Link' as const, linkType: 'Entry' as const, id: 'de-locale-ref' } };
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      fields: {
+        references: {
+          'en-US': [existingLink],
+          de: [deLocaleLink],        // German locale — must remain untouched
+        },
+      },
+    };
+
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 2 },
+      fields: {
+        references: {
+          'en-US': [existingLink, newLink], // only en-US changed
+          de: [deLocaleLink],               // de unchanged
+        },
+      },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'references',
+      locale: 'en-US',
+      values: [newLink],
+    });
+
+    expect(mockEntryUpdate).toHaveBeenCalledWith(
+      { spaceId: 'test-space-id', environmentId: 'test-environment', entryId: 'test-entry-id' },
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          references: {
+            'en-US': [existingLink, newLink],
+            de: [deLocaleLink], // untouched
+          },
+        }),
+      }),
+    );
+  });
+
+  // ── Test 8: protected environment ───────────────────────────────────────
+  it('returns an error when the environment is protected', async () => {
+    const protectedConfig = createMockConfig({ protectedEnvironments: ['master'] });
+    const tool = appendEntryFieldTool(protectedConfig);
+
+    const result = await tool({
+      ...mockArgs,
+      environmentId: 'master',
+      entryId: 'test-entry-id',
+      fieldId: 'tags',
+      locale: 'en-US',
+      values: ['new-tag'],
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: "Error appending entry field: Environment 'master' is protected. Write and delete operations are not allowed.",
+        },
+      ],
+    });
+    expect(mockEntryUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── Test 9: no version passed → appends without conflict check ───────────
+  it('appends successfully when no version is supplied (no conflict check)', async () => {
+    const existingSymbol = 'tag-existing';
+    const newSymbol = 'tag-new';
+
+    const mockExistingEntry = {
+      ...mockEntry,
+      sys: { ...mockEntry.sys, version: 7 }, // any version — no check expected
+      fields: { tags: { 'en-US': [existingSymbol] } },
+    };
+
+    const mockUpdatedEntry = {
+      ...mockExistingEntry,
+      sys: { ...mockExistingEntry.sys, version: 8 },
+      fields: { tags: { 'en-US': [existingSymbol, newSymbol] } },
+    };
+
+    mockEntryGet.mockResolvedValue(mockExistingEntry);
+    mockEntryUpdate.mockResolvedValue(mockUpdatedEntry);
+
+    const tool = appendEntryFieldTool(mockConfig);
+    const result = await tool({
+      ...mockArgs,
+      entryId: 'test-entry-id',
+      fieldId: 'tags',
+      locale: 'en-US',
+      values: [newSymbol],
+      // version intentionally omitted
+    });
+
+    expect(mockEntryUpdate).toHaveBeenCalled();
+    expect(result).not.toHaveProperty('isError');
+  });
+});

--- a/packages/mcp-tools/src/tools/entries/appendEntryField.ts
+++ b/packages/mcp-tools/src/tools/entries/appendEntryField.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import {
+  BaseToolSchema,
+  createToolClient,
+  assertEnvironmentNotProtected,
+} from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export const AppendEntryFieldToolParams = BaseToolSchema.extend({
+  entryId: z.string().describe('The ID of the entry to modify'),
+  fieldId: z.string().describe('The ID of the array field to append to'),
+  locale: z
+    .string()
+    .describe(
+      'The locale key to target (e.g. "en-US"). Fields are locale-keyed; ' +
+        'you must supply the exact locale string.',
+    ),
+  values: z
+    .array(z.unknown())
+    .min(1)
+    .describe(
+      'One or more items to append. Each item must match the element shape ' +
+        'of the target array field: a plain string for Array of Symbols, ' +
+        '{ sys: { type: "Link", linkType: "Entry"|"Asset", id: "..." } } for ' +
+        'Array of Links, or { sys: { type: "ResourceLink", linkType: "...", ' +
+        'urn: "..." } } for Array of ResourceLinks.',
+    ),
+  version: z
+    .number()
+    .optional()
+    .describe(
+      'Optional. The entry\'s sys.version as returned by get_entry. ' +
+        'If provided, the append is rejected when the entry has changed since ' +
+        'you read it (same conflict check as update_entry). ' +
+        'If omitted, the append targets the current server state without a ' +
+        'version check — safe for additive operations.',
+    ),
+});
+
+type Params = z.infer<typeof AppendEntryFieldToolParams>;
+
+/**
+ * Determine a deduplication key for an array item.
+ * - Link: sys.id
+ * - ResourceLink: sys.urn
+ * - Primitive (Symbol): exact string value cast to string
+ * Returns undefined for items that cannot be keyed (treated as always-new).
+ */
+function itemKey(item: unknown): string | undefined {
+  if (item !== null && typeof item === 'object') {
+    const sys = (item as Record<string, unknown>)['sys'];
+    if (sys !== null && typeof sys === 'object') {
+      const sysObj = sys as Record<string, unknown>;
+      if (typeof sysObj['id'] === 'string') return `id:${sysObj['id']}`;
+      if (typeof sysObj['urn'] === 'string') return `urn:${sysObj['urn']}`;
+    }
+  }
+  if (typeof item === 'string') return `str:${item}`;
+  return undefined;
+}
+
+export function appendEntryFieldTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    assertEnvironmentNotProtected(
+      args.environmentId,
+      config.protectedEnvironments,
+    );
+
+    const params = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+      entryId: args.entryId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    // Step 1: Fetch the current entry server-side (never truncated).
+    const existingEntry = await contentfulClient.entry.get(params);
+
+    // Step 2: Optional version conflict check — only when caller passes version.
+    if (
+      args.version !== undefined &&
+      args.version !== existingEntry.sys.version
+    ) {
+      throw new Error(
+        `Version conflict: the entry has changed since you read it ` +
+          `(your version: ${args.version}, current version: ${existingEntry.sys.version}). ` +
+          `Re-fetch the entry with get_entry and retry with the latest version.`,
+      );
+    }
+
+    // Step 3: Resolve the current array for this field/locale.
+    const fieldLocaleValue =
+      existingEntry.fields?.[args.fieldId]?.[args.locale];
+
+    // Step 4: Initialize absent field/locale as empty array; reject non-arrays.
+    let existingArray: unknown[];
+    if (fieldLocaleValue === undefined || fieldLocaleValue === null) {
+      existingArray = [];
+    } else if (!Array.isArray(fieldLocaleValue)) {
+      throw new Error(
+        `Field "${args.fieldId}" locale "${args.locale}" is not an array ` +
+          `(got ${typeof fieldLocaleValue}). append_entry_field only works on ` +
+          `Array of Symbols, Array of Links, and Array of ResourceLinks fields.`,
+      );
+    } else {
+      existingArray = fieldLocaleValue as unknown[];
+    }
+
+    // Step 5: Deduplicate — collect existing keys once, then filter incoming values.
+    const existingKeys = new Set<string>();
+    for (const item of existingArray) {
+      const k = itemKey(item);
+      if (k !== undefined) existingKeys.add(k);
+    }
+
+    const appended: unknown[] = [];
+    const skipped: unknown[] = [];
+    for (const incoming of args.values) {
+      const k = itemKey(incoming);
+      if (k !== undefined && existingKeys.has(k)) {
+        skipped.push(incoming);
+      } else {
+        appended.push(incoming);
+        if (k !== undefined) existingKeys.add(k); // guard against dupes within args.values
+      }
+    }
+
+    const newArray = [...existingArray, ...appended];
+
+    // Step 6: Write back — merge only the target field/locale; leave everything
+    // else (other fields, other locales within this field) completely untouched.
+    const updatedFields = {
+      ...existingEntry.fields,
+      [args.fieldId]: {
+        ...(existingEntry.fields?.[args.fieldId] ?? {}),
+        [args.locale]: newArray,
+      },
+    };
+
+    const updatedEntry = await contentfulClient.entry.update(params, {
+      ...existingEntry,
+      fields: updatedFields,
+    });
+
+    return createSuccessResponse('Entry field appended successfully', {
+      updatedEntry,
+      appended,
+      skipped,
+      newLength: newArray.length,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error appending entry field');
+}

--- a/packages/mcp-tools/src/tools/entries/register.ts
+++ b/packages/mcp-tools/src/tools/entries/register.ts
@@ -25,6 +25,10 @@ import {
   unarchiveEntryTool,
   UnarchiveEntryToolParams,
 } from './unarchiveEntry.js';
+import {
+  appendEntryFieldTool,
+  AppendEntryFieldToolParams,
+} from './appendEntryField.js';
 import type { ContentfulConfig } from '../../config/types.js';
 
 export function createEntryTools(config: ContentfulConfig) {
@@ -40,6 +44,7 @@ export function createEntryTools(config: ContentfulConfig) {
   const unpublishEntry = unpublishEntryTool(config);
   const archiveEntry = archiveEntryTool(config);
   const unarchiveEntry = unarchiveEntryTool(config);
+  const appendEntryField = appendEntryFieldTool(config);
 
   return {
     searchEntries: {
@@ -116,7 +121,16 @@ export function createEntryTools(config: ContentfulConfig) {
     updateEntry: {
       title: 'update_entry',
       description:
-        'Update an existing entry. You MUST call get_entry first to read the current state, then pass the sys.version you received as the version parameter. The handler merges your field updates with the existing entry fields, so you only need to provide the fields you want to change. However, for multiple-locale fields, all existing locales must be included in the update. If the version is stale (the entry changed since you read it), the update is rejected and you must re-fetch with get_entry.',
+        'Update an existing entry. You MUST call get_entry first to read the current state, ' +
+        'then pass the sys.version you received as the version parameter. ' +
+        'The handler merges your field updates with the existing entry fields, so you only need ' +
+        'to provide the fields you want to change. However, for multiple-locale fields, all ' +
+        'existing locales must be included in the update. ' +
+        'If the version is stale (the entry changed since you read it), the update is rejected ' +
+        'and you must re-fetch with get_entry. ' +
+        'NOTE: for appending items to large array fields (e.g. reference arrays with many items), ' +
+        'prefer append_entry_field — it performs the read-modify-append server-side and deduplicates, ' +
+        'so you never need to hold the full array.',
       inputParams: UpdateEntryToolParams.shape,
       annotations: {
         readOnlyHint: false,
@@ -190,6 +204,30 @@ export function createEntryTools(config: ContentfulConfig) {
         openWorldHint: false,
       },
       tool: unarchiveEntry,
+    },
+    appendEntryField: {
+      title: 'append_entry_field',
+      description:
+        'Append one or more items to an array-typed entry field (Array of Symbols, ' +
+        'Array of Links, or Array of ResourceLinks) entirely server-side. ' +
+        'The agent never holds or resends the full array — the tool reads the ' +
+        'current array on the server, deduplicates (Links by sys.id, ResourceLinks ' +
+        'by sys.urn, Symbols by exact value), appends survivors, and writes back ' +
+        'only the target field/locale. ' +
+        'PREFER this over update_entry when adding items to large reference arrays ' +
+        '(e.g. a page with dozens of references) — update_entry replaces the full ' +
+        'array and will silently lose items if the agent held a truncated read. ' +
+        'Optionally pass version (from get_entry) to enforce a conflict check; ' +
+        'omit it to append without a version guard (safe for additive operations). ' +
+        'Returns the updated entry plus appended/skipped item lists and the new array length.',
+      inputParams: AppendEntryFieldToolParams.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      tool: appendEntryField,
     },
   };
 }


### PR DESCRIPTION
[DX-1295](https://contentful.atlassian.net/browse/DX-1295)

## Summary
- Adds `append_entry_field` tool that appends items to an Array of Symbols, Array of Links, or Array of ResourceLinks entirely server-side — the agent never holds or resends the full array
- Deduplicates incoming values against existing array items (Links by `sys.id`, ResourceLinks by `sys.urn`, Symbols by exact value) and returns separate `appended`/`skipped` lists with the new array length
- Updates `update_entry` description to cross-reference `append_entry_field` for large reference array use cases

## Test plan
- [ ] Unit tests cover: append to existing array, cold-start (null field/locale), dedup by `sys.id`, dedup by `sys.urn`, version conflict guard, non-array field error, multi-locale isolation, protected environment guard, no-version (no conflict check)
- [ ] `append_entry_field` appears in the MCP tool list on local server startup
- [ ] Append to a page entry with 20+ references works without holding the full array in agent context
- [ ] Duplicate values in `values` param are deduped (intra-batch)
- [ ] Appending to a published entry leaves it in `changed` state (draft on top of published)

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1295]: https://contentful.atlassian.net/browse/DX-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds the `append_entry_field` MCP tool that enables agents to append items to entry array fields (Symbols, Links, or ResourceLinks) entirely server-side, avoiding the need to hold or resend the full array in agent context. The tool performs server-side deduplication and optionally validates version conflicts to prevent lost updates on large reference arrays.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces `append_entry_field` tool that reads current array, deduplicates incoming values (Links by sys.id, ResourceLinks by sys.urn, Symbols by exact value), and appends only unique items server-side in `appendEntryField.ts`</li>

<li>Returns `appended` and `skipped` item lists along with `newLength` and the `updatedEntry`, enabling agents to understand exactly which values were added versus skipped as duplicates</li>

<li>Implements optional version conflict guard — when `version` is supplied from a prior `get_entry` call, the tool rejects the append if the entry has changed since the read; omitting `version` allows additive-only operations without conflict checking</li>

<li>Updates `update_entry` description in `register.ts` to cross-reference `append_entry_field` as the preferred approach for appending to large reference arrays to prevent silent data loss</li>

<li>Includes 9 comprehensive unit tests covering: append to existing array, cold-start field/locale initialization, deduplication by sys.id and sys.urn, version conflict, non-array field error, multi-locale isolation, protected environment guard, and no-version append</li>

</ul>
</details>

</div>