### PR TITLE
feat: tag ExO MCP tool calls for Datadog attribution []

### DIFF
--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -41,6 +41,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
     organizationId: env.data.ORGANIZATION_ID,
     appId: env.data.APP_ID,
     mcpVersion: getVersion(),
+    mcpSource: 'local' as const,
     deliveryToken: env.data.CONTENTFUL_DELIVERY_TOKEN,
     hostDelivery: env.data.CONTENTFUL_DELIVERY_HOST,
     protectedEnvironments,

--- a/packages/mcp-tools/src/config/types.ts
+++ b/packages/mcp-tools/src/config/types.ts
@@ -16,6 +16,8 @@ export interface ContentfulConfig {
   appId?: string;
   /** Version number to use for MCP tool calls */
   mcpVersion: string;
+  /** Which MCP server surface is issuing the call. Threaded into the client-identifying headers for Datadog attribution. Defaults to 'local' when unset. */
+  mcpSource?: 'local' | 'remote';
   /** Contentful CDA token for exporting only published content */
   deliveryToken?: string;
   /** Contentful Delivery API host (used with deliveryToken for custom CDA endpoints) */

--- a/packages/mcp-tools/src/tools/exo/components/createComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/createComponent.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -52,7 +52,7 @@ export function createComponentTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const component = await contentfulClient.component.create(
       { spaceId: args.spaceId, environmentId: args.environmentId },

--- a/packages/mcp-tools/src/tools/exo/components/deleteComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/deleteComponent.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -46,7 +46,7 @@ export function deleteComponentTool(config: ContentfulConfig) {
       componentId: args.componentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
     const component = await contentfulClient.component.get(params);
 
     const expectedToken = buildConfirmToken(

--- a/packages/mcp-tools/src/tools/exo/components/getComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/getComponent.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetComponentToolParams = BaseToolSchema.extend({
@@ -16,7 +16,7 @@ type Params = z.infer<typeof GetComponentToolParams>;
 
 export function getComponentTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const component = await contentfulClient.component.get({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/components/listComponents.ts
+++ b/packages/mcp-tools/src/tools/exo/components/listComponents.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListComponentsToolParams>;
 
 export function listComponentsTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // CursorPaginationParams is a discriminated union (pageNext/pagePrev are
     // mutually exclusive via `?: never`), so we pick one cursor arm explicitly

--- a/packages/mcp-tools/src/tools/exo/components/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/components/mockClient.ts
@@ -43,7 +43,7 @@ vi.mock('../../../utils/tools.js', async (importOriginal) => {
   const org = await importOriginal<typeof import('../../../utils/tools.js')>();
   return {
     ...org,
-    createToolClient: mockCreateToolClient,
+    createExoToolClient: mockCreateToolClient,
   };
 });
 

--- a/packages/mcp-tools/src/tools/exo/components/publishComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/publishComponent.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function publishComponentTool(config: ContentfulConfig) {
       componentId: args.componentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the publish endpoint requires the current version.
     const current = await contentfulClient.component.get(params);

--- a/packages/mcp-tools/src/tools/exo/components/unpublishComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/unpublishComponent.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function unpublishComponentTool(config: ContentfulConfig) {
       componentId: args.componentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the unpublish endpoint requires the current version.
     const current = await contentfulClient.component.get(params);

--- a/packages/mcp-tools/src/tools/exo/components/upsertComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/upsertComponent.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -70,7 +70,7 @@ export function upsertComponentTool(config: ContentfulConfig) {
       componentId: args.componentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: fetch current state to obtain sys.version and to
     // preserve fields the caller did not supply.

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/createDataAssembly.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -48,7 +48,7 @@ export function createDataAssemblyTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const dataAssembly = await contentfulClient.dataAssembly.create(
       { spaceId: args.spaceId, environmentId: args.environmentId },

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/deleteDataAssembly.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -46,7 +46,7 @@ export function deleteDataAssemblyTool(config: ContentfulConfig) {
       dataAssemblyId: args.dataAssemblyId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
     const dataAssembly = await contentfulClient.dataAssembly.get(params);
 
     const expectedToken = buildConfirmToken(

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getDataAssembly.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetDataAssemblyToolParams = BaseToolSchema.extend({
@@ -14,7 +14,7 @@ type Params = z.infer<typeof GetDataAssemblyToolParams>;
 
 export function getDataAssemblyTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const dataAssembly = await contentfulClient.dataAssembly.get({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/getPublishedDataAssembly.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetPublishedDataAssemblyToolParams = BaseToolSchema.extend({
@@ -14,7 +14,7 @@ type Params = z.infer<typeof GetPublishedDataAssemblyToolParams>;
 
 export function getPublishedDataAssemblyTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const dataAssembly = await contentfulClient.dataAssembly.getPublished({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listDataAssemblies.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListDataAssembliesToolParams>;
 
 export function listDataAssembliesTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const dataAssemblies = await contentfulClient.dataAssembly.getMany({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/listPublishedDataAssemblies.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListPublishedDataAssembliesToolParams>;
 
 export function listPublishedDataAssembliesTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const dataAssemblies = await contentfulClient.dataAssembly.getManyPublished({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/mockClient.ts
@@ -44,7 +44,7 @@ vi.mock('../../../utils/tools.js', async (importOriginal) => {
   const org = await importOriginal<typeof import('../../../utils/tools.js')>();
   return {
     ...org,
-    createToolClient: mockCreateToolClient,
+    createExoToolClient: mockCreateToolClient,
   };
 });
 

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/publishDataAssembly.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function publishDataAssemblyTool(config: ContentfulConfig) {
       dataAssemblyId: args.dataAssemblyId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the publish endpoint requires the current version.
     const current = await contentfulClient.dataAssembly.get(params);

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/unpublishDataAssembly.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function unpublishDataAssemblyTool(config: ContentfulConfig) {
       dataAssemblyId: args.dataAssemblyId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the unpublish endpoint requires the current version.
     const current = await contentfulClient.dataAssembly.get(params);

--- a/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
+++ b/packages/mcp-tools/src/tools/exo/data-assemblies/updateDataAssembly.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -66,7 +66,7 @@ export function updateDataAssemblyTool(config: ContentfulConfig) {
       dataAssemblyId: args.dataAssemblyId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: fetch current state to preserve fields the caller did not supply.
     const current = await contentfulClient.dataAssembly.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/createExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/createExperienceFragment.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -53,7 +53,7 @@ export function createExperienceFragmentTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceFragment = await contentfulClient.experienceFragment.create(
       { spaceId: args.spaceId, environmentId: args.environmentId },

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/deleteExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/deleteExperienceFragment.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -48,7 +48,7 @@ export function deleteExperienceFragmentTool(config: ContentfulConfig) {
       experienceFragmentId: args.experienceFragmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
     const experienceFragment =
       await contentfulClient.experienceFragment.get(params);
 

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/getExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/getExperienceFragment.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetExperienceFragmentToolParams = BaseToolSchema.extend({
@@ -16,7 +16,7 @@ type Params = z.infer<typeof GetExperienceFragmentToolParams>;
 
 export function getExperienceFragmentTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceFragment = await contentfulClient.experienceFragment.get({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/listExperienceFragments.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/listExperienceFragments.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListExperienceFragmentsToolParams>;
 
 export function listExperienceFragmentsTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceFragments =
       await contentfulClient.experienceFragment.getMany({

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/mockClient.ts
@@ -38,7 +38,7 @@ vi.mock('../../../utils/tools.js', async (importOriginal) => {
   const org = await importOriginal<typeof import('../../../utils/tools.js')>();
   return {
     ...org,
-    createToolClient: mockCreateToolClient,
+    createExoToolClient: mockCreateToolClient,
   };
 });
 

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/publishExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/publishExperienceFragment.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -39,7 +39,7 @@ export function publishExperienceFragmentTool(config: ContentfulConfig) {
       experienceFragmentId: args.experienceFragmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the publish endpoint requires the current version.
     const current = await contentfulClient.experienceFragment.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/unpublishExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/unpublishExperienceFragment.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -39,7 +39,7 @@ export function unpublishExperienceFragmentTool(config: ContentfulConfig) {
       experienceFragmentId: args.experienceFragmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the unpublish endpoint requires the current version.
     const current = await contentfulClient.experienceFragment.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-fragments/updateExperienceFragment.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-fragments/updateExperienceFragment.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -69,7 +69,7 @@ export function updateExperienceFragmentTool(config: ContentfulConfig) {
       experienceFragmentId: args.experienceFragmentId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: fetch current state to preserve fields the caller did not supply.
     const current = await contentfulClient.experienceFragment.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-templates/createExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/createExperienceTemplate.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -54,7 +54,7 @@ export function createExperienceTemplateTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceTemplate = await contentfulClient.experienceTemplate.create(
       { spaceId: args.spaceId, environmentId: args.environmentId },

--- a/packages/mcp-tools/src/tools/exo/experience-templates/deleteExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/deleteExperienceTemplate.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -48,7 +48,7 @@ export function deleteExperienceTemplateTool(config: ContentfulConfig) {
       experienceTemplateId: args.experienceTemplateId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
     const experienceTemplate =
       await contentfulClient.experienceTemplate.get(params);
 

--- a/packages/mcp-tools/src/tools/exo/experience-templates/getExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/getExperienceTemplate.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetExperienceTemplateToolParams = BaseToolSchema.extend({
@@ -16,7 +16,7 @@ type Params = z.infer<typeof GetExperienceTemplateToolParams>;
 
 export function getExperienceTemplateTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceTemplate = await contentfulClient.experienceTemplate.get({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/experience-templates/listExperienceTemplates.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/listExperienceTemplates.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListExperienceTemplatesToolParams>;
 
 export function listExperienceTemplatesTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experienceTemplates =
       await contentfulClient.experienceTemplate.getMany({

--- a/packages/mcp-tools/src/tools/exo/experience-templates/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/mockClient.ts
@@ -43,7 +43,7 @@ vi.mock('../../../utils/tools.js', async (importOriginal) => {
   const org = await importOriginal<typeof import('../../../utils/tools.js')>();
   return {
     ...org,
-    createToolClient: mockCreateToolClient,
+    createExoToolClient: mockCreateToolClient,
   };
 });
 

--- a/packages/mcp-tools/src/tools/exo/experience-templates/publishExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/publishExperienceTemplate.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -39,7 +39,7 @@ export function publishExperienceTemplateTool(config: ContentfulConfig) {
       experienceTemplateId: args.experienceTemplateId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the publish endpoint requires the current version.
     const current = await contentfulClient.experienceTemplate.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-templates/unpublishExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/unpublishExperienceTemplate.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -39,7 +39,7 @@ export function unpublishExperienceTemplateTool(config: ContentfulConfig) {
       experienceTemplateId: args.experienceTemplateId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the unpublish endpoint requires the current version.
     const current = await contentfulClient.experienceTemplate.get(params);

--- a/packages/mcp-tools/src/tools/exo/experience-templates/upsertExperienceTemplate.ts
+++ b/packages/mcp-tools/src/tools/exo/experience-templates/upsertExperienceTemplate.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -75,7 +75,7 @@ export function upsertExperienceTemplateTool(config: ContentfulConfig) {
       experienceTemplateId: args.experienceTemplateId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: fetch current state to obtain sys.version and to
     // preserve fields the caller did not supply.

--- a/packages/mcp-tools/src/tools/exo/experiences/createExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/createExperience.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -56,7 +56,7 @@ export function createExperienceTool(config: ContentfulConfig) {
       config.protectedEnvironments,
     );
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experience = await contentfulClient.experience.create(
       { spaceId: args.spaceId, environmentId: args.environmentId },

--- a/packages/mcp-tools/src/tools/exo/experiences/deleteExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/deleteExperience.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -46,7 +46,7 @@ export function deleteExperienceTool(config: ContentfulConfig) {
       experienceId: args.experienceId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
     const experience = await contentfulClient.experience.get(params);
 
     const expectedToken = buildConfirmToken(

--- a/packages/mcp-tools/src/tools/exo/experiences/getExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/getExperience.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const GetExperienceToolParams = BaseToolSchema.extend({
@@ -14,7 +14,7 @@ type Params = z.infer<typeof GetExperienceToolParams>;
 
 export function getExperienceTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experience = await contentfulClient.experience.get({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/experiences/listExperiences.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/listExperiences.ts
@@ -3,7 +3,7 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../../utils/response.js';
-import { BaseToolSchema, createToolClient } from '../../../utils/tools.js';
+import { BaseToolSchema, createExoToolClient } from '../../../utils/tools.js';
 import { summarizeData } from '../../../utils/summarizer.js';
 import type { ContentfulConfig } from '../../../config/types.js';
 
@@ -30,7 +30,7 @@ type Params = z.infer<typeof ListExperiencesToolParams>;
 
 export function listExperiencesTool(config: ContentfulConfig) {
   async function tool(args: Params) {
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     const experiences = await contentfulClient.experience.getMany({
       spaceId: args.spaceId,

--- a/packages/mcp-tools/src/tools/exo/experiences/mockClient.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/mockClient.ts
@@ -38,7 +38,7 @@ vi.mock('../../../utils/tools.js', async (importOriginal) => {
   const org = await importOriginal<typeof import('../../../utils/tools.js')>();
   return {
     ...org,
-    createToolClient: mockCreateToolClient,
+    createExoToolClient: mockCreateToolClient,
   };
 });
 

--- a/packages/mcp-tools/src/tools/exo/experiences/publishExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/publishExperience.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function publishExperienceTool(config: ContentfulConfig) {
       experienceId: args.experienceId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the publish endpoint requires the current version.
     const current = await contentfulClient.experience.get(params);

--- a/packages/mcp-tools/src/tools/exo/experiences/unpublishExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/unpublishExperience.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import type { ContentfulConfig } from '../../../config/types.js';
@@ -37,7 +37,7 @@ export function unpublishExperienceTool(config: ContentfulConfig) {
       experienceId: args.experienceId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: the unpublish endpoint requires the current version.
     const current = await contentfulClient.experience.get(params);

--- a/packages/mcp-tools/src/tools/exo/experiences/upsertExperience.ts
+++ b/packages/mcp-tools/src/tools/exo/experiences/upsertExperience.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/response.js';
 import {
   BaseToolSchema,
-  createToolClient,
+  createExoToolClient,
   assertEnvironmentNotProtected,
 } from '../../../utils/tools.js';
 import {
@@ -66,7 +66,7 @@ export function upsertExperienceTool(config: ContentfulConfig) {
       experienceId: args.experienceId,
     };
 
-    const contentfulClient = createToolClient(config, args);
+    const contentfulClient = createExoToolClient(config, args);
 
     // Read before write: fetch current state to obtain sys.version and to
     // preserve fields the caller did not supply.

--- a/packages/mcp-tools/src/utils/tools.test.ts
+++ b/packages/mcp-tools/src/utils/tools.test.ts
@@ -1,5 +1,63 @@
-import { describe, it, expect } from 'vitest';
-import { assertEnvironmentNotProtected } from './tools.js';
+import { describe, it, expect, vi } from 'vitest';
+import type { ClientOptions } from 'contentful-management';
+import { createMockConfig } from '../test-helpers/mockConfig.js';
+import {
+  assertEnvironmentNotProtected,
+  createToolClient,
+  createExoToolClient,
+  createClientConfig,
+} from './tools.js';
+
+const { mockCreateClient } = vi.hoisted(() => {
+  return { mockCreateClient: vi.fn((_config: ClientOptions) => ({})) };
+});
+
+vi.mock('contentful-management', () => {
+  return {
+    default: { createClient: mockCreateClient },
+    createClient: mockCreateClient,
+  };
+});
+
+function getCapturedHeaders(): Record<string, string> {
+  const calls = mockCreateClient.mock.calls;
+  const { headers } = calls[calls.length - 1][0];
+  expect(headers).toBeDefined();
+  return headers as Record<string, string>;
+}
+
+describe('client-identifying headers', () => {
+  const args = { spaceId: 'test-space-id', environmentId: 'test-environment' };
+
+  it('createToolClient tags classic calls without the -exo marker', () => {
+    createToolClient(createMockConfig(), args);
+
+    const headers = getCapturedHeaders();
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp/0.0.0',
+    );
+    expect(headers['User-Agent']).toBe('contentful-mcp/0.0.0');
+  });
+
+  it('createExoToolClient tags ExO calls with the -exo marker on both headers', () => {
+    createExoToolClient(createMockConfig(), args);
+
+    const headers = getCapturedHeaders();
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp-exo/0.0.0',
+    );
+    expect(headers['User-Agent']).toBe('contentful-mcp-exo/0.0.0');
+  });
+
+  it('createClientConfig (org-level) uses the classic, non-exo marker', () => {
+    const config = createClientConfig(createMockConfig());
+    const headers = config.headers as Record<string, string>;
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp/0.0.0',
+    );
+    expect(headers['User-Agent']).toBe('contentful-mcp/0.0.0');
+  });
+});
 
 describe('assertEnvironmentNotProtected', () => {
   it('does nothing when protectedEnvironments is undefined', () => {

--- a/packages/mcp-tools/src/utils/tools.test.ts
+++ b/packages/mcp-tools/src/utils/tools.test.ts
@@ -34,9 +34,9 @@ describe('client-identifying headers', () => {
 
     const headers = getCapturedHeaders();
     expect(headers['X-Contentful-User-Agent-Tool']).toBe(
-      'contentful-mcp/0.0.0',
+      'contentful-mcp/local-0.0.0',
     );
-    expect(headers['User-Agent']).toBe('contentful-mcp/0.0.0');
+    expect(headers['User-Agent']).toBe('contentful-mcp/local-0.0.0');
   });
 
   it('createExoToolClient tags ExO calls with the -exo marker on both headers', () => {
@@ -44,18 +44,47 @@ describe('client-identifying headers', () => {
 
     const headers = getCapturedHeaders();
     expect(headers['X-Contentful-User-Agent-Tool']).toBe(
-      'contentful-mcp-exo/0.0.0',
+      'contentful-mcp-exo/local-0.0.0',
     );
-    expect(headers['User-Agent']).toBe('contentful-mcp-exo/0.0.0');
+    expect(headers['User-Agent']).toBe('contentful-mcp-exo/local-0.0.0');
   });
 
   it('createClientConfig (org-level) uses the classic, non-exo marker', () => {
     const config = createClientConfig(createMockConfig());
     const headers = config.headers as Record<string, string>;
     expect(headers['X-Contentful-User-Agent-Tool']).toBe(
-      'contentful-mcp/0.0.0',
+      'contentful-mcp/local-0.0.0',
     );
-    expect(headers['User-Agent']).toBe('contentful-mcp/0.0.0');
+    expect(headers['User-Agent']).toBe('contentful-mcp/local-0.0.0');
+  });
+
+  it('defaults to the local source when mcpSource is unset', () => {
+    createToolClient(createMockConfig({ mcpSource: undefined }), args);
+
+    const headers = getCapturedHeaders();
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp/local-0.0.0',
+    );
+  });
+
+  it('tags calls from the remote server with the remote source', () => {
+    createToolClient(createMockConfig({ mcpSource: 'remote' }), args);
+
+    const headers = getCapturedHeaders();
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp/remote-0.0.0',
+    );
+    expect(headers['User-Agent']).toBe('contentful-mcp/remote-0.0.0');
+  });
+
+  it('combines the remote source with the -exo marker', () => {
+    createExoToolClient(createMockConfig({ mcpSource: 'remote' }), args);
+
+    const headers = getCapturedHeaders();
+    expect(headers['X-Contentful-User-Agent-Tool']).toBe(
+      'contentful-mcp-exo/remote-0.0.0',
+    );
+    expect(headers['User-Agent']).toBe('contentful-mcp-exo/remote-0.0.0');
   });
 });
 

--- a/packages/mcp-tools/src/utils/tools.ts
+++ b/packages/mcp-tools/src/utils/tools.ts
@@ -8,26 +8,56 @@ export const BaseToolSchema = z.object({
 });
 
 /**
+ * Builds the client-identifying header value for MCP tool calls. ExO calls get a
+ * distinguishing `-exo` suffix so Datadog can filter them out from classic CMA
+ * calls on the `user-agent` header, which downstream services already capture
+ * on their APM spans (unlike this same value on `X-Contentful-User-Agent-Tool`,
+ * which today isn't captured anywhere for the ExO-backing services).
+ */
+function buildUserAgentToolValue(
+  config: ContentfulConfig,
+  options?: { exo?: boolean },
+): string {
+  return `contentful-mcp${options?.exo ? '-exo' : ''}/${config.mcpVersion}`;
+}
+
+/**
  * Creates a Contentful client configuration from ContentfulConfig
  *
  * @param config - Contentful configuration
  * @param params - Tool parameters that may include a resource
+ * @param options - Set `exo: true` for tools operating on ExO entities
  * @returns Configured Contentful client
  */
 export function createToolClient(
   config: ContentfulConfig,
   params: z.infer<typeof BaseToolSchema>,
+  options?: { exo?: boolean },
 ) {
+  const userAgentTool = buildUserAgentToolValue(config, options);
   const clientConfig: ClientOptions = {
     accessToken: config.accessToken,
     host: config.host ?? 'api.contentful.com',
     space: params.spaceId ?? config.spaceId,
     headers: {
-      'X-Contentful-User-Agent-Tool': `contentful-mcp/${config.mcpVersion}`,
+      'X-Contentful-User-Agent-Tool': userAgentTool,
+      'User-Agent': userAgentTool,
     },
   };
 
   return createClient(clientConfig);
+}
+
+/**
+ * Creates a Contentful client for tools operating on ExO entities (components, experiences,
+ * experience templates, experience fragments, data assemblies). Identical to
+ * {@link createToolClient}, only with the `-exo` marker on the client-identifying headers.
+ */
+export function createExoToolClient(
+  config: ContentfulConfig,
+  params: z.infer<typeof BaseToolSchema>,
+) {
+  return createToolClient(config, params, { exo: true });
 }
 
 /**
@@ -37,11 +67,13 @@ export function createToolClient(
  * @returns Configured Contentful client options (without space)
  */
 export function createClientConfig(config: ContentfulConfig): ClientOptions {
+  const userAgentTool = buildUserAgentToolValue(config);
   const clientConfig: ClientOptions = {
     accessToken: config.accessToken,
     host: config.host ?? 'api.contentful.com',
     headers: {
-      'X-Contentful-User-Agent-Tool': `contentful-mcp/${config.mcpVersion}`,
+      'X-Contentful-User-Agent-Tool': userAgentTool,
+      'User-Agent': userAgentTool,
     },
   };
 

--- a/packages/mcp-tools/src/utils/tools.ts
+++ b/packages/mcp-tools/src/utils/tools.ts
@@ -12,13 +12,16 @@ export const BaseToolSchema = z.object({
  * distinguishing `-exo` suffix so Datadog can filter them out from classic CMA
  * calls on the `user-agent` header, which downstream services already capture
  * on their APM spans (unlike this same value on `X-Contentful-User-Agent-Tool`,
- * which today isn't captured anywhere for the ExO-backing services).
+ * which today isn't captured anywhere for the ExO-backing services). The version
+ * segment is prefixed with `config.mcpSource` (`local` or `remote`) so Datadog can
+ * also distinguish traffic from the stdio/local server versus the hosted remote server.
  */
 function buildUserAgentToolValue(
   config: ContentfulConfig,
   options?: { exo?: boolean },
 ): string {
-  return `contentful-mcp${options?.exo ? '-exo' : ''}/${config.mcpVersion}`;
+  const source = config.mcpSource ?? 'local';
+  return `contentful-mcp${options?.exo ? '-exo' : ''}/${source}-${config.mcpVersion}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ExO entities (components, experiences, templates, fragments, data assemblies) route through `experiences-management-api` and `assemblies-management-api`, not the classic `content-management-api` that already logs `X-Contentful-User-Agent-Tool`. Neither ExO service captures that header today, so ExO usage from MCP tools has been invisible in Datadog.
- Both services already capture the standard `user-agent` header on their APM spans by default (per `@contentful/service-kit`'s Datadog middleware). `axios` only sets its own default `User-Agent` when one isn't already supplied, so setting it ourselves in `createToolClient` survives through to the origin request.
- Added `createExoToolClient` (wraps `createToolClient` with `{ exo: true }`) and switched all ExO tool files to it. Both the existing `X-Contentful-User-Agent-Tool` and the standard `User-Agent` header now carry `contentful-mcp/<version>` for classic tools and `contentful-mcp-exo/<version>` for ExO tools, so Datadog can filter ExO MCP traffic once the ExO dashboard is updated to query `@http.request.headers.user-agent:contentful-mcp-exo*` on `experiences-management-api`/`assemblies-management-api`.
- Added a further split on top of that: a new optional `mcpSource?: 'local' | 'remote'` field on `ContentfulConfig` (defaulting to `local`) prefixes the version segment, so both headers now read `contentful-mcp[-exo]/<local|remote>-<version>`. This lets Datadog also distinguish traffic from the local/stdio MCP server versus the hosted remote MCP server, independent of the classic/ExO split. The local server (`mcp-server/tools/register.ts`) explicitly passes `mcpSource: 'local'`; [contentful/remote-mcp-server#151](https://github.com/contentful/remote-mcp-server/pull/151) threads `mcpSource: 'remote'` through on the remote side once this publishes.

## Test plan
- [x] `nx test mcp-tools` — 644 tests passing, including coverage in `tools.test.ts` asserting the classic vs `-exo` header values, the default `local` source, an explicit `remote` source, and the two combined, on `createToolClient`, `createExoToolClient`, and `createClientConfig`
- [x] `nx typecheck mcp-tools` — clean
- [x] `nx lint mcp-tools` — clean (only pre-existing unrelated warnings)
- [ ] Confirm in Datadog that `contentful-mcp-exo/*` shows up on `experiences-management-api`/`assemblies-management-api` APM spans once this ships to the remote MCP server
- [ ] Confirm in Datadog that the `local-`/`remote-` prefix shows up correctly on both the local and remote MCP server deployments

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR makes MCP client-identifying headers distinguish whether traffic originated from the local or remote MCP server surface. It adds an optional source field to the shared configuration, sets the local server explicitly, and includes the source in both attribution headers alongside the existing MCP version and ExO marker.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds the optional local/remote mcpSource field to ContentfulConfig and applies a local default in tools.ts, preserving backward compatibility for callers that omit the field.</li>

<li>Changes both User-Agent and X-Contentful-User-Agent-Tool values from the previous version-only format to source-qualified values such as contentful-mcp/local-<version> or contentful-mcp/remote-<version> in tools.ts.</li>

<li>Sets mcpSource to local in register.ts so the local MCP server emits explicit local attribution, while the shared configuration remains capable of representing remote-server traffic.</li>

<li>Adds mocked client-header tests in tools.test.ts covering unset-source fallback, remote classic calls, and remote ExO calls.</li>

</ul>
</details>

</div>