### PR TITLE
feat: require exoM1 entitlement to register ExO tools [AIS-191]

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -71,7 +71,7 @@ npm run build
 | `CONTENTFUL_HOST`                    | ❌ No    | `api.contentful.com` | Contentful API host                                                                                                                                                                                      |
 | `NODE_ENV`                           | ❌ No    | `production`         | Node Environment to run in                                                                                                                                                                               |
 | `MAX_BULK_SIZE`                      | ❌ No    | `10`                 | Maximum number of IDs allowed in a single bulk-operation tool call (1–100). Caps publish/unpublish/archive/unarchive on entries and assets. Mitigates accidental mass operations from AI hallucinations. |
-| `ENABLE_EXO_TOOLS`                   | ❌ No    | `false`              | Opt in to Experience Orchestration (ExO) tools. Set to `true` to register the ExO tool collections (component types, data assemblies, experiences, templates, fragments).                               |
+| `ENABLE_EXO_TOOLS`                   | ❌ No    | `false`              | Opt in to Experience Orchestration (ExO) tools. Set to `true` to register the ExO tool collections (component types, data assemblies, experiences, templates, fragments). Also requires the token to hold the `exoM1` entitlement in at least one accessible org — both gates must pass. |
 
 ### Configuration
 

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -42,7 +42,7 @@ const EnvSchema = z.object({
     .optional()
     .transform((v) => v === 'true')
     .describe(
-      'Opt in to Experience Orchestration (ExO) tools. Set to "true" to register the ExO tool collections (component types, data assemblies, experiences, templates, fragments). Defaults to off.',
+      'Opt in to Experience Orchestration (ExO) tools. Set to "true" to register the ExO tool collections (component types, data assemblies, experiences, templates, fragments). Tools register only if the token also holds the exoM1 entitlement in at least one accessible org — both gates must pass. Defaults to off.',
     ),
   CONTENTFUL_DELIVERY_TOKEN: z
     .string()

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -24,7 +24,7 @@ async function initializeServer() {
     version: getVersion(),
   });
 
-  registerAllTools(server);
+  await registerAllTools(server);
   registerAllPrompts(server);
   registerAllResources(server);
 

--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -27,6 +27,14 @@ vi.mock('../config/env.js', () => ({
   },
 }));
 
