### PR TITLE
fix: sanitize serialized Contentful SDK errors

### DIFF
--- a/packages/mcp-tools/src/test-helpers/sdkError.ts
+++ b/packages/mcp-tools/src/test-helpers/sdkError.ts
@@ -1,0 +1,44 @@
+import * as contentful from 'contentful-management';
+
+/** Build an actual SDK error without network access or real credentials. */
+export async function createSdkError(status = 422): Promise<Error> {
+  const client = contentful.createClient({
+    accessToken: 'synthetic-token-ABCDE',
+    host: 'contentful.invalid',
+    retryOnError: false,
+    headers: { 'X-Custom-Secret': 'synthetic-secret' },
+    adapter: async (config) => {
+      throw {
+        config: { ...config, data: 'synthetic-secret' },
+        response: {
+          status,
+          statusText: 'Bad Request',
+          data: {
+            sys: { id: status === 400 ? 'BadRequest' : 'ValidationFailed' },
+            message: 'Validation failed',
+            requestId: 'synthetic-request-id',
+            details: {
+              errors: [
+                {
+                  name: 'unknown',
+                  path: ['fields', 'title'],
+                  value: 'synthetic-secret',
+                },
+              ],
+              request: { headers: { Authorization: 'synthetic-secret' } },
+            },
+          },
+        },
+      };
+    },
+  });
+
+  return client.contentType
+    .getMany({ spaceId: 'test-space', environmentId: 'test-environment' })
+    .then(
+      () => {
+        throw new Error('Expected the SDK request to fail');
+      },
+      (error: Error) => error,
+    );
+}

