### PR TITLE
feat: add get_usages MCP tool [MOI-6821]

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Below is a sample configuration:
 |                           | `publish_ai_action`        | Publish AI actions for use                       |
 |                           | `unpublish_ai_action`      | Unpublish AI actions                             |
 |                           | `delete_ai_action`         | Remove AI actions                                |
+| **Usage**                 | `get_usages`               | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 
 ## 🤝 Contributing and Development
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -141,7 +141,6 @@ Below is a sample configuration:
 |                           | `create_tag`                       | Create new tags with public/private visibility   |
 | **Organizations**         | `list_orgs`                        | List organizations user has access to            |
 |                           | `get_org`                          | Get details of a specific organization           |
-| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 | **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
 |                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
 |                           | `get_ai_action_invocation`         | Get AI action invocation details                 |
@@ -165,6 +164,7 @@ Below is a sample configuration:
 |                           | `space_to_space_param_collection`  | Collect parameters for migration workflow        |
 |                           | `export_space`                     | Export space to file for migration               |
 |                           | `import_space`                     | Import space from exported file                  |
+| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 
 ## 🤝 Contributing
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -141,6 +141,7 @@ Below is a sample configuration:
 |                           | `create_tag`                       | Create new tags with public/private visibility   |
 | **Organizations**         | `list_orgs`                        | List organizations user has access to            |
 |                           | `get_org`                          | Get details of a specific organization           |
+| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 | **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
 |                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
 |                           | `get_ai_action_invocation`         | Get AI action invocation details                 |

--- a/packages/mcp-server/scripts/inspect.mjs
+++ b/packages/mcp-server/scripts/inspect.mjs
@@ -6,7 +6,7 @@ import { dirname, resolve } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const serverPath = resolve(__dirname, '../build/index.js');
+const serverPath = resolve(__dirname, '../dist/index.js');
 
 const args = ['npx', '@modelcontextprotocol/inspector', 'node', serverPath];
 