+// hasExoM1Entitlement is mocked so tests don't hit the network. Defaults to
+// entitled (true) so existing ExO-on tests keep seeing the full tool surface;
+// entitlement-gate tests override per-case. Hoisted so the vi.mock factory can
+// reference it (factories are lifted above top-level consts).
+const { mockHasExoM1Entitlement } = vi.hoisted(() => ({
+  mockHasExoM1Entitlement: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@contentful/mcp-tools', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@contentful/mcp-tools')>();
   return {
@@ -34,6 +42,7 @@ vi.mock('@contentful/mcp-tools', async (importOriginal) => {
     ContentfulMcpTools: vi
       .fn()
       .mockImplementation((config) => new actual.ContentfulMcpTools(config)),
+    hasExoM1Entitlement: mockHasExoM1Entitlement,
   };
 });
 
@@ -64,7 +73,7 @@ describe('registerAllTools', () => {
   });
 
   it('should register all standard tool collections', async () => {
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     // Create a ContentfulMcpTools instance to count tools
     const mcpTools = new ContentfulMcpTools({
@@ -110,7 +119,7 @@ describe('registerAllTools', () => {
   });
 
   it('should register tools with correct metadata structure', async () => {
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     // Check that all calls follow the expected structure
     const calls = registerToolSpy.mock.calls;
@@ -125,14 +134,14 @@ describe('registerAllTools', () => {
   });
 
   it('should register workflow tools with disable called', async () => {
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     // The disable method should be called 3 times (once for each workflow tool)
     expect(mockRegisteredTool.disable).toHaveBeenCalledTimes(3);
   });
 
   it('should register spaceToSpaceMigrationHandler with workflow tools', async () => {
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     const mcpTools = new ContentfulMcpTools({
       accessToken: env.data!.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
@@ -170,6 +179,9 @@ describe('registerAllTools ExO opt-in', () => {
 
   beforeEach(() => {
     mockEnvData.ENABLE_EXO_TOOLS = true;
+    mockEnvData.ORGANIZATION_ID = 'test-org-id';
+    mockHasExoM1Entitlement.mockReset();
+    mockHasExoM1Entitlement.mockResolvedValue(true);
     registerToolSpy = vi.fn(() => ({ disable: vi.fn() }));
     mockServer = { registerTool: registerToolSpy } as unknown as McpServer;
     vi.mocked(ContentfulMcpTools).mockClear();
@@ -178,10 +190,11 @@ describe('registerAllTools ExO opt-in', () => {
   const registeredToolTitles = () =>
     registerToolSpy.mock.calls.map((c) => c[0] as string);
 
-  it('registers ExO tools and sets exoToolsRegistered:true when ENABLE_EXO_TOOLS is on', () => {
+  it('registers ExO tools when ENABLE_EXO_TOOLS is on AND the org is entitled', async () => {
     mockEnvData.ENABLE_EXO_TOOLS = true;
+    mockHasExoM1Entitlement.mockResolvedValue(true);
 
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     // create_component_type is an ExO tool title
     expect(registeredToolTitles()).toContain('create_component_type');
@@ -192,10 +205,10 @@ describe('registerAllTools ExO opt-in', () => {
     );
   });
 
-  it('omits ExO tools and sets exoToolsRegistered:false when ENABLE_EXO_TOOLS is off', () => {
+  it('omits ExO tools when ENABLE_EXO_TOOLS is off (and never checks entitlement)', async () => {
     mockEnvData.ENABLE_EXO_TOOLS = false;
 
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
 
     expect(registeredToolTitles()).not.toContain('create_component_type');
     // classic tools still present
@@ -203,6 +216,37 @@ describe('registerAllTools ExO opt-in', () => {
     expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
       expect.objectContaining({ exoToolsRegistered: false }),
     );
+    // Short-circuit: no entitlement network call when the env var is off.
+    expect(mockHasExoM1Entitlement).not.toHaveBeenCalled();
+  });
+
+  it('omits ExO tools when the env var is on but the org is NOT entitled', async () => {
+    mockEnvData.ENABLE_EXO_TOOLS = true;
+    mockHasExoM1Entitlement.mockResolvedValue(false);
+
+    await registerAllTools(mockServer);
+
+    expect(registeredToolTitles()).not.toContain('create_component_type');
+    expect(registeredToolTitles()).toContain('list_content_types');
+    expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
+      expect.objectContaining({ exoToolsRegistered: false }),
+    );
+    // Org is derived from the PAT inside the helper — the caller passes only
+    // the config, not an org id.
+    expect(mockHasExoM1Entitlement).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'test-token' }),
+    );
+  });
+
+  it('fails closed: omits ExO tools when both gates would pass but entitlement lookup rejects', async () => {
+    mockEnvData.ENABLE_EXO_TOOLS = true;
+    // hasExoM1Entitlement itself swallows errors and returns false; simulate
+    // that resolved-false result here (the helper never throws to the caller).
+    mockHasExoM1Entitlement.mockResolvedValue(false);
+
+    await registerAllTools(mockServer);
+
+    expect(registeredToolTitles()).not.toContain('create_component_type');
   });
 });
 
@@ -221,7 +265,7 @@ describe('registerAllTools — PROTECTED_ENVIRONMENTS parsing', () => {
 
   it('passes undefined when PROTECTED_ENVIRONMENTS is absent', async () => {
     mockEnvData.PROTECTED_ENVIRONMENTS = undefined;
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
     expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
       expect.objectContaining({ protectedEnvironments: undefined }),
     );
@@ -229,7 +273,7 @@ describe('registerAllTools — PROTECTED_ENVIRONMENTS parsing', () => {
 
   it('passes parsed array when PROTECTED_ENVIRONMENTS is "master,staging"', async () => {
     mockEnvData.PROTECTED_ENVIRONMENTS = 'master,staging';
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
     expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
       expect.objectContaining({ protectedEnvironments: ['master', 'staging'] }),
     );
@@ -237,7 +281,7 @@ describe('registerAllTools — PROTECTED_ENVIRONMENTS parsing', () => {
 
   it('trims whitespace when PROTECTED_ENVIRONMENTS is " master , staging "', async () => {
     mockEnvData.PROTECTED_ENVIRONMENTS = ' master , staging ';
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
     expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
       expect.objectContaining({ protectedEnvironments: ['master', 'staging'] }),
     );
@@ -245,7 +289,7 @@ describe('registerAllTools — PROTECTED_ENVIRONMENTS parsing', () => {
 
   it('passes undefined when PROTECTED_ENVIRONMENTS is only commas/whitespace (", ,")', async () => {
     mockEnvData.PROTECTED_ENVIRONMENTS = ', ,';
-    registerAllTools(mockServer);
+    await registerAllTools(mockServer);
     expect(vi.mocked(ContentfulMcpTools)).toHaveBeenCalledWith(
       expect.objectContaining({ protectedEnvironments: undefined }),
     );

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { ContentfulMcpTools } from '@contentful/mcp-tools';
+import { ContentfulMcpTools, hasExoM1Entitlement } from '@contentful/mcp-tools';
 import { env } from '../config/env.js';
 import { getVersion } from '../getVersion.js';
 
@@ -7,15 +7,18 @@ import { getVersion } from '../getVersion.js';
  * Registers all Contentful MCP tools with the server.
  * Each tool is registered with its title, description, input schema, annotations, and implementation.
  *
- * ExO (Experience Orchestration) tool collections are opt-in via the
- * ENABLE_EXO_TOOLS env var: they register only when it is set to "true".
- * Classic collections always register.
+ * ExO (Experience Orchestration) tool collections require BOTH gates:
+ * 1. the ENABLE_EXO_TOOLS env var is "true" (explicit local opt-in), AND
+ * 2. the org holds the shared `exoM1` entitlement (the coordinated M1 rollout
+ *    gate — see the ExO M1 rollout doc).
+ * The entitlement check fails closed: offline or any error withholds ExO. This
+ * makes registration async. Classic collections always register.
  *
  * Special handling for space-to-space migration workflow tools:
  * - The param collection, export, and import tools are disabled by default
  * - The migration handler controls their enable/disable state
  */
-export function registerAllTools(server: McpServer): void {
+export async function registerAllTools(server: McpServer): Promise<void> {
   if (!env.success || !env.data) {
     throw new Error('Environment variables are not properly configured');
   }
@@ -49,8 +52,14 @@ export function registerAllTools(server: McpServer): void {
     maxBulkSize,
   };
 
-  // ExO tools are opt-in via ENABLE_EXO_TOOLS. Off by default.
-  const registerExoTools = env.data.ENABLE_EXO_TOOLS;
+  // ExO tools require BOTH the local opt-in env var AND the exoM1 entitlement.
+  // The org is derived from the PAT (the user may have ExO in any org they can
+  // access), since spaceId/organizationId are per-call, not required config.
+  // Off by default; the entitlement check fails closed (offline / error / no
+  // accessible orgs → no ExO). Skip the network call entirely when the env var
+  // is off.
+  const registerExoTools =
+    env.data.ENABLE_EXO_TOOLS && (await hasExoM1Entitlement(baseConfig));
 
   // Initialize tools with configuration from environment variables
   const tools = new ContentfulMcpTools({

--- a/packages/mcp-tools/src/index.test.ts
+++ b/packages/mcp-tools/src/index.test.ts
@@ -36,12 +36,19 @@ describe('Package Exports', () => {
     }
   });
 
-  it('should export exactly 5 runtime items (class + 4 instruction constants)', async () => {
+  it('should export the exoM1 entitlement helper and feature constant', async () => {
+    const moduleExports = await import('./index.js');
+
+    expect(typeof moduleExports.hasExoM1Entitlement).toBe('function');
+    expect(moduleExports.EXO_M1_FEATURE).toBe('exoM1');
+  });
+
+  it('should export exactly 7 runtime items (class + 4 instruction constants + entitlement helper + feature constant)', async () => {
     // TypeScript types are erased at runtime, so ContentfulConfig won't be in exports
     const moduleExports = await import('./index.js');
     const exportedKeys = Object.keys(moduleExports);
 
-    expect(exportedKeys).toHaveLength(5);
+    expect(exportedKeys).toHaveLength(7);
     expect(exportedKeys).toContain('ContentfulMcpTools');
     expect(exportedKeys).toEqual(
       expect.arrayContaining([
@@ -49,6 +56,8 @@ describe('Package Exports', () => {
         'SEARCHING_GUIDANCE',
         'CONVENTIONS_GUIDANCE',
         'EXO_DISPOSITION',
+        'hasExoM1Entitlement',
+        'EXO_M1_FEATURE',
       ]),
     );
   });

--- a/packages/mcp-tools/src/index.ts
+++ b/packages/mcp-tools/src/index.ts
@@ -1,6 +1,10 @@
 export { ContentfulMcpTools } from './ContentfulMcpTools.js';
 export type { ContentfulConfig } from './config/types.js';
 export {
+  hasExoM1Entitlement,
+  EXO_M1_FEATURE,
+} from './utils/entitlements.js';
+export {
   CORE_INVARIANTS,
   SEARCHING_GUIDANCE,
   CONVENTIONS_GUIDANCE,

--- a/packages/mcp-tools/src/utils/entitlements.test.ts
+++ b/packages/mcp-tools/src/utils/entitlements.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRawGet, mockGetAllOrgs, mockCreateClient } = vi.hoisted(() => {
+  const mockRawGet = vi.fn();
+  const mockGetAllOrgs = vi.fn();
+  return {
+    mockRawGet,
+    mockGetAllOrgs,
+    mockCreateClient: vi.fn(() => ({
+      raw: { get: mockRawGet },
+      organization: { getAll: mockGetAllOrgs },
+    })),
+  };
+});
+
+vi.mock('contentful-management', () => ({
+  createClient: mockCreateClient,
+}));
+
+import { hasExoM1Entitlement } from './entitlements.js';
+import type { ContentfulConfig } from '../config/types.js';
+
+const config: ContentfulConfig = {
+  accessToken: 'tok',
+  mcpVersion: '0.0.0',
+};
+
+const orgsCollection = (...ids: string[]) => ({
+  items: ids.map((id) => ({ sys: { id } })),
+});
+
+/** Route raw.get responses per-org by URL. */
+const entitlementByOrg = (map: Record<string, boolean>) => (url: string) => {
+  const match = url.match(/\/organizations\/([^/]+)\//);
+  const orgId = match?.[1] ?? '';
+  return Promise.resolve({ features: { exoM1: { value: map[orgId] ?? false } } });
+};
+
+describe('hasExoM1Entitlement', () => {
+  beforeEach(() => {
+    mockRawGet.mockReset();
+    mockGetAllOrgs.mockReset();
+    mockCreateClient.mockClear();
+  });
+
+  it('returns true when the user is entitled in their only org', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1'));
+    mockRawGet.mockImplementation(entitlementByOrg({ 'org-1': true }));
+
+    const result = await hasExoM1Entitlement(config);
+
+    expect(result).toBe(true);
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/org-1/organization_entitlement_set',
+    );
+    // plain client is required for the raw + organization surfaces
+    expect(mockCreateClient).toHaveBeenCalledWith(expect.anything(), {
+      type: 'plain',
+    });
+  });
+
+  it('returns true when ANY of several orgs is entitled', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1', 'org-2', 'org-3'));
+    mockRawGet.mockImplementation(entitlementByOrg({ 'org-2': true }));
+
+    expect(await hasExoM1Entitlement(config)).toBe(true);
+    expect(mockRawGet).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false when no org is entitled', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1', 'org-2'));
+    mockRawGet.mockImplementation(entitlementByOrg({}));
+
+    expect(await hasExoM1Entitlement(config)).toBe(false);
+  });
+
+  it('returns false when the user belongs to no orgs', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection());
+
+    expect(await hasExoM1Entitlement(config)).toBe(false);
+    expect(mockRawGet).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on a single org even if its entitlement lookup errors, still honoring others', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1', 'org-2'));
+    mockRawGet.mockImplementation((url: string) => {
+      if (url.includes('org-1')) return Promise.reject(new Error('403'));
+      return Promise.resolve({ features: { exoM1: { value: true } } });
+    });
+
+    // org-1 lookup fails closed, org-2 is entitled → overall true
+    expect(await hasExoM1Entitlement(config)).toBe(true);
+  });
+
+  it('returns false and does not throw when listing orgs errors (fail closed / offline)', async () => {
+    mockGetAllOrgs.mockRejectedValue(new Error('ENOTFOUND'));
+
+    expect(await hasExoM1Entitlement(config)).toBe(false);
+  });
+
+  it('returns false when the exoM1 feature object has no value key', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1'));
+    mockRawGet.mockResolvedValue({ features: { exoM1: {} } });
+
+    expect(await hasExoM1Entitlement(config)).toBe(false);
+  });
+
+  it('coerces a truthy-but-non-true feature value to false', async () => {
+    mockGetAllOrgs.mockResolvedValue(orgsCollection('org-1'));
+    mockRawGet.mockResolvedValue({ features: { exoM1: { value: 'yes' } } });
+
+    expect(await hasExoM1Entitlement(config)).toBe(false);
+  });
+});

--- a/packages/mcp-tools/src/utils/entitlements.ts
+++ b/packages/mcp-tools/src/utils/entitlements.ts
@@ -1,0 +1,76 @@
+import { createClient } from 'contentful-management';
+import type { ContentfulConfig } from '../config/types.js';
+import { createClientConfig } from './tools.js';
+
+/** Feature name for the shared ExO M1 rollout entitlement. */
+export const EXO_M1_FEATURE = 'exoM1';
+
+/**
+ * Minimal shape of the organization entitlement set we care about. Each feature
+ * is an object `{ value: boolean }`, not a bare boolean.
+ */
+interface OrganizationEntitlementSet {
+  features?: Record<string, { value?: boolean } | undefined>;
+}
+
+type PlainClient = ReturnType<typeof createPlainClient>;
+
+function createPlainClient(config: ContentfulConfig) {
+  return createClient(createClientConfig(config), { type: 'plain' });
+}
+
+/**
+ * Checks the exoM1 entitlement for a single organization via the public CMA
+ * endpoint `GET /organizations/{orgId}/organization_entitlement_set` — the same
+ * path browser callers use (see experience-packages' ContentOpsEntitlements).
+ * Fails CLOSED per-org: any error (403 on an org where the user isn't an admin,
+ * network, malformed body) returns false so it never sinks the overall check.
+ */
+async function orgHasExoM1(
+  client: PlainClient,
+  organizationId: string,
+): Promise<boolean> {
+  try {
+    const entitlements = await client.raw.get<OrganizationEntitlementSet>(
+      `/organizations/${organizationId}/organization_entitlement_set`,
+    );
+    return entitlements.features?.[EXO_M1_FEATURE]?.value === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks whether the user (identified solely by their management token) has the
+ * shared ExO M1 entitlement in ANY organization they can access.
+ *
+ * The local server takes `spaceId`/`organizationId` per tool call, not as
+ * required config, so at registration time there is no single authoritative org
+ * to scope to. We therefore derive orgs from the PAT: list every org the token
+ * can reach (`organization.getAll`) and register ExO if at least one is
+ * entitled. Combined with the `ENABLE_EXO_TOOLS` opt-in (the primary gate),
+ * this answers "does this user have ExO access anywhere?".
+ *
+ * The Node-only `@contentful/entitlements-api-client` and its internal cluster
+ * URL are not used (unreachable from a locally-run server).
+ *
+ * Fails CLOSED: any error (offline, network, no accessible orgs) returns false,
+ * so the caller withholds ExO tools rather than exposing them unentitled.
+ */
+export async function hasExoM1Entitlement(
+  config: ContentfulConfig,
+): Promise<boolean> {
+  try {
+    const client = createPlainClient(config);
+    const orgs = await client.organization.getAll();
+    if (!orgs.items.length) {
+      return false;
+    }
+    const results = await Promise.all(
+      orgs.items.map((org) => orgHasExoM1(client, org.sys.id)),
+    );
+    return results.some(Boolean);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
[AIS-191](https://contentful.atlassian.net/browse/AIS-191)

## Summary
- ExO tool collections now require **both** gates: the `ENABLE_EXO_TOOLS` opt-in env var **AND** the `exoM1` entitlement (the coordinated M1 rollout gate, per the [ExO M1 rollout doc](https://contentful.atlassian.net/wiki/spaces/PROD/pages/6610124821)).
- **Org is derived from the PAT**, not config. Since the local server takes `spaceId`/`organizationId` per tool call (both are optional env vars), there's no single authoritative org at registration time. `hasExoM1Entitlement` lists the token's accessible orgs (`organization.getAll`) and registers ExO if **any** is entitled — i.e. "does this user have ExO access anywhere?".
- Reads the **public** CMA `GET /organizations/{orgId}/organization_entitlement_set` per org (feature shape is `{ value: boolean }`). **Fails closed** per-org (a 403 on one org doesn't sink the check) and overall (offline / no accessible orgs → no ExO). The Node-only `@contentful/entitlements-api-client` / internal cluster URL is deliberately avoided — unreachable from a locally-run stdio server.
- `registerAllTools` is now async; the entitlement lookup is **skipped entirely** when `ENABLE_EXO_TOOLS` is off, so the flag-off/offline path stays zero-cost.

## Test plan
- [x] Unit tests: `entitlements.test.ts` (8 — any-org-entitled, none-entitled, no-orgs, per-org fail-closed, list-orgs error, feature-shape edge cases) + `register.test.ts` gate matrix (env×entitlement, fail-closed, short-circuit, PAT-derived) — full suites pass
- [x] Typecheck clean for both packages; `organization.getAll` verified against the real SDK type
- [x] Live `features.exoM1.value` shape confirmed against a real org payload

> Base is `feat/exo` (not `main`) — stacks on the ExO tool-registration work.

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-191]: https://contentful.atlassian.net/browse/AIS-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