--- a/packages/mcp-tools/src/tools/ai-actions/publishAiAction.test.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/publishAiAction.test.ts
@@ -72,7 +72,7 @@ describe('publishAiAction', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('AI action publish failed', {
-      status: error,
+      status: error.message,
       aiActionId: 'test-ai-action-id',
     });
     expect(result).toEqual({

--- a/packages/mcp-tools/src/tools/ai-actions/publishAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/publishAiAction.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -50,7 +51,7 @@ export function publishAiActionTool(config: ContentfulConfig) {
       });
     } catch (error) {
       return createSuccessResponse('AI action publish failed', {
-        status: error,
+        status: formatErrorMessage(error),
         aiActionId: args.aiActionId,
       });
     }

--- a/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.test.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.test.ts
@@ -67,7 +67,7 @@ describe('unpublishAiAction', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('AI action unpublish failed', {
-      status: error,
+      status: error.message,
       aiActionId: 'test-ai-action-id',
     });
     expect(result).toEqual({
@@ -88,7 +88,7 @@ describe('unpublishAiAction', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('AI action unpublish failed', {
-      status: error,
+      status: error.message,
       aiActionId: 'test-ai-action-id',
     });
     expect(result).toEqual({

--- a/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.ts
+++ b/packages/mcp-tools/src/tools/ai-actions/unpublishAiAction.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -40,7 +41,7 @@ export function unpublishAiActionTool(config: ContentfulConfig) {
       });
     } catch (error) {
       return createSuccessResponse('AI action unpublish failed', {
-        status: error,
+        status: formatErrorMessage(error),
         aiActionId: args.aiActionId,
       });
     }

--- a/packages/mcp-tools/src/tools/assets/archiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/archiveAsset.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -77,8 +78,8 @@ export function archiveAssetTool(config: ContentfulConfig) {
       } catch (error) {
         const errorMessage =
           successfullyArchived.length > 0
-            ? `Failed to archive asset '${assetId}' after successfully archiving ${successfullyArchived.length} asset(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-            : `Failed to archive asset '${assetId}': ${error instanceof Error ? error.message : String(error)}`;
+            ? `Failed to archive asset '${assetId}' after successfully archiving ${successfullyArchived.length} asset(s): [${successfullyArchived.join(', ')}]. Original error: ${formatErrorMessage(error)}`
+            : `Failed to archive asset '${assetId}': ${formatErrorMessage(error)}`;
 
         throw new Error(errorMessage);
       }

--- a/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.test.ts
@@ -164,7 +164,7 @@ describe('publishAsset', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('Asset publish failed', {
-      status: publishError,
+      status: publishError.message,
       assetId: mockArgs.assetId,
     });
     expect(result).toEqual({
@@ -185,7 +185,7 @@ describe('publishAsset', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('Asset publish failed', {
-      status: error,
+      status: error.message,
       assetId: mockArgs.assetId,
     });
     expect(result).toEqual({

--- a/packages/mcp-tools/src/tools/assets/publishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/publishAsset.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -89,7 +90,7 @@ export function publishAssetTool(config: ContentfulConfig) {
         });
       } catch (error) {
         return createSuccessResponse('Asset publish failed', {
-          status: error,
+          status: formatErrorMessage(error),
           assetId: assetIds[0],
         });
       }

--- a/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unarchiveAsset.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -77,8 +78,8 @@ export function unarchiveAssetTool(config: ContentfulConfig) {
       } catch (error) {
         const errorMessage =
           successfullyUnarchived.length > 0
-            ? `Failed to unarchive asset '${assetId}' after successfully unarchiving ${successfullyUnarchived.length} asset(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-            : `Failed to unarchive asset '${assetId}': ${error instanceof Error ? error.message : String(error)}`;
+            ? `Failed to unarchive asset '${assetId}' after successfully unarchiving ${successfullyUnarchived.length} asset(s): [${successfullyUnarchived.join(', ')}]. Original error: ${formatErrorMessage(error)}`
+            : `Failed to unarchive asset '${assetId}': ${formatErrorMessage(error)}`;
 
         throw new Error(errorMessage);
       }

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.test.ts
@@ -165,7 +165,7 @@ describe('unpublishAsset', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('Asset unpublish failed', {
-      status: unpublishError,
+      status: unpublishError.message,
       assetId: mockArgs.assetId,
     });
     expect(result).toEqual({
@@ -186,7 +186,7 @@ describe('unpublishAsset', () => {
     const result = await tool(mockArgs);
 
     const expectedResponse = formatResponse('Asset unpublish failed', {
-      status: error,
+      status: error.message,
       assetId: mockArgs.assetId,
     });
     expect(result).toEqual({

--- a/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
+++ b/packages/mcp-tools/src/tools/assets/unpublishAsset.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -89,7 +90,7 @@ export function unpublishAssetTool(config: ContentfulConfig) {
         });
       } catch (error) {
         return createSuccessResponse('Asset unpublish failed', {
-          status: error,
+          status: formatErrorMessage(error),
           assetId: assetIds[0],
         });
       }

--- a/packages/mcp-tools/src/tools/entries/archiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/archiveEntry.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -76,8 +77,8 @@ export function archiveEntryTool(config: ContentfulConfig) {
       } catch (error) {
         const errorMessage =
           successfullyArchived.length > 0
-            ? `Failed to archive entry '${entryId}' after successfully archiving ${successfullyArchived.length} entry(s): [${successfullyArchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-            : `Failed to archive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
+            ? `Failed to archive entry '${entryId}' after successfully archiving ${successfullyArchived.length} entry(s): [${successfullyArchived.join(', ')}]. Original error: ${formatErrorMessage(error)}`
+            : `Failed to archive entry '${entryId}': ${formatErrorMessage(error)}`;
 
         throw new Error(errorMessage);
       }

--- a/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
+++ b/packages/mcp-tools/src/tools/entries/unarchiveEntry.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../utils/response.js';
 import {
@@ -76,8 +77,8 @@ export function unarchiveEntryTool(config: ContentfulConfig) {
       } catch (error) {
         const errorMessage =
           successfullyUnarchived.length > 0
-            ? `Failed to unarchive entry '${entryId}' after successfully unarchiving ${successfullyUnarchived.length} entry(s): [${successfullyUnarchived.join(', ')}]. Original error: ${error instanceof Error ? error.message : String(error)}`
-            : `Failed to unarchive entry '${entryId}': ${error instanceof Error ? error.message : String(error)}`;
+            ? `Failed to unarchive entry '${entryId}' after successfully unarchiving ${successfullyUnarchived.length} entry(s): [${successfullyUnarchived.join(', ')}]. Original error: ${formatErrorMessage(error)}`
+            : `Failed to unarchive entry '${entryId}': ${formatErrorMessage(error)}`;
 
         throw new Error(errorMessage);
       }

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/exportSpace.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../../utils/response.js';
 import { BaseToolSchema, createClientConfig } from '../../../utils/tools.js';
@@ -152,9 +153,7 @@ export function createExportSpaceTool(config: ContentfulConfig) {
         editorInterfaces: result.editorInterfaces?.length || 0,
       });
     } catch (error) {
-      throw new Error(
-        `Failed to export space: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      throw new Error(`Failed to export space: ${formatErrorMessage(error)}`);
     }
   }
 

--- a/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
+++ b/packages/mcp-tools/src/tools/jobs/space-to-space-migration/importSpace.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   createSuccessResponse,
+  formatErrorMessage,
   withErrorHandling,
 } from '../../../utils/response.js';
 import {
@@ -127,9 +128,7 @@ export function createImportSpaceTool(config: ContentfulConfig) {
         editorInterfaces: result.editorInterfaces?.length || 0,
       });
     } catch (error) {
-      throw new Error(
-        `Failed to import space: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      throw new Error(`Failed to import space: ${formatErrorMessage(error)}`);
     }
   }
 

--- a/packages/mcp-tools/src/utils/response.test.ts
+++ b/packages/mcp-tools/src/utils/response.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSdkError } from '../test-helpers/sdkError.js';
+import { createSuccessResponse, withErrorHandling } from './response.js';
+
+const fail = (error: unknown) =>
+  withErrorHandling(async () => {
+    throw error;
+  })({});
+
+describe('withErrorHandling', () => {
+  it('leaves successful responses unchanged', async () => {
+    const response = createSuccessResponse('Done', { total: 1 });
+    expect(await withErrorHandling(async () => response)({})).toBe(response);
+  });
+
+  it.each([new Error('Space not found'), 'Space not found'])(
+    'preserves ordinary error messages and the tool prefix',
+    async (error) => {
+      const handler = withErrorHandling(async () => {
+        throw error;
+      }, 'Error listing content types');
+      expect(await handler({})).toEqual({
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Error listing content types: Space not found',
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([400, 422])('omits SDK request data for HTTP %s', async (status) => {
+    const response = await fail(await createSdkError(status));
+    expect(response.isError).toBe(true);
+    expect(
+      JSON.parse(response.content[0].text.slice('Error: '.length)),
+    ).toEqual({
+      name: status === 400 ? 'BadRequest' : 'ValidationFailed',
+      status,
+      statusText: 'Bad Request',
+      message: 'Validation failed',
+      requestId: 'synthetic-request-id',
+      details: { errors: [{ name: 'unknown', path: ['fields', 'title'] }] },
+    });
+  });
+
+  it('filters a serialized SDK error thrown as a string', async () => {
+    const response = await fail(
+      JSON.stringify({
+        status: 401,
+        message: 'Access denied',
+        request: { headers: { authorization: 'synthetic-secret' } },
+      }),
+    );
+    expect(
+      JSON.parse(response.content[0].text.slice('Error: '.length)),
+    ).toEqual({
+      status: 401,
+      message: 'Access denied',
+    });
+  });
+
+  it.each([
+    '{"request":{"headers":{"Authorization":"synthetic-secret"}}',
+    '[{"request":{"headers":{"Cookie":"synthetic-secret"}}}]',
+    '{"request":{"headers":{"Authorization":"synthetic-secret"}}}',
+  ])('does not fall back to raw structured error text', async (message) => {
+    expect((await fail(new Error(message))).content[0].text).toBe(
+      'Error: Request failed.',
+    );
+  });
+});

--- a/packages/mcp-tools/src/utils/response.test.ts
+++ b/packages/mcp-tools/src/utils/response.test.ts
@@ -1,0 +1,149 @@
+import * as contentful from 'contentful-management';
+import { describe, expect, it } from 'vitest';
+
+import { createSuccessResponse, withErrorHandling } from './response.js';
+
+describe('withErrorHandling', () => {
+  it('leaves successful responses unchanged', async () => {
+    const response = createSuccessResponse('Done', { total: 1 });
+    const handler = withErrorHandling(async () => response);
+
+    expect(await handler({})).toBe(response);
+  });
+
+  it.each([new Error('Space not found'), 'Space not found'])(
+    'preserves ordinary error messages and the tool prefix',
+    async (error) => {
+      const handler = withErrorHandling(async () => {
+        throw error;
+      }, 'Error listing content types');
+
+      expect(await handler({})).toEqual({
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: 'Error listing content types: Space not found',
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    {
+      status: 422,
+      name: 'ValidationFailed',
+      message: 'No field with id "internalName" found.',
+    },
+    {
+      status: 400,
+      name: 'BadRequest',
+      message: 'Select is only applicable for Entries and Assets.',
+    },
+  ])('omits SDK request data for HTTP $status', async (failure) => {
+    const client = contentful.createClient(
+      {
+        accessToken: 'synthetic-token-ABCDE',
+        host: 'contentful.invalid',
+        retryOnError: false,
+        headers: {
+          Cookie: 'synthetic-cookie',
+          'Proxy-Authorization': 'synthetic-proxy-credential',
+          'X-Contentful-Resource-Resolution': 'synthetic-resolution-UVWXY',
+          'X-Custom-Secret': 'synthetic-custom-secret',
+        },
+        adapter: async (config) => {
+          throw {
+            config: { ...config, data: 'synthetic-request-payload' },
+            response: {
+              status: failure.status,
+              statusText: 'Bad Request',
+              data: {
+                sys: { id: failure.name, type: 'Error' },
+                message: failure.message,
+                requestId: 'synthetic-request-id',
+                details: {
+                  errors: [
+                    {
+                      name: 'unknown',
+                      path: ['fields', 'internalName'],
+                      value: 'synthetic-invalid-field-value',
+                    },
+                  ],
+                  request: {
+                    headers: { Authorization: 'synthetic-nested-secret' },
+                  },
+                },
+              },
+            },
+          };
+        },
+      },
+      { type: 'plain' },
+    );
+    const handler = withErrorHandling(async () => {
+      await client.contentType.getMany({
+        spaceId: 'test-space',
+        environmentId: 'test-environment',
+      });
+      return createSuccessResponse('Unexpected success');
+    }, 'Error listing content types');
+
+    const response = await handler({});
+
+    expect(response.isError).toBe(true);
+    expect(response.content).toHaveLength(1);
+    const text = response.content[0].text;
+    expect(text).toMatch(/^Error listing content types: /);
+    expect(
+      JSON.parse(text.replace(/^Error listing content types: /, '')),
+    ).toEqual({
+      name: failure.name,
+      status: failure.status,
+      statusText: 'Bad Request',
+      message: failure.message,
+      requestId: 'synthetic-request-id',
+      details: {
+        errors: [{ name: 'unknown', path: ['fields', 'internalName'] }],
+      },
+    });
+    expect(text).not.toMatch(
+      /synthetic-(?:token|cookie|proxy|resolution|custom|request-payload|invalid|nested)|ABCDE|UVWXY|headers|payloadData/,
+    );
+  });
+
+  it('filters a serialized SDK error thrown as a string', async () => {
+    const handler = withErrorHandling(async () => {
+      throw JSON.stringify({
+        status: 401,
+        message: 'Access denied',
+        request: { headers: { authorization: 'synthetic-secret' } },
+      });
+    });
+
+    const response = await handler({});
+
+    expect(
+      JSON.parse(response.content[0].text.slice('Error: '.length)),
+    ).toEqual({
+      status: 401,
+      message: 'Access denied',
+    });
+  });
+
+  it.each([
+    '{"request":{"headers":{"Authorization":"synthetic-secret"}}',
+    '[{"request":{"headers":{"Cookie":"synthetic-secret"}}}]',
+    '{"request":{"headers":{"Authorization":"synthetic-secret"}}}',
+  ])('does not fall back to raw structured error text', async (message) => {
+    const handler = withErrorHandling(async () => {
+      throw new Error(message);
+    });
+
+    expect(await handler({})).toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'Error: Request failed.' }],
+    });
+  });
+});

--- a/packages/mcp-tools/src/utils/response.ts
+++ b/packages/mcp-tools/src/utils/response.ts
@@ -36,6 +36,74 @@ export function createSuccessResponse(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The CMA SDK serializes request headers and payloads into Error.message,
+ * including partially masked tokens. Only return diagnostic fields from that
+ * envelope; never forward the request, even when the SDK has masked it.
+ */
+function formatErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!/^\s*[[{]/.test(message)) return message;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(message);
+  } catch {
+    // A malformed or truncated envelope can still contain credentials.
+    return 'Request failed.';
+  }
+  if (!isRecord(data)) return 'Request failed.';
+
+  const diagnostics: Record<string, unknown> = {};
+  if (
+    error instanceof Error &&
+    error.name !== 'Error' &&
+    /^[A-Za-z]\w*$/.test(error.name)
+  ) {
+    diagnostics['name'] = error.name;
+  }
+  if (
+    typeof data['status'] === 'number' &&
+    Number.isInteger(data['status']) &&
+    data['status'] >= 100 &&
+    data['status'] <= 599
+  ) {
+    diagnostics['status'] = data['status'];
+  }
+  for (const key of ['statusText', 'message', 'requestId']) {
+    if (typeof data[key] === 'string' && !/^\s*[[{]/.test(data[key])) {
+      diagnostics[key] = data[key];
+    }
+  }
+  if (isRecord(data['details']) && Array.isArray(data['details']['errors'])) {
+    const errors = data['details']['errors']
+      .filter(isRecord)
+      .map((item) => {
+        const diagnostic: Record<string, unknown> = {};
+        if (typeof item['name'] === 'string') diagnostic['name'] = item['name'];
+        if (
+          Array.isArray(item['path']) &&
+          item['path'].every(
+            (part) => typeof part === 'string' || typeof part === 'number',
+          )
+        ) {
+          diagnostic['path'] = item['path'];
+        }
+        return diagnostic;
+      })
+      .filter((item) => Object.keys(item).length > 0);
+    if (errors.length > 0) diagnostics['details'] = { errors };
+  }
+
+  return Object.keys(diagnostics).length > 0
+    ? JSON.stringify(diagnostics, null, '  ')
+    : 'Request failed.';
+}
+
 /**
  * Higher-order function that wraps tool handlers with standardized error handling
  */
@@ -56,8 +124,7 @@ export function withErrorHandling<T extends Record<string, unknown>>(
     try {
       return await handler(params, extra);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error);
       return {
         isError: true,
         content: [

--- a/packages/mcp-tools/src/utils/response.ts
+++ b/packages/mcp-tools/src/utils/response.ts
@@ -36,6 +36,75 @@ export function createSuccessResponse(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The CMA SDK serializes request headers and payloads into Error.message,
+ * including partially masked tokens. Only return diagnostic fields from that
+ * envelope; never forward the request, even when the SDK has masked it.
+ * Call this before adding contextual text to an SDK error message.
+ */
+export function formatErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!/^\s*[[{]/.test(message)) return message;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(message);
+  } catch {
+    // A malformed or truncated envelope can still contain credentials.
+    return 'Request failed.';
+  }
+  if (!isRecord(data)) return 'Request failed.';
+
+  const diagnostics: Record<string, unknown> = {};
+  if (
+    error instanceof Error &&
+    error.name !== 'Error' &&
+    /^[A-Za-z]\w*$/.test(error.name)
+  ) {
+    diagnostics['name'] = error.name;
+  }
+  if (
+    typeof data['status'] === 'number' &&
+    Number.isInteger(data['status']) &&
+    data['status'] >= 100 &&
+    data['status'] <= 599
+  ) {
+    diagnostics['status'] = data['status'];
+  }
+  for (const key of ['statusText', 'message', 'requestId']) {
+    if (typeof data[key] === 'string' && !/^\s*[[{]/.test(data[key])) {
+      diagnostics[key] = data[key];
+    }
+  }
+  if (isRecord(data['details']) && Array.isArray(data['details']['errors'])) {
+    const errors = data['details']['errors']
+      .filter(isRecord)
+      .map((item) => {
+        const diagnostic: Record<string, unknown> = {};
+        if (typeof item['name'] === 'string') diagnostic['name'] = item['name'];
+        if (
+          Array.isArray(item['path']) &&
+          item['path'].every(
+            (part) => typeof part === 'string' || typeof part === 'number',
+          )
+        ) {
+          diagnostic['path'] = item['path'];
+        }
+        return diagnostic;
+      })
+      .filter((item) => Object.keys(item).length > 0);
+    if (errors.length > 0) diagnostics['details'] = { errors };
+  }
+
+  return Object.keys(diagnostics).length > 0
+    ? JSON.stringify(diagnostics, null, '  ')
+    : 'Request failed.';
+}
+
 /**
  * Higher-order function that wraps tool handlers with standardized error handling
  */
@@ -56,8 +125,7 @@ export function withErrorHandling<T extends Record<string, unknown>>(
     try {
       return await handler(params, extra);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error);
       return {
         isError: true,
         content: [

--- a/packages/mcp-tools/src/utils/wrappedErrors.test.ts
+++ b/packages/mcp-tools/src/utils/wrappedErrors.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { publishAiActionTool } from '../tools/ai-actions/publishAiAction.js';
+import { unpublishAiActionTool } from '../tools/ai-actions/unpublishAiAction.js';
+import { archiveAssetTool } from '../tools/assets/archiveAsset.js';
+import { publishAssetTool } from '../tools/assets/publishAsset.js';
+import { unarchiveAssetTool } from '../tools/assets/unarchiveAsset.js';
+import { unpublishAssetTool } from '../tools/assets/unpublishAsset.js';
+import { archiveEntryTool } from '../tools/entries/archiveEntry.js';
+import { unarchiveEntryTool } from '../tools/entries/unarchiveEntry.js';
+import {
+  createExportSpaceTool,
+  ExportSpaceToolParams,
+} from '../tools/jobs/space-to-space-migration/exportSpace.js';
+import {
+  createImportSpaceTool,
+  ImportSpaceToolParams,
+} from '../tools/jobs/space-to-space-migration/importSpace.js';
+import { createMockConfig } from '../test-helpers/mockConfig.js';
+import { createSdkError } from '../test-helpers/sdkError.js';
+import { createToolClient } from './tools.js';
+
+vi.mock('./tools.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./tools.js')>()),
+  createToolClient: vi.fn(),
+}));
+
+const { mockExport, mockImport } = vi.hoisted(() => ({
+  mockExport: vi.fn(),
+  mockImport: vi.fn(),
+}));
+vi.mock('contentful-export', () => ({ default: mockExport }));
+vi.mock('contentful-import', () => ({ default: mockImport }));
+
+const config = createMockConfig({ host: 'contentful.invalid' });
+const baseParams = { spaceId: 'test-space', environmentId: 'test-environment' };
+let error: Error;
+beforeAll(async () => {
+  error = await createSdkError();
+});
+
+function expectSanitizedDiagnostics(text: string) {
+  expect(text).toContain('Validation failed');
+  expect(text).not.toMatch(/ABCDE|synthetic-secret|headers|payloadData/);
+}
+
+describe('tools that add error context', () => {
+  it.each([
+    ['Asset publish', publishAssetTool],
+    ['Asset unpublish', unpublishAssetTool],
+    ['AI action publish', publishAiActionTool],
+    ['AI action unpublish', unpublishAiActionTool],
+  ])('%s sanitizes returned SDK errors', async (name, tool) => {
+    const reject = vi.fn().mockRejectedValue(error);
+    vi.mocked(createToolClient).mockReturnValue({
+      asset: { get: reject },
+      aiAction: { get: reject, unpublish: reject },
+    } as unknown as ReturnType<typeof createToolClient>);
+
+    const response = await tool(config)({
+      ...baseParams,
+      assetId: 'test-entity',
+      aiActionId: 'test-entity',
+    });
+
+    expectSanitizedDiagnostics(response.content[0].text);
+    expect(response.content[0].text).toContain(`${name} failed:`);
+  });
+
+  it.each([
+    ['archive entry', archiveEntryTool, 'archiving'],
+    ['unarchive entry', unarchiveEntryTool, 'unarchiving'],
+    ['archive asset', archiveAssetTool, 'archiving'],
+    ['unarchive asset', unarchiveAssetTool, 'unarchiving'],
+  ])(
+    '%s preserves partial success without leaking SDK request data',
+    async (_name, tool, progress) => {
+      const operation = vi
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValue(error);
+      vi.mocked(createToolClient).mockReturnValue({
+        entry: { archive: operation, unarchive: operation },
+        asset: { archive: operation, unarchive: operation },
+      } as unknown as ReturnType<typeof createToolClient>);
+
+      const response = await tool(config)({
+        ...baseParams,
+        entryId: ['completed-id', 'failed-id'],
+        assetId: ['completed-id', 'failed-id'],
+      });
+
+      expect(response.isError).toBe(true);
+      const text = response.content[0].text;
+      expect(text).toContain(`successfully ${progress} 1`);
+      expect(text).toContain('[completed-id]');
+      expect(text).toContain("'failed-id'");
+      expectSanitizedDiagnostics(text);
+    },
+  );
+
+  it.each([
+    {
+      name: 'export',
+      mock: mockExport,
+      run: () =>
+        createExportSpaceTool(config)(
+          ExportSpaceToolParams.parse({ ...baseParams, saveFile: false }),
+        ),
+    },
+    {
+      name: 'import',
+      mock: mockImport,
+      run: () =>
+        createImportSpaceTool(config)(
+          ImportSpaceToolParams.parse({ ...baseParams, content: {} }),
+        ),
+    },
+  ])(
+    '$name preserves migration context without leaking SDK request data',
+    async ({ name, mock, run }) => {
+      mock.mockRejectedValueOnce(error);
+
+      const response = await run();
+
+      expect(response.isError).toBe(true);
+      const text = response.content[0].text;
+      expect(text).toContain(`Failed to ${name} space: `);
+      expectSanitizedDiagnostics(text);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Keep serialized CMA SDK request data out of MCP error responses while preserving useful API diagnostics.

## Motivation and Context

During read-only MCP usage, HTTP 400/422 API failures returned a JSON-serialized SDK error containing both the API diagnostic and the originating request. The shared `withErrorHandling` wrapper currently returns `Error.message` verbatim, so that request envelope becomes part of the tool response visible to the client and potentially its conversation history.

The installed `contentful-management` SDK serializes the request URL, headers, method, and payload into the error message. Its SDK-level masking leaves part of recognized credentials visible and does not cover arbitrary credential-bearing headers. Removing the entire request envelope at the MCP boundary avoids relying on a growing denylist of header names.

This is reproduced below using the repository's pinned CMA SDK, an in-memory adapter, a deliberately invalid hostname, and synthetic credentials only. No real tokens, customer content, internal logs, or request IDs are included in this PR.

## Description

- Parse structured error messages and return an allowlisted diagnostic projection: error name, HTTP status/text, API message, request ID, and validation error names/field paths.
- Omit request URLs, all request headers, request payloads, invalid field values, and arbitrary nested details.
- Preserve the existing MCP `isError` response shape and tool-specific prefix, along with ordinary plain-text errors and successful responses.
- Return `Request failed.` for malformed/truncated JSON, arrays, or unsupported structured errors rather than falling back to raw structured text.
- Sanitize errors before archive/unarchive and migration tools add contextual text, preserving entity IDs and partial-success details.
- Sanitize errors returned as XML status data by asset and AI action publish/unpublish tools, which otherwise bypass the shared catch handler. Their existing response envelopes and entity IDs remain unchanged.
- Add regression tests through the real SDK error-construction path for HTTP 400/422 and all four returned-error paths, plus plain-text compatibility, structured-error fallbacks, and contextual wrappers.

The retained diagnostics still tell an agent what failed and where, and provide a request ID for follow-up. For example, the synthetic validation fixture produces:

```text
Error listing content types: {
  "name": "ValidationFailed",
  "status": 422,
  "statusText": "Bad Request",
  "message": "Validation failed",
  "requestId": "synthetic-request-id",
  "details": {
    "errors": [{ "name": "unknown", "path": ["fields", "title"] }]
  }
}
```

### Scope and compatibility

This is a targeted fix for serialized request envelopes, not a general-purpose secret detector: ordinary plain-text errors and API diagnostic messages are still returned. Structured error text intentionally contains fewer fields; consumers should not depend on raw request metadata in an error response. There are no tool-name, input-schema, dependency, request-header, retry, or transport changes.

The change is in `@contentful/mcp-tools`, shared by the local server and downstream hosted consumers. It does not update an already deployed hosted server; consumers need to adopt a release containing the fix. The separate API-input issues that caused the 400/422 responses are outside this PR.

## Test Plan

Validated with Node 24.14.0 and npm 11.9.0 using the committed lockfile:

- Formatter/wrapper regression suites: **19 passed**, covering direct errors and all ten contextual/returned-error call sites. Restoring the original implementation yields **16 failures and 3 compatibility passes**. The shared fixture uses the real CMA SDK with an in-memory adapter, an invalid hostname, and synthetic credentials only.
- `npm run test:run`: **679 passed** (667 tools + 12 server).
- `npm run lint`: passed with 17 existing warnings in unrelated files, no errors.
- `npm run typecheck`: passed.
- `npm run build`: passed for both packages.
- Prettier and `git diff --check`: passed.
- Normal pre-commit hooks completed, including the full test suite and type-checking.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow conventional commits
- [x] Documentation is updated where necessary (formatter rationale and compatibility details above)
- [x] PR doesn't contain any sensitive information
- [x] No tool names, input schemas, or MCP response-envelope contracts change; structured diagnostic text is intentionally reduced as described above