--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -105,6 +105,7 @@ describe('registerAllTools', () => {
       mcpTools.getSpaceTools(),
       mcpTools.getTagTools(),
       mcpTools.getTaxonomyTools(),
+      mcpTools.getUsageTools(),
     ];
 
     const expectedStandardToolCount = standardToolCollections.reduce(

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -70,6 +70,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   const spaceTools = tools.getSpaceTools();
   const tagTools = tools.getTagTools();
   const taxonomyTools = tools.getTaxonomyTools();
+  const usageTools = tools.getUsageTools();
 
   // ExO collections appended only when both gates pass.
   const allToolCollections = [
@@ -85,6 +86,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
     spaceTools,
     tagTools,
     taxonomyTools,
+    usageTools,
     ...(registerExoTools
       ? [
           tools.getComponentTools(),

--- a/packages/mcp-tools/README.md
+++ b/packages/mcp-tools/README.md
@@ -123,7 +123,6 @@ Each tool includes semantic annotations to help MCP clients understand tool beha
 |                           | `create_tag`                       | Create new tags with public/private visibility   |
 | **Organizations**         | `list_orgs`                        | List organizations user has access to            |
 |                           | `get_org`                          | Get details of a specific organization           |
-| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 | **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
 |                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
 |                           | `get_ai_action_invocation`         | Get AI action invocation details                 |
@@ -147,6 +146,7 @@ Each tool includes semantic annotations to help MCP clients understand tool beha
 |                           | `space_to_space_param_collection`  | Collect parameters for migration workflow        |
 |                           | `export_space`                     | Export space to file for migration               |
 |                           | `import_space`                     | Import space from exported file                  |
+| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 
 ## Configuration
 

--- a/packages/mcp-tools/README.md
+++ b/packages/mcp-tools/README.md
@@ -123,6 +123,7 @@ Each tool includes semantic annotations to help MCP clients understand tool beha
 |                           | `create_tag`                       | Create new tags with public/private visibility   |
 | **Organizations**         | `list_orgs`                        | List organizations user has access to            |
 |                           | `get_org`                          | Get details of a specific organization           |
+| **Usage**                 | `get_usages`                       | Get aggregated usage metrics for an organization, optionally filtered or grouped by space |
 | **AI Actions**            | `create_ai_action`                 | Create custom AI-powered workflows               |
 |                           | `invoke_ai_action`                 | Invoke AI action with variables (bulk support)   |
 |                           | `get_ai_action_invocation`         | Get AI action invocation details                 |

--- a/packages/mcp-tools/src/ContentfulMcpTools.ts
+++ b/packages/mcp-tools/src/ContentfulMcpTools.ts
@@ -11,6 +11,7 @@ import { createOrgTools } from './tools/orgs/register.js';
 import { createSpaceTools } from './tools/spaces/register.js';
 import { createTagTools } from './tools/tags/register.js';
 import { createTaxonomyTools } from './tools/taxonomies/register.js';
+import { createUsageTools } from './tools/usage/register.js';
 import { createJobTools } from './tools/jobs/space-to-space-migration/register.js';
 import { createComponentTools } from './tools/exo/components/register.js';
 import { createExperienceFragmentTools } from './tools/exo/experience-fragments/register.js';
@@ -149,6 +150,13 @@ export class ContentfulMcpTools {
    */
   getTaxonomyTools() {
     return createTaxonomyTools(this.config);
+  }
+
+  /**
+   * Get usage tools
+   */
+  getUsageTools() {
+    return createUsageTools(this.config);
   }
 
   /**

--- a/packages/mcp-tools/src/tools/usage/getUsages.test.ts
+++ b/packages/mcp-tools/src/tools/usage/getUsages.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  mockRawGet,
+  mockCreateClient,
+  testUsageCollection,
+} from './mockClient.js';
+import { getUsagesTool } from './getUsages.js';
+import { formatResponse } from '../../utils/formatters.js';
+import { summarizeData } from '../../utils/summarizer.js';
+import { createClientConfig } from '../../utils/tools.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+describe('getUsagesTool', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the aggregated usage endpoint and returns a summarized response', async () => {
+    mockRawGet.mockResolvedValue(testUsageCollection);
+
+    const tool = getUsagesTool(mockConfig);
+    const result = await tool({
+      organizationId: 'test-org-id',
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+      granularity: 'P1D',
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      createClientConfig(mockConfig),
+      { type: 'plain' },
+    );
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/test-org-id/usages/api_call_cma',
+      {
+        params: {
+          'date[gte]': '2026-06-01',
+          'date[lte]': '2026-06-30',
+          granularity: 'P1D',
+        },
+      },
+    );
+
+    const summarized = summarizeData(testUsageCollection, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more usage buckets, please ask me to retrieve the next page using the skip parameter.',
+    });
+
+    const expectedResponse = formatResponse('Usage retrieved successfully', {
+      usage: summarized,
+      total: testUsageCollection.total,
+      limit: testUsageCollection.limit,
+      skip: testUsageCollection.skip,
+      metricKey: 'api_call_cma',
+      organizationId: 'test-org-id',
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expectedResponse }],
+    });
+  });
+
+  it('falls back to config.organizationId when organizationId is omitted', async () => {
+    mockRawGet.mockResolvedValue(testUsageCollection);
+
+    const tool = getUsagesTool(mockConfig);
+    await tool({
+      metricKey: 'functions_invocations',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+    });
+
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/test-org-id/usages/functions_invocations',
+      {
+        params: {
+          'date[gte]': '2026-06-01',
+          'date[lte]': '2026-06-30',
+        },
+      },
+    );
+  });
+
+  it('serializes a single-value dimension filter as filter[<key>]=<value>', async () => {
+    mockRawGet.mockResolvedValue(testUsageCollection);
+
+    const tool = getUsagesTool(mockConfig);
+    await tool({
+      organizationId: 'test-org-id',
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+      filter: { 'sys.dimensions.space.sys.id': 'space-1' },
+    });
+
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/test-org-id/usages/api_call_cma',
+      {
+        params: {
+          'date[gte]': '2026-06-01',
+          'date[lte]': '2026-06-30',
+          'filter[sys.dimensions.space.sys.id]': 'space-1',
+        },
+      },
+    );
+  });
+
+  it('serializes a multi-value dimension filter as filter[<key>][in]=<csv>', async () => {
+    mockRawGet.mockResolvedValue(testUsageCollection);
+
+    const tool = getUsagesTool(mockConfig);
+    await tool({
+      organizationId: 'test-org-id',
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+      filter: {
+        'sys.dimensions.space.sys.id': ['space-1', 'space-2', 'space-3'],
+      },
+    });
+
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/test-org-id/usages/api_call_cma',
+      {
+        params: {
+          'date[gte]': '2026-06-01',
+          'date[lte]': '2026-06-30',
+          'filter[sys.dimensions.space.sys.id][in]': 'space-1,space-2,space-3',
+        },
+      },
+    );
+  });
+
+  it('passes group, order, limit, and skip through to the query', async () => {
+    mockRawGet.mockResolvedValue(testUsageCollection);
+
+    const tool = getUsagesTool(mockConfig);
+    await tool({
+      organizationId: 'test-org-id',
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+      group: 'space_id',
+      order: '-total_usage',
+      limit: 25,
+      skip: 50,
+    });
+
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/organizations/test-org-id/usages/api_call_cma',
+      {
+        params: {
+          'date[gte]': '2026-06-01',
+          'date[lte]': '2026-06-30',
+          group: 'space_id',
+          order: '-total_usage',
+          limit: 25,
+          skip: 50,
+        },
+      },
+    );
+  });
+
+  it('returns an error response when no organizationId is provided or configured', async () => {
+    const configWithoutOrg = createMockConfig({ organizationId: undefined });
+    const tool = getUsagesTool(configWithoutOrg);
+    const result = await tool({
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+    });
+
+    expect(mockRawGet).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving usage: organizationId is required (either as a tool argument or via the ORGANIZATION_ID env var).',
+        },
+      ],
+    });
+  });
+
+  it('surfaces errors from the underlying API call', async () => {
+    mockRawGet.mockRejectedValue(new Error('Request failed'));
+
+    const tool = getUsagesTool(mockConfig);
+    const result = await tool({
+      organizationId: 'test-org-id',
+      metricKey: 'api_call_cma',
+      dateGte: '2026-06-01',
+      dateLte: '2026-06-30',
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error retrieving usage: Request failed',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/usage/getUsages.test.ts
+++ b/packages/mcp-tools/src/tools/usage/getUsages.test.ts
@@ -144,7 +144,7 @@ describe('getUsagesTool', () => {
       metricKey: 'api_call_cma',
       dateGte: '2026-06-01',
       dateLte: '2026-06-30',
-      group: 'space_id',
+      group: 'sys.dimensions.space.sys.id',
       order: '-total_usage',
       limit: 25,
       skip: 50,
@@ -156,7 +156,7 @@ describe('getUsagesTool', () => {
         params: {
           'date[gte]': '2026-06-01',
           'date[lte]': '2026-06-30',
-          group: 'space_id',
+          group: 'sys.dimensions.space.sys.id',
           order: '-total_usage',
           limit: 25,
           skip: 50,

--- a/packages/mcp-tools/src/tools/usage/getUsages.ts
+++ b/packages/mcp-tools/src/tools/usage/getUsages.ts
@@ -1,0 +1,231 @@
+import { z } from 'zod';
+import { createClient } from 'contentful-management';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { createClientConfig } from '../../utils/tools.js';
+import { summarizeData } from '../../utils/summarizer.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+// NOTE: This tool calls the aggregated usage endpoint via the SDK's plain-client
+// escape hatch (`client.raw.get`) because `contentful-management.js` has not yet
+// shipped `client.usage.getAggregated` (see MOI-6808 / contentful-management.js#3088).
+// Follow-up MOI-7192 tracks swapping this for the typed SDK method once released.
+
+export const AGGREGATED_USAGE_METRIC_KEYS = [
+  'api_call_cma',
+  'api_call_cpa',
+  'api_call_cda',
+  'api_call_graphql',
+  'asset_bandwidth',
+  'functions_invocations',
+  'ai_action_invocation',
+  'ai_action_word_count',
+  'ai_consumption_unit',
+] as const;
+
+type AggregatedUsageMetricKey = (typeof AGGREGATED_USAGE_METRIC_KEYS)[number];
+
+type SysLink = {
+  sys: { type: 'Link'; linkType: string; id: string };
+};
+
+type AggregatedUsageItemProps = {
+  sys: {
+    id: string;
+    type: string;
+    key: string;
+    organization: {
+      sys: { type: 'Link'; linkType: 'Organization'; id: string };
+    };
+    unitOfMeasurement: string;
+    dimensions: Record<string, SysLink>;
+    accumulation: string;
+  };
+  dateRange: { start: string; end: string };
+  granularity?: string;
+  data: number[];
+};
+
+type AggregatedUsageCollectionProps = {
+  sys: { type: 'Array' };
+  total: number;
+  skip: number;
+  limit: number;
+  items: AggregatedUsageItemProps[];
+};
+
+const FilterValueSchema = z.union([
+  z.string().min(1),
+  z.array(z.string().min(1)).min(1).max(10),
+]);
+
+// Per-metric allowed dimensions, from the Usage API OpenAPI `MetricDimensions` component.
+// See: https://github.com/contentful/usage-api openapi/v1.oas3.yaml
+export const METRIC_DIMENSIONS = {
+  functions_invocations: ['space_id', 'app_id', 'function_id'],
+  asset_bandwidth: ['space_id', 'asset_id'],
+  api_call_cma: ['space_id'],
+  api_call_cpa: ['space_id'],
+  api_call_cda: ['space_id'],
+  api_call_graphql: ['space_id'],
+  ai_action_invocation: [
+    'space_id',
+    'ai_action_id',
+    'model_provider',
+    'model_id',
+  ],
+  ai_action_word_count: [
+    'space_id',
+    'ai_action_id',
+    'model_provider',
+    'model_id',
+  ],
+  ai_consumption_unit: [
+    'space_id',
+    'ai_action_id',
+    'model_provider',
+    'model_id',
+  ],
+} as const satisfies Record<AggregatedUsageMetricKey, readonly string[]>;
+
+export const GetUsagesToolParams = z.object({
+  organizationId: z
+    .string()
+    .optional()
+    .describe(
+      'Organization ID. If omitted, falls back to the ORGANIZATION_ID configured on the server.',
+    ),
+  metricKey: z
+    .enum(AGGREGATED_USAGE_METRIC_KEYS)
+    .describe(
+      'Metric to aggregate. Availability depends on the products enabled for the organization. ' +
+        'Allowed dimensions per metric (used by "group", "filter", and "order"): ' +
+        'api_call_cma / api_call_cpa / api_call_cda / api_call_graphql → space_id. ' +
+        'asset_bandwidth → space_id, asset_id. ' +
+        'functions_invocations → space_id, app_id, function_id. ' +
+        'ai_action_invocation / ai_action_word_count / ai_consumption_unit → space_id, ai_action_id, model_provider, model_id.',
+    ),
+  dateGte: z
+    .string()
+    .describe(
+      'Start date (inclusive) in ISO-8601 format (YYYY-MM-DD or full date-time). ' +
+        'Sent as query param date[gte]. Max lookback: 12 months from now.',
+    ),
+  dateLte: z
+    .string()
+    .describe(
+      'End date (inclusive) in ISO-8601 format (YYYY-MM-DD or full date-time). ' +
+        'Sent as query param date[lte].',
+    ),
+  granularity: z
+    .enum(['P1D', 'P1M'])
+    .optional()
+    .describe(
+      'Bucket size as an ISO-8601 duration: "P1D" (daily, max 31-day range) or "P1M" ' +
+        '(monthly, max 12 calendar months including current). Default P1D.',
+    ),
+  group: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated dimension names to group results by. Values must come from ' +
+        'the allowed dimensions for the chosen metricKey (see metricKey description), ' +
+        'e.g. "space_id" or "space_id,function_id".',
+    ),
+  filter: z
+    .record(z.string(), FilterValueSchema)
+    .optional()
+    .describe(
+      'Filter by dimension values. Keys use the shape "sys.dimensions.<dimension>.sys.<attribute>", ' +
+        'for example "sys.dimensions.space.sys.id" for the space_id dimension. Pass a string for a ' +
+        'single-value filter or an array of up to 10 strings to filter by multiple values (uses the ' +
+        '[in] operator). Available dimensions per metric are listed in the metricKey description.',
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(1000)
+    .optional()
+    .describe('Maximum number of items to return (1–1000, default 1000).'),
+  skip: z
+    .number()
+    .int()
+    .min(0)
+    .max(10000)
+    .optional()
+    .describe('Number of items to skip for pagination (0–10000, default 0).'),
+  order: z
+    .string()
+    .optional()
+    .describe(
+      'Column to sort by; prefix with "-" for descending (e.g. "-total_usage"). ' +
+        'Allowed columns: space_id, app_id, function_id, asset_id, ai_action_id, ' +
+        'model_provider, model_id, total_usage. When "group" is set, non-synthetic ' +
+        'order columns must be a subset of grouped columns. ' +
+        '"total_usage" sums usage per group across the requested date range.',
+    ),
+});
+
+type Params = z.infer<typeof GetUsagesToolParams>;
+
+function buildQuery(args: Params): Record<string, string | number> {
+  const query: Record<string, string | number> = {};
+  if (args.dateGte) query['date[gte]'] = args.dateGte;
+  if (args.dateLte) query['date[lte]'] = args.dateLte;
+  if (args.granularity) query['granularity'] = args.granularity;
+  if (args.group) query['group'] = args.group;
+  if (args.order) query['order'] = args.order;
+  if (typeof args.limit === 'number') query['limit'] = args.limit;
+  if (typeof args.skip === 'number') query['skip'] = args.skip;
+
+  if (args.filter) {
+    for (const [key, value] of Object.entries(args.filter)) {
+      if (Array.isArray(value)) {
+        query[`filter[${key}][in]`] = value.join(',');
+      } else {
+        query[`filter[${key}]`] = value;
+      }
+    }
+  }
+
+  return query;
+}
+
+export function getUsagesTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const organizationId = args.organizationId ?? config.organizationId;
+    if (!organizationId) {
+      throw new Error(
+        'organizationId is required (either as a tool argument or via the ORGANIZATION_ID env var).',
+      );
+    }
+
+    const client = createClient(createClientConfig(config), { type: 'plain' });
+
+    const metricKey: AggregatedUsageMetricKey = args.metricKey;
+    const collection = await client.raw.get<AggregatedUsageCollectionProps>(
+      `/organizations/${organizationId}/usages/${metricKey}`,
+      { params: buildQuery(args) },
+    );
+
+    const summarized = summarizeData(collection, {
+      maxItems: 10,
+      remainingMessage:
+        'To see more usage buckets, please ask me to retrieve the next page using the skip parameter.',
+    });
+
+    return createSuccessResponse('Usage retrieved successfully', {
+      usage: summarized,
+      total: collection.total,
+      limit: collection.limit,
+      skip: collection.skip,
+      metricKey,
+      organizationId,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error retrieving usage');
+}

--- a/packages/mcp-tools/src/tools/usage/getUsages.ts
+++ b/packages/mcp-tools/src/tools/usage/getUsages.ts
@@ -31,6 +31,13 @@ type SysLink = {
   sys: { type: 'Link'; linkType: string; id: string };
 };
 
+// A response dimension is either a classic Link (id-only families like
+// space/app/function/ai_action/asset) or an embedded-entity block whose
+// sys.type names the entity (e.g. 'Model') and carries the grouped suffixes.
+type DimensionValue =
+  | SysLink
+  | { sys: { type: string; [suffix: string]: unknown } };
+
 type AggregatedUsageItemProps = {
   sys: {
     id: string;
@@ -40,7 +47,7 @@ type AggregatedUsageItemProps = {
       sys: { type: 'Link'; linkType: 'Organization'; id: string };
     };
     unitOfMeasurement: string;
-    dimensions: Record<string, SysLink>;
+    dimensions: Record<string, DimensionValue>;
     accumulation: string;
   };
   dateRange: { start: string; end: string };
@@ -62,31 +69,39 @@ const FilterValueSchema = z.union([
 ]);
 
 // Per-metric allowed dimensions, from the Usage API OpenAPI `MetricDimensions` component.
+// Values are in the wire form used by `group`, `filter`, and `order`.
 // See: https://github.com/contentful/usage-api openapi/v1.oas3.yaml
 export const METRIC_DIMENSIONS = {
-  functions_invocations: ['space_id', 'app_id', 'function_id'],
-  asset_bandwidth: ['space_id', 'asset_id'],
-  api_call_cma: ['space_id'],
-  api_call_cpa: ['space_id'],
-  api_call_cda: ['space_id'],
-  api_call_graphql: ['space_id'],
+  functions_invocations: [
+    'sys.dimensions.space.sys.id',
+    'sys.dimensions.app.sys.id',
+    'sys.dimensions.function.sys.id',
+  ],
+  asset_bandwidth: [
+    'sys.dimensions.space.sys.id',
+    'sys.dimensions.asset.sys.id',
+  ],
+  api_call_cma: ['sys.dimensions.space.sys.id'],
+  api_call_cpa: ['sys.dimensions.space.sys.id'],
+  api_call_cda: ['sys.dimensions.space.sys.id'],
+  api_call_graphql: ['sys.dimensions.space.sys.id'],
   ai_action_invocation: [
-    'space_id',
-    'ai_action_id',
-    'model_provider',
-    'model_id',
+    'sys.dimensions.space.sys.id',
+    'sys.dimensions.ai_action.sys.id',
+    'sys.dimensions.model.sys.provider',
+    'sys.dimensions.model.sys.id',
   ],
   ai_action_word_count: [
-    'space_id',
-    'ai_action_id',
-    'model_provider',
-    'model_id',
+    'sys.dimensions.space.sys.id',
+    'sys.dimensions.ai_action.sys.id',
+    'sys.dimensions.model.sys.provider',
+    'sys.dimensions.model.sys.id',
   ],
   ai_consumption_unit: [
-    'space_id',
-    'ai_action_id',
-    'model_provider',
-    'model_id',
+    'sys.dimensions.space.sys.id',
+    'sys.dimensions.ai_action.sys.id',
+    'sys.dimensions.model.sys.provider',
+    'sys.dimensions.model.sys.id',
   ],
 } as const satisfies Record<AggregatedUsageMetricKey, readonly string[]>;
 
@@ -101,11 +116,13 @@ export const GetUsagesToolParams = z.object({
     .enum(AGGREGATED_USAGE_METRIC_KEYS)
     .describe(
       'Metric to aggregate. Availability depends on the products enabled for the organization. ' +
-        'Allowed dimensions per metric (used by "group", "filter", and "order"): ' +
-        'api_call_cma / api_call_cpa / api_call_cda / api_call_graphql → space_id. ' +
-        'asset_bandwidth → space_id, asset_id. ' +
-        'functions_invocations → space_id, app_id, function_id. ' +
-        'ai_action_invocation / ai_action_word_count / ai_consumption_unit → space_id, ai_action_id, model_provider, model_id.',
+        'Allowed dimensions per metric (used by "group", "filter", and "order", all in the ' +
+        'form sys.dimensions.<name>.sys.<suffix>): ' +
+        'api_call_cma / api_call_cpa / api_call_cda / api_call_graphql → sys.dimensions.space.sys.id. ' +
+        'asset_bandwidth → sys.dimensions.space.sys.id, sys.dimensions.asset.sys.id. ' +
+        'functions_invocations → sys.dimensions.space.sys.id, sys.dimensions.app.sys.id, sys.dimensions.function.sys.id. ' +
+        'ai_action_invocation / ai_action_word_count / ai_consumption_unit → sys.dimensions.space.sys.id, ' +
+        'sys.dimensions.ai_action.sys.id, sys.dimensions.model.sys.provider, sys.dimensions.model.sys.id.',
     ),
   dateGte: z
     .string()
@@ -130,9 +147,10 @@ export const GetUsagesToolParams = z.object({
     .string()
     .optional()
     .describe(
-      'Comma-separated dimension names to group results by. Values must come from ' +
-        'the allowed dimensions for the chosen metricKey (see metricKey description), ' +
-        'e.g. "space_id" or "space_id,function_id".',
+      'Comma-separated dimension keys (in the form sys.dimensions.<name>.sys.<suffix>) ' +
+        'to group results by. Values must come from the allowed dimensions for the chosen ' +
+        'metricKey (see metricKey description), e.g. "sys.dimensions.space.sys.id" or ' +
+        '"sys.dimensions.space.sys.id,sys.dimensions.function.sys.id".',
     ),
   filter: z
     .record(z.string(), FilterValueSchema)
@@ -161,11 +179,13 @@ export const GetUsagesToolParams = z.object({
     .string()
     .optional()
     .describe(
-      'Column to sort by; prefix with "-" for descending (e.g. "-total_usage"). ' +
-        'Allowed columns: space_id, app_id, function_id, asset_id, ai_action_id, ' +
-        'model_provider, model_id, total_usage. When "group" is set, non-synthetic ' +
-        'order columns must be a subset of grouped columns. ' +
-        '"total_usage" sums usage per group across the requested date range.',
+      'Column to sort by, in the form sys.dimensions.<name>.sys.<suffix>; ' +
+        'prefix with "-" for descending (e.g. "-sys.dimensions.space.sys.id"). ' +
+        'Allowed dimension columns match the metricKey (see metricKey description). ' +
+        'The synthetic column "total_usage" is a bare token (e.g. "total_usage" or ' +
+        '"-total_usage") and sums usage per group across the requested date range. ' +
+        'When "group" is set, non-synthetic order columns must be a subset of grouped ' +
+        'columns. Legacy underscore-form tokens (e.g. "space_id") return a 422.',
     ),
 });
 

--- a/packages/mcp-tools/src/tools/usage/mockClient.ts
+++ b/packages/mcp-tools/src/tools/usage/mockClient.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest';
+
+const { mockRawGet, mockCreateClient } = vi.hoisted(() => {
+  const mockRawGet = vi.fn();
+  const mockCreateClient = vi.fn(() => ({
+    raw: {
+      get: mockRawGet,
+    },
+  }));
+  return { mockRawGet, mockCreateClient };
+});
+
+vi.mock('contentful-management', () => {
+  return {
+    default: {
+      createClient: mockCreateClient,
+    },
+    createClient: mockCreateClient,
+  };
+});
+
+export { mockRawGet, mockCreateClient };
+
+export const testUsageCollection = {
+  sys: { type: 'Array' as const },
+  total: 1,
+  skip: 0,
+  limit: 100,
+  items: [
+    {
+      sys: {
+        id: 'mock-metric-id',
+        type: 'AggregatedUsage',
+        key: 'api_call_cma',
+        organization: {
+          sys: {
+            type: 'Link' as const,
+            linkType: 'Organization' as const,
+            id: 'test-org-id',
+          },
+        },
+        unitOfMeasurement: 'requests',
+        dimensions: {},
+        accumulation: 'integrate',
+      },
+      dateRange: { start: '2026-06-01', end: '2026-06-30' },
+      granularity: 'P1D',
+      data: [1200, 980, 1430],
+    },
+  ],
+};

--- a/packages/mcp-tools/src/tools/usage/register.test.ts
+++ b/packages/mcp-tools/src/tools/usage/register.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { createUsageTools } from './register.js';
+import { GetUsagesToolParams } from './getUsages.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+describe('usage tools collection', () => {
+  const mockConfig = createMockConfig();
+
+  it('should export createUsageTools factory function', () => {
+    expect(createUsageTools).toBeDefined();
+    expect(typeof createUsageTools).toBe('function');
+  });
+
+  it('should create usageTools collection with correct structure', () => {
+    const usageTools = createUsageTools(mockConfig);
+    expect(usageTools).toBeDefined();
+    expect(Object.keys(usageTools)).toHaveLength(1);
+  });
+
+  it('should have getUsages tool with correct properties', () => {
+    const usageTools = createUsageTools(mockConfig);
+    const { getUsages } = usageTools;
+
+    expect(getUsages.title).toBe('get_usages');
+    expect(getUsages.description).toContain(
+      'aggregated usage metrics for a Contentful organization',
+    );
+    expect(getUsages.inputParams).toStrictEqual(GetUsagesToolParams.shape);
+    expect(getUsages.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+    expect(getUsages.tool).toBeDefined();
+    expect(typeof getUsages.tool).toBe('function');
+  });
+});

--- a/packages/mcp-tools/src/tools/usage/register.ts
+++ b/packages/mcp-tools/src/tools/usage/register.ts
@@ -9,10 +9,9 @@ export function createUsageTools(config: ContentfulConfig) {
       title: 'get_usages',
       description:
         'Get aggregated usage metrics for a Contentful organization, optionally scoped to one or ' +
-        'more spaces (or other dimensions) via filter/group. Calls the public Usage API ' +
-        '(/organizations/{orgId}/usages/{metricKey}), scoped to a single metricKey per call. ' +
+        'more spaces (or other dimensions) via filter/group. ' +
         'Supports date-range windowing, ISO-8601 granularity (e.g. "P1D"), grouping by dimensions ' +
-        '(e.g. group="space"), and single-value / [in] filtering by dimensions ' +
+        '(e.g. group="sys.dimensions.space.sys.id"), and single-value / [in] filtering by dimensions ' +
         '(e.g. filter={"sys.dimensions.space.sys.id": "<space-id>"} or an array of up to 10 IDs). ' +
         'Use for questions like: "how much CMA traffic did this org make last month?", ' +
         '"which spaces used the most asset bandwidth this week?", "were there any AI action ' +

--- a/packages/mcp-tools/src/tools/usage/register.ts
+++ b/packages/mcp-tools/src/tools/usage/register.ts
@@ -1,0 +1,29 @@
+import { GetUsagesToolParams, getUsagesTool } from './getUsages.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export function createUsageTools(config: ContentfulConfig) {
+  const getUsages = getUsagesTool(config);
+
+  return {
+    getUsages: {
+      title: 'get_usages',
+      description:
+        'Get aggregated usage metrics for a Contentful organization, optionally scoped to one or ' +
+        'more spaces (or other dimensions) via filter/group. Calls the public Usage API ' +
+        '(/organizations/{orgId}/usages/{metricKey}), scoped to a single metricKey per call. ' +
+        'Supports date-range windowing, ISO-8601 granularity (e.g. "P1D"), grouping by dimensions ' +
+        '(e.g. group="space"), and single-value / [in] filtering by dimensions ' +
+        '(e.g. filter={"sys.dimensions.space.sys.id": "<space-id>"} or an array of up to 10 IDs). ' +
+        'Use for questions like: "how much CMA traffic did this org make last month?", ' +
+        '"which spaces used the most asset bandwidth this week?", "were there any AI action ' +
+        'invocations for space X?".',
+      inputParams: GetUsagesToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getUsages,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a `get_usages` tool under a new **Usage** category that wraps the public Usage API (`GET /organizations/{orgId}/usages/{metricKey}`), so AI assistants can answer questions like "how much CMA traffic did this org use last month?" or "which spaces used the most asset bandwidth this week?".
- The tool routes through the SDK's plain-client escape hatch `client.raw.get(...)` (same pattern as `utils/entitlements.ts`) because the typed SDK method `client.usage.getAggregated` from [contentful/contentful-management.js#3088](https://github.com/contentful/contentful-management.js/pull/3088) is still pending release. Swap-out to the typed method is tracked in [MOI-7192](https://contentful.atlassian.net/browse/MOI-7192).
- Zod input schema is aligned with the [usage-api OpenAPI spec](https://github.com/contentful/usage-api/blob/aeaf6c125117626d0073e58deb2739f36a7f2ded/openapi/v1.oas3.yaml): `metricKey` and `granularity` (P1D/P1M) as enums, `dateGte`/`dateLte` required, `limit` (1–1000) and `skip` (0–10000) bounded, and per-metric allowed dimensions documented inline for `group`/`filter`/`order`.

## Test plan

- [x] Unit tests for URL construction, org fallback to env, single-value filter, `[in]` filter, group/order/limit/skip pass-through, missing-org error, and API error surfacing (7 tests in `getUsages.test.ts`)
- [x] Registration structure tests (3 tests in `register.test.ts`)
- [x] Server registration count test updated (`packages/mcp-server/src/tools/register.test.ts`)
- [x] `npm run test:run` — mcp-tools (128 files, 647 tests) and mcp-server (12 tests) all pass
- [x] `npm run typecheck` clean on both packages
- [x] `npm run lint` — only pre-existing warnings, no new ones
- [x] `npm run build` succeeds on both packages
- [ ] Integration test against staging — deferred to [MOI-7192](https://contentful.atlassian.net/browse/MOI-7192) (no integration harness exists yet)

## Related tickets

- [MOI-6821](https://contentful.atlassian.net/browse/MOI-6821) — this ticket
- [MOI-6808](https://contentful.atlassian.net/browse/MOI-6808) — SDK release (blocking dependency, pending)
- [MOI-7192](https://contentful.atlassian.net/browse/MOI-7192) — follow-up: swap `client.raw.get` for `client.usage.getAggregated` once the SDK ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOI-7192]: https://contentful.atlassian.net/browse/MOI-7192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOI-7192]: https://contentful.atlassian.net/browse/MOI-7192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a new `get_usages` MCP tool under a Usage category that wraps the Contentful Usage API, enabling AI assistants to answer questions about API traffic, asset bandwidth, function invocations, and AI consumption metrics. The tool uses the SDK's raw client escape hatch since the typed SDK method is pending release, with dimension keys updated to the long-form `sys.dimensions.<name>.sys.<suffix>` format per the usage-api OpenAPI spec.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds `get_usages` tool supporting 9 usage metrics (api_call_cma, api_call_cpa, api_call_cda, api_call_graphql, asset_bandwidth, functions_invocations, ai_action_invocation, ai_action_word_count, ai_consumption_unit) with date range filtering, ISO-8601 granularity (P1D/P1M), dimension-based grouping, and pagination via limit/skip in getUsages.ts and register.ts</li>

<li>Updates METRIC_DIMENSIONS constant to use long-form wire keys (sys.dimensions.space.sys.id) instead of legacy underscore-form (space_id) across all metrics, and widens DimensionValue type to accept both SysLink and embedded-entity shapes for model families in getUsages.ts</li>

<li>Implements SDK escape-hatch pattern using `client.raw.get()` via plain client type instead of the pending `client.usage.getAggregated` typed method, with MOI-7192 tracking the future swap in getUsages.ts</li>

<li>Adds comprehensive test coverage with 10 unit tests across getUsages.test.ts (URL construction, org fallback, single-value/[in] filters, group/order/limit/skip passthrough, missing-org and API error handling) and register.test.ts (registration structure validation)</li>

<li>Fixes inspect.mjs script path from `build/index.js` to `dist/index.js` to match the actual build output directory structure</li>

</ul>
</details>

</div>