### PR TITLE
feat: add content preview tools to MCP server [AIS-479]

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Below is a sample configuration:
 |                           | `list_environments`        | List environments                                |
 |                           | `create_environment`       | Create new environments                          |
 |                           | `delete_environment`       | Remove environments                              |
+| **Content Preview**       | `list_content_previews`    | List content previews and their URL templates    |
+|                           | `get_entry_preview_url`    | Resolve the draft-preview URL for an entry       |
 | **Locales**               | `list_locales`             | List all locales in your environment             |
 |                           | `get_locale`               | Retrieve specific locale information             |
 |                           | `create_locale`            | Create new locales for multi-language content    |

--- a/packages/mcp-server/src/tools/register.test.ts
+++ b/packages/mcp-server/src/tools/register.test.ts
@@ -90,6 +90,7 @@ describe('registerAllTools', () => {
     const standardToolCollections = [
       mcpTools.getAiActionTools(),
       mcpTools.getAssetTools(),
+      mcpTools.getContentPreviewTools(),
       mcpTools.getComponentTools(),
       mcpTools.getDataAssemblyTools(),
       mcpTools.getExperienceTools(),

--- a/packages/mcp-server/src/tools/register.ts
+++ b/packages/mcp-server/src/tools/register.ts
@@ -61,6 +61,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   // Classic (always-registered) tool collections
   const aiActionTools = tools.getAiActionTools();
   const assetTools = tools.getAssetTools();
+  const contentPreviewTools = tools.getContentPreviewTools();
   const contentTypeTools = tools.getContentTypeTools();
   const contextTools = tools.getContextTools();
   const editorInterfaceTools = tools.getEditorInterfaceTools();
@@ -77,6 +78,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   const allToolCollections = [
     aiActionTools,
     assetTools,
+    contentPreviewTools,
     contentTypeTools,
     contextTools,
     editorInterfaceTools,

--- a/packages/mcp-tools/src/ContentfulMcpTools.ts
+++ b/packages/mcp-tools/src/ContentfulMcpTools.ts
@@ -1,6 +1,7 @@
 import type { ContentfulConfig } from './config/types.js';
 import { createAiActionTools } from './tools/ai-actions/register.js';
 import { createAssetTools } from './tools/assets/register.js';
+import { createContentPreviewTools } from './tools/content-previews/register.js';
 import { createContentTypeTools } from './tools/content-types/register.js';
 import { createContextTools } from './tools/context/register.js';
 import { createEditorInterfaceTools } from './tools/editor-interfaces/register.js';
@@ -59,6 +60,13 @@ export class ContentfulMcpTools {
    */
   getAssetTools() {
     return createAssetTools(this.config);
+  }
+
+  /**
+   * Get content preview tools
+   */
+  getContentPreviewTools() {
+    return createContentPreviewTools(this.config);
   }
 
   /**

--- a/packages/mcp-tools/src/tools/content-previews/client.ts
+++ b/packages/mcp-tools/src/tools/content-previews/client.ts
@@ -1,0 +1,11 @@
+/**
+ * `preview_environments` is a space-level CMA endpoint that is not exposed by
+ * the `contentful-management` client yet, so it is reached through the plain
+ * client's `raw` methods. Keeping the path in one place means there is a single
+ * spot to update if the endpoint is restructured.
+ *
+ * See: https://contentful.atlassian.net/wiki/spaces/PROD/pages/4440785098
+ */
+export function previewEnvironmentsPath(spaceId: string): string {
+  return `/spaces/${spaceId}/preview_environments`;
+}

--- a/packages/mcp-tools/src/tools/content-previews/getEntryPreviewUrl.test.ts
+++ b/packages/mcp-tools/src/tools/content-previews/getEntryPreviewUrl.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getEntryPreviewUrlTool } from './getEntryPreviewUrl.js';
+import { formatResponse } from '../../utils/formatters.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+import {
+  mockArgs,
+  mockBlogPostPreview,
+  mockEntry,
+  mockEntryGet,
+  mockEntryGetMany,
+  mockLegacyPreview,
+  mockLocaleGetMany,
+  mockLocales,
+  mockRawGet,
+  previewCollection,
+  setupMockClient,
+} from './mockClient.js';
+
+vi.mock('../../utils/tools.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../utils/tools.js')>();
+  return { ...orig, createToolClient: vi.fn() };
+});
+
+describe('getEntryPreviewUrl', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    mockEntryGet.mockReset();
+    mockEntryGetMany.mockReset();
+    mockLocaleGetMany.mockReset();
+    mockRawGet.mockReset();
+    setupMockClient();
+
+    mockEntryGet.mockResolvedValue(mockEntry);
+    mockLocaleGetMany.mockResolvedValue(mockLocales);
+    mockRawGet.mockResolvedValue(previewCollection([mockBlogPostPreview]));
+  });
+
+  it('resolves the preview URL for an entry', async () => {
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockEntryGet).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      entryId: mockArgs.entryId,
+    });
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/spaces/test-space-id/preview_environments',
+      { params: { limit: 100 } },
+    );
+
+    const expected = formatResponse('Entry preview URL resolved successfully', {
+      previewUrl: 'https://example.com/en-US/blog/hello-world?secret=shhh',
+      previewId: 'preview-1',
+      previewName: 'Blog Preview',
+      contentTypeId: 'blogPost',
+      urlTemplate:
+        'https://example.com/{locale}/blog/{entry.fields.slug}?secret=shhh',
+      locale: 'en-US',
+    });
+
+    expect(result).toEqual({ content: [{ type: 'text', text: expected }] });
+  });
+
+  it('honours the requested locale', async () => {
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool({ ...mockArgs, locale: 'de-DE' });
+
+    expect(result.content[0].text).toContain(
+      'https://example.com/de-DE/blog/hello-world?secret=shhh',
+    );
+  });
+
+  it('selects the requested preview when several match', async () => {
+    mockRawGet.mockResolvedValue(
+      previewCollection([mockBlogPostPreview, mockLegacyPreview]),
+    );
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool({ ...mockArgs, previewId: 'preview-2' });
+
+    expect(result.content[0].text).toContain(
+      'https://legacy.example.com/test-entry-id',
+    );
+    expect(result.content[0].text).toContain('Legacy Preview');
+  });
+
+  it('matches configurations that only carry the deprecated contentType field', async () => {
+    mockRawGet.mockResolvedValue(previewCollection([mockLegacyPreview]));
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain(
+      'https://legacy.example.com/test-entry-id',
+    );
+  });
+
+  it('reports unresolved tokens with a warning', async () => {
+    mockRawGet.mockResolvedValue(
+      previewCollection([
+        {
+          ...mockBlogPostPreview,
+          configurations: [
+            {
+              url: 'https://example.com/{entry.fields.missing}',
+              entityType: 'ContentType',
+              entityId: 'blogPost',
+              enabled: true,
+            },
+          ],
+        },
+      ]),
+    );
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result.content[0].text).toContain('entry.fields.missing');
+    expect(result.content[0].text).toContain('Verify the link before sharing');
+  });
+
+  it('errors when no preview is configured for the content type', async () => {
+    mockRawGet.mockResolvedValue(previewCollection([]));
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      'No content preview with an enabled configuration for content type "blogPost"',
+    );
+  });
+
+  it('errors when the requested preview does not cover the content type', async () => {
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool({ ...mockArgs, previewId: 'does-not-exist' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      'Content preview "does-not-exist" has no enabled configuration',
+    );
+    expect(result.content[0].text).toContain('Blog Preview (preview-1)');
+  });
+
+  it('errors when the entry has no content type', async () => {
+    mockEntryGet.mockResolvedValue({
+      sys: { id: 'test-entry-id', type: 'Entry' },
+      fields: {},
+    });
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('has no content type');
+  });
+
+  it('errors when the environment has no locales', async () => {
+    mockLocaleGetMany.mockResolvedValue({ items: [] });
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No locales found');
+  });
+
+  it('resolves linkedBy tokens through incoming links', async () => {
+    mockRawGet.mockResolvedValue(
+      previewCollection([
+        {
+          ...mockBlogPostPreview,
+          configurations: [
+            {
+              url: 'https://example.com/{entry.linkedBy.fields.slug}/{entry.fields.slug}',
+              entityType: 'ContentType',
+              entityId: 'blogPost',
+              enabled: true,
+            },
+          ],
+        },
+      ]),
+    );
+    mockEntryGetMany.mockResolvedValue({
+      items: [{ sys: { id: 'page-1' }, fields: { slug: { 'en-US': 'blog' } } }],
+    });
+
+    const tool = getEntryPreviewUrlTool(mockConfig);
+    const result = await tool(mockArgs);
+
+    expect(mockEntryGetMany).toHaveBeenCalledWith({
+      spaceId: mockArgs.spaceId,
+      environmentId: mockArgs.environmentId,
+      query: { links_to_entry: 'test-entry-id', limit: 1 },
+    });
+    expect(result.content[0].text).toContain(
+      'https://example.com/blog/hello-world',
+    );
+  });
+});

--- a/packages/mcp-tools/src/tools/content-previews/getEntryPreviewUrl.ts
+++ b/packages/mcp-tools/src/tools/content-previews/getEntryPreviewUrl.ts
@@ -1,0 +1,155 @@
+import { z } from 'zod';
+import type { CollectionProp, EntryProps } from 'contentful-management';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { BaseToolSchema, createToolClient } from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+import { findEnabledConfiguration, type PreviewEnvironment } from './types.js';
+import { previewEnvironmentsPath } from './client.js';
+import { resolvePreviewUrl, type PreviewEntryContext } from './previewUrl.js';
+
+export const GetEntryPreviewUrlToolParams = BaseToolSchema.extend({
+  entryId: z
+    .string()
+    .describe('The ID of the entry to build a preview URL for'),
+  previewId: z
+    .string()
+    .optional()
+    .describe(
+      'ID of the content preview to use. Defaults to the first preview with an enabled configuration for the entry content type. Use list_content_previews to see the options.',
+    ),
+  locale: z
+    .string()
+    .optional()
+    .describe(
+      'Locale code substituted into the {locale} token. Defaults to the space default locale.',
+    ),
+});
+
+type Params = z.infer<typeof GetEntryPreviewUrlToolParams>;
+
+function toEntryContext(entry: EntryProps): PreviewEntryContext {
+  return {
+    sys: entry.sys as unknown as PreviewEntryContext['sys'],
+    fields: entry.fields as Record<string, unknown>,
+  };
+}
+
+export function getEntryPreviewUrlTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    const scope = {
+      spaceId: args.spaceId,
+      environmentId: args.environmentId,
+    };
+
+    const contentfulClient = createToolClient(config, args);
+
+    const entry = await contentfulClient.entry.get({
+      ...scope,
+      entryId: args.entryId,
+    });
+
+    const contentTypeId = entry.sys.contentType?.sys.id;
+    if (!contentTypeId) {
+      throw new Error(
+        `Entry "${args.entryId}" has no content type, so no preview configuration can be matched.`,
+      );
+    }
+
+    const previews = await contentfulClient.raw.get<
+      CollectionProp<PreviewEnvironment>
+    >(previewEnvironmentsPath(args.spaceId), { params: { limit: 100 } });
+
+    // Pair each preview with the configuration that matched, so the selected
+    // preview and its URL template stay together.
+    const candidates = previews.items.flatMap((preview) => {
+      const configuration = findEnabledConfiguration(preview, contentTypeId);
+      return configuration ? [{ preview, configuration }] : [];
+    });
+
+    if (candidates.length === 0) {
+      throw new Error(
+        `No content preview with an enabled configuration for content type "${contentTypeId}" exists in space "${args.spaceId}". Add one under Settings → Content Preview, or call list_content_previews to see what is configured.`,
+      );
+    }
+
+    const selected = args.previewId
+      ? candidates.find(
+          (candidate) => candidate.preview.sys.id === args.previewId,
+        )
+      : candidates[0];
+
+    if (!selected) {
+      throw new Error(
+        `Content preview "${args.previewId}" has no enabled configuration for content type "${contentTypeId}". Available previews for this content type: ${candidates
+          .map(({ preview }) => `${preview.name} (${preview.sys.id})`)
+          .join(', ')}.`,
+      );
+    }
+
+    const { preview, configuration } = selected;
+
+    const locales = await contentfulClient.locale.getMany({
+      ...scope,
+      query: { limit: 100 },
+    });
+    const defaultLocaleCode =
+      locales.items.find((locale) => locale.default)?.code ??
+      locales.items[0]?.code;
+
+    if (!defaultLocaleCode) {
+      throw new Error(
+        `No locales found for ${args.spaceId}/${args.environmentId}, so localized preview tokens cannot be resolved.`,
+      );
+    }
+
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      template: configuration.url,
+      entry: toEntryContext(entry),
+      environmentId: args.environmentId,
+      defaultLocaleCode,
+      currentLocaleCode: args.locale,
+      getEntry: async (entryId) => {
+        try {
+          return toEntryContext(
+            await contentfulClient.entry.get({ ...scope, entryId }),
+          );
+        } catch {
+          return undefined;
+        }
+      },
+      getIncomingLink: async (entryId) => {
+        try {
+          const linking = await contentfulClient.entry.getMany({
+            ...scope,
+            query: { links_to_entry: entryId, limit: 1 },
+          });
+          const first = linking.items[0];
+          return first ? toEntryContext(first) : undefined;
+        } catch {
+          return undefined;
+        }
+      },
+    });
+
+    return createSuccessResponse('Entry preview URL resolved successfully', {
+      previewUrl: url,
+      previewId: preview.sys.id,
+      previewName: preview.name,
+      contentTypeId,
+      urlTemplate: configuration.url,
+      locale: args.locale ?? defaultLocaleCode,
+      ...(unresolvedTokens.length > 0
+        ? {
+            unresolvedTokens,
+            warning:
+              'The URL still contains the tokens listed above because no value could be resolved for them. Verify the link before sharing it.',
+          }
+        : {}),
+    });
+  }
+
+  return withErrorHandling(tool, 'Error resolving entry preview URL');
+}

--- a/packages/mcp-tools/src/tools/content-previews/listContentPreviews.test.ts
+++ b/packages/mcp-tools/src/tools/content-previews/listContentPreviews.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { listContentPreviewsTool } from './listContentPreviews.js';
+import { formatResponse } from '../../utils/formatters.js';
+import { createClientConfig } from '../../utils/tools.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+import {
+  mockBlogPostPreview,
+  mockLegacyPreview,
+  previewCollection,
+} from './mockClient.js';
+
+const { mockRawGet, mockCreateClient } = vi.hoisted(() => {
+  const mockRawGet = vi.fn();
+  const mockCreateClient = vi.fn(() => ({ raw: { get: mockRawGet } }));
+  return { mockRawGet, mockCreateClient };
+});
+
+vi.mock('contentful-management', () => ({
+  default: { createClient: mockCreateClient },
+  createClient: mockCreateClient,
+}));
+
+describe('listContentPreviews', () => {
+  const mockConfig = createMockConfig();
+
+  beforeEach(() => {
+    mockRawGet.mockReset();
+  });
+
+  it('lists content previews for a space', async () => {
+    mockRawGet.mockResolvedValue(
+      previewCollection([mockBlogPostPreview, mockLegacyPreview]),
+    );
+
+    const tool = listContentPreviewsTool(mockConfig);
+    const result = await tool({ spaceId: 'test-space-id' });
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      createClientConfig(mockConfig),
+    );
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/spaces/test-space-id/preview_environments',
+      { params: { limit: 100 } },
+    );
+
+    const expected = formatResponse('Content previews retrieved successfully', {
+      contentPreviews: [
+        {
+          id: 'preview-1',
+          name: 'Blog Preview',
+          description: 'Preview blog posts',
+          configurations: [
+            {
+              contentTypeId: 'blogPost',
+              entityType: 'ContentType',
+              urlTemplate:
+                'https://example.com/{locale}/blog/{entry.fields.slug}?secret=shhh',
+              enabled: true,
+            },
+            {
+              contentTypeId: 'landingPage',
+              entityType: 'ContentType',
+              urlTemplate:
+                'https://example.com/{locale}/page/{entry.fields.slug}',
+              enabled: false,
+            },
+          ],
+        },
+        {
+          id: 'preview-2',
+          name: 'Legacy Preview',
+          description: null,
+          configurations: [
+            {
+              contentTypeId: 'blogPost',
+              entityType: 'ContentType',
+              urlTemplate: 'https://legacy.example.com/{entry_id}',
+              enabled: true,
+            },
+          ],
+        },
+      ],
+      total: 2,
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: expected }],
+    });
+  });
+
+  it('filters to previews with an enabled configuration for a content type', async () => {
+    mockRawGet.mockResolvedValue(
+      previewCollection([mockBlogPostPreview, mockLegacyPreview]),
+    );
+
+    const tool = listContentPreviewsTool(mockConfig);
+    const result = await tool({
+      spaceId: 'test-space-id',
+      contentTypeId: 'landingPage',
+    });
+
+    // `landingPage` is configured on preview-1 but disabled, so nothing matches.
+    const expected = formatResponse('Content previews retrieved successfully', {
+      contentPreviews: [],
+      total: 2,
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: expected }] });
+  });
+
+  it('passes pagination params through', async () => {
+    mockRawGet.mockResolvedValue(previewCollection([]));
+
+    const tool = listContentPreviewsTool(mockConfig);
+    await tool({ spaceId: 'test-space-id', limit: 5, skip: 10 });
+
+    expect(mockRawGet).toHaveBeenCalledWith(
+      '/spaces/test-space-id/preview_environments',
+      { params: { limit: 5, skip: 10 } },
+    );
+  });
+
+  it('reports errors from the CMA', async () => {
+    mockRawGet.mockRejectedValue(new Error('Unauthorized'));
+
+    const tool = listContentPreviewsTool(mockConfig);
+    const result = await tool({ spaceId: 'test-space-id' });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'Error listing content previews: Unauthorized',
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp-tools/src/tools/content-previews/listContentPreviews.ts
+++ b/packages/mcp-tools/src/tools/content-previews/listContentPreviews.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { createClient, type CollectionProp } from 'contentful-management';
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from '../../utils/response.js';
+import { createClientConfig } from '../../utils/tools.js';
+import type { ContentfulConfig } from '../../config/types.js';
+import {
+  configurationContentTypeId,
+  type PreviewEnvironment,
+} from './types.js';
+import { previewEnvironmentsPath } from './client.js';
+
+export const ListContentPreviewsToolParams = z.object({
+  spaceId: z.string().describe('The ID of the Contentful space'),
+  contentTypeId: z
+    .string()
+    .optional()
+    .describe(
+      'Only return previews that have an enabled configuration for this content type',
+    ),
+  limit: z
+    .number()
+    .optional()
+    .describe('Maximum number of content previews to return (default 100)'),
+  skip: z
+    .number()
+    .optional()
+    .describe('Skip this many content previews for pagination'),
+});
+
+type Params = z.infer<typeof ListContentPreviewsToolParams>;
+
+export function listContentPreviewsTool(config: ContentfulConfig) {
+  async function tool(args: Params) {
+    // Content previews are configured per space, so the client is created
+    // without a space/environment default and the path is passed explicitly.
+    const contentfulClient = createClient(createClientConfig(config));
+
+    const previews = await contentfulClient.raw.get<
+      CollectionProp<PreviewEnvironment>
+    >(previewEnvironmentsPath(args.spaceId), {
+      params: {
+        limit: args.limit ?? 100,
+        ...(args.skip ? { skip: args.skip } : {}),
+      },
+    });
+
+    const summarized = previews.items
+      .map((preview) => ({
+        id: preview.sys.id,
+        name: preview.name,
+        description: preview.description ?? null,
+        configurations: preview.configurations
+          .filter(
+            (configuration) =>
+              !args.contentTypeId ||
+              (configuration.enabled &&
+                configurationContentTypeId(configuration) ===
+                  args.contentTypeId),
+          )
+          .map((configuration) => ({
+            contentTypeId: configurationContentTypeId(configuration) ?? null,
+            entityType: configuration.entityType ?? 'ContentType',
+            urlTemplate: configuration.url,
+            enabled: configuration.enabled,
+          })),
+      }))
+      .filter(
+        (preview) => !args.contentTypeId || preview.configurations.length > 0,
+      );
+
+    return createSuccessResponse('Content previews retrieved successfully', {
+      contentPreviews: summarized,
+      total: previews.total,
+    });
+  }
+
+  return withErrorHandling(tool, 'Error listing content previews');
+}

--- a/packages/mcp-tools/src/tools/content-previews/mockClient.ts
+++ b/packages/mcp-tools/src/tools/content-previews/mockClient.ts
@@ -1,0 +1,112 @@
+import { vi } from 'vitest';
+import { createToolClient } from '../../utils/tools.js';
+import type { PreviewEnvironment } from './types.js';
+
+/** Shared mocks for content preview tool tests. */
+export const mockRawGet = vi.fn();
+export const mockEntryGet = vi.fn();
+export const mockEntryGetMany = vi.fn();
+export const mockLocaleGetMany = vi.fn();
+
+export const mockClient = {
+  raw: { get: mockRawGet },
+  entry: { get: mockEntryGet, getMany: mockEntryGetMany },
+  locale: { getMany: mockLocaleGetMany },
+};
+
+export function setupMockClient() {
+  vi.mocked(createToolClient).mockReturnValue(
+    mockClient as unknown as ReturnType<typeof createToolClient>,
+  );
+}
+
+export const mockArgs = {
+  spaceId: 'test-space-id',
+  environmentId: 'test-environment',
+  entryId: 'test-entry-id',
+};
+
+export const mockEntry = {
+  sys: {
+    id: 'test-entry-id',
+    type: 'Entry' as const,
+    version: 3,
+    contentType: {
+      sys: {
+        id: 'blogPost',
+        type: 'Link' as const,
+        linkType: 'ContentType' as const,
+      },
+    },
+  },
+  fields: {
+    slug: { 'en-US': 'hello-world' },
+  },
+};
+
+export const mockLocales = {
+  items: [
+    { code: 'en-US', default: true },
+    { code: 'de-DE', default: false },
+  ],
+};
+
+export const mockBlogPostPreview: PreviewEnvironment = {
+  sys: {
+    id: 'preview-1',
+    type: 'PreviewEnvironment',
+    version: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    space: { sys: { id: 'test-space-id', type: 'Link', linkType: 'Space' } },
+  },
+  name: 'Blog Preview',
+  description: 'Preview blog posts',
+  configurations: [
+    {
+      url: 'https://example.com/{locale}/blog/{entry.fields.slug}?secret=shhh',
+      entityType: 'ContentType',
+      entityId: 'blogPost',
+      contentType: 'blogPost',
+      enabled: true,
+      example: false,
+    },
+    {
+      url: 'https://example.com/{locale}/page/{entry.fields.slug}',
+      entityType: 'ContentType',
+      entityId: 'landingPage',
+      contentType: 'landingPage',
+      enabled: false,
+      example: false,
+    },
+  ],
+};
+
+export const mockLegacyPreview: PreviewEnvironment = {
+  sys: {
+    id: 'preview-2',
+    type: 'PreviewEnvironment',
+    version: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    space: { sys: { id: 'test-space-id', type: 'Link', linkType: 'Space' } },
+  },
+  name: 'Legacy Preview',
+  configurations: [
+    {
+      url: 'https://legacy.example.com/{entry_id}',
+      contentType: 'blogPost',
+      enabled: true,
+    },
+  ],
+};
+
+export function previewCollection(items: PreviewEnvironment[]) {
+  return {
+    sys: { type: 'Array' as const },
+    total: items.length,
+    limit: 100,
+    skip: 0,
+    items,
+  };
+}

--- a/packages/mcp-tools/src/tools/content-previews/previewUrl.test.ts
+++ b/packages/mcp-tools/src/tools/content-previews/previewUrl.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  addLocale,
+  countIncomingLinkHops,
+  resolvePreviewUrl,
+  type PreviewEntryContext,
+} from './previewUrl.js';
+
+const entry: PreviewEntryContext = {
+  sys: {
+    id: 'entry-1',
+    type: 'Entry',
+    contentType: {
+      sys: { id: 'blogPost', type: 'Link', linkType: 'ContentType' },
+    },
+  },
+  fields: {
+    slug: { 'en-US': 'hello-world', 'de-DE': 'hallo-welt' },
+    order: { 'en-US': 7 },
+    author: {
+      'en-US': { sys: { id: 'author-1', type: 'Link', linkType: 'Entry' } },
+    },
+    hero: {
+      'en-US': { sys: { id: 'asset-1', type: 'Link', linkType: 'Asset' } },
+    },
+  },
+};
+
+const base = {
+  entry,
+  environmentId: 'master',
+  defaultLocaleCode: 'en-US',
+};
+
+describe('addLocale', () => {
+  it('leaves paths without a field segment untouched', () => {
+    expect(addLocale('entry.sys.id', 'en-US')).toBe('entry.sys.id');
+    expect(addLocale('env_id', 'en-US')).toBe('env_id');
+  });
+
+  it('leaves a bare field path untouched so it can be unwrapped later', () => {
+    expect(addLocale('entry.fields.slug', 'en-US')).toBe('entry.fields.slug');
+  });
+
+  it('inserts the locale between the field name and the rest of the path', () => {
+    expect(addLocale('entry.fields.author.sys.id', 'en-US')).toBe(
+      'entry.fields.author.en-US.sys.id',
+    );
+  });
+});
+
+describe('countIncomingLinkHops', () => {
+  it('returns 0 when no linkedBy token is present', () => {
+    expect(countIncomingLinkHops('https://x.com/{entry.sys.id}')).toBe(0);
+    expect(countIncomingLinkHops('https://x.com/static')).toBe(0);
+  });
+
+  it('returns the deepest linkedBy chain in the template', () => {
+    expect(
+      countIncomingLinkHops(
+        'https://x.com/{entry.linkedBy.linkedBy.fields.slug}/{entry.linkedBy.sys.id}',
+      ),
+    ).toBe(2);
+  });
+});
+
+describe('resolvePreviewUrl', () => {
+  it('substitutes locale, env, and localized field tokens', async () => {
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template:
+        'https://example.com/{locale}/{env_id}/blog/{entry.fields.slug}?id={entry.sys.id}&secret=shhh',
+    });
+
+    expect(url).toBe(
+      'https://example.com/en-US/master/blog/hello-world?id=entry-1&secret=shhh',
+    );
+    expect(unresolvedTokens).toEqual([]);
+  });
+
+  it('uses the requested locale for {locale} but the default locale for field values', async () => {
+    const { url } = await resolvePreviewUrl({
+      ...base,
+      currentLocaleCode: 'de-DE',
+      template: 'https://example.com/{locale}/{entry.fields.slug}',
+    });
+
+    expect(url).toBe('https://example.com/de-DE/hello-world');
+  });
+
+  it('supports the legacy entry_id and entry_field tokens', async () => {
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry_id}/{entry_field.slug}',
+    });
+
+    expect(url).toBe('https://example.com/entry-1/hello-world');
+    expect(unresolvedTokens).toEqual([]);
+  });
+
+  it('stringifies non-string scalar field values', async () => {
+    const { url } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.fields.order}',
+    });
+
+    expect(url).toBe('https://example.com/7');
+  });
+
+  it('resolves one hop into a referenced entry', async () => {
+    const getEntry = vi.fn().mockResolvedValue({
+      sys: { id: 'author-1' },
+      fields: { name: { 'en-US': 'Ada' } },
+    });
+
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.fields.author.fields.name}',
+      getEntry,
+    });
+
+    expect(getEntry).toHaveBeenCalledWith('author-1');
+    expect(url).toBe('https://example.com/Ada');
+    expect(unresolvedTokens).toEqual([]);
+  });
+
+  it('reads sys off an asset link without fetching an entry', async () => {
+    const getEntry = vi.fn();
+
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.fields.hero.sys.id}',
+      getEntry,
+    });
+
+    expect(getEntry).not.toHaveBeenCalled();
+    expect(url).toBe('https://example.com/asset-1');
+    expect(unresolvedTokens).toEqual([]);
+  });
+
+  it('cannot read fields off an asset link', async () => {
+    const getEntry = vi.fn();
+
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.fields.hero.fields.title}',
+      getEntry,
+    });
+
+    expect(getEntry).not.toHaveBeenCalled();
+    expect(url).toBe('https://example.com/{entry.fields.hero.fields.title}');
+    expect(unresolvedTokens).toEqual(['entry.fields.hero.fields.title']);
+  });
+
+  it('walks incoming links for linkedBy tokens', async () => {
+    const getIncomingLink = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sys: { id: 'page-1' },
+        fields: { slug: { 'en-US': 'parent-page' } },
+      })
+      .mockResolvedValueOnce({
+        sys: { id: 'site-1' },
+        fields: { slug: { 'en-US': 'root' } },
+      });
+
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template:
+        'https://example.com/{entry.linkedBy.linkedBy.fields.slug}/{entry.linkedBy.fields.slug}/{entry.fields.slug}',
+      getIncomingLink,
+    });
+
+    expect(getIncomingLink).toHaveBeenNthCalledWith(1, 'entry-1');
+    expect(getIncomingLink).toHaveBeenNthCalledWith(2, 'page-1');
+    expect(url).toBe('https://example.com/root/parent-page/hello-world');
+    expect(unresolvedTokens).toEqual([]);
+  });
+
+  it('reports tokens it cannot resolve and leaves them in the URL', async () => {
+    const { url, unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template:
+        'https://example.com/{entry.fields.slug}?release={release.sys.id}&missing={entry.fields.nope}',
+    });
+
+    expect(url).toBe(
+      'https://example.com/hello-world?release={release.sys.id}&missing={entry.fields.nope}',
+    );
+    expect(unresolvedTokens).toEqual(['release.sys.id', 'entry.fields.nope']);
+  });
+
+  it('does not resolve a field value that is not a scalar', async () => {
+    const { unresolvedTokens } = await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.fields.author}',
+    });
+
+    expect(unresolvedTokens).toEqual(['entry.fields.author']);
+  });
+
+  it('treats replacement values literally', async () => {
+    const { url } = await resolvePreviewUrl({
+      ...base,
+      entry: {
+        ...entry,
+        fields: { slug: { 'en-US': 'a$&b' } },
+      },
+      template: 'https://example.com/{entry.fields.slug}',
+    });
+
+    expect(url).toBe('https://example.com/a$&b');
+  });
+
+  it('does not mutate the entry it was given', async () => {
+    const original = structuredClone(entry);
+
+    await resolvePreviewUrl({
+      ...base,
+      template: 'https://example.com/{entry.linkedBy.fields.slug}',
+      getIncomingLink: vi
+        .fn()
+        .mockResolvedValue({ sys: { id: 'page-1' }, fields: {} }),
+    });
+
+    expect(entry).toEqual(original);
+  });
+});

--- a/packages/mcp-tools/src/tools/content-previews/previewUrl.ts
+++ b/packages/mcp-tools/src/tools/content-previews/previewUrl.ts
@@ -1,0 +1,253 @@
+import { cloneDeep, get } from 'lodash-es';
+
+/**
+ * Resolution of Content Preview URL templates.
+ *
+ * This is a port of the token grammar the web app uses (via the internal
+ * `@contentful/experience-content-preview` package) so that MCP clients get the
+ * same link an editor would get from the Content Preview dropdown. The internal
+ * package cannot be depended on here: it is UNLICENSED and published to GitHub
+ * Packages, while this package ships to the public npm registry under MIT.
+ *
+ * One deliberate difference: the web app substitutes `<path>_NOT_FOUND` for
+ * tokens it cannot resolve. That would hand an agent a silently broken link, so
+ * unresolved tokens are left in place and reported back to the caller instead.
+ */
+
+/** `{locale}` is resolved before every other token, exactly as the web app does. */
+const LOCALE_TOKEN = /{\s*locale\s*}/g;
+/** Any `{ some.path }` token. Group 1 is the raw (possibly padded) path. */
+const TOKEN = /{(\s*([\S]+?)\s*)}/g;
+/** A whole placeholder, used only to count `linkedBy` hops. */
+const PLACEHOLDER = /\{.*?\}/g;
+const LINKED_BY = /linkedBy/g;
+/** e.g. `entry.fields.reference.en-US.sys.contentType.sys.id` */
+const NESTED_REFERENCE = /^entry\.fields\.\w+\.[a-zA-Z-]+\.(fields|sys)/;
+const NESTED_REFERENCE_PREFIX = /^entry\.fields\.\w+\.[a-zA-Z-]+\./;
+/** A second `fields.<x>.fields` hop would mean loading yet another entry. */
+const SECOND_REFERENCE_HOP = /fields\.[a-zA-Z]+\.fields/;
+
+export type PreviewEntryContext = {
+  sys: Record<string, unknown> & { id: string };
+  fields: Record<string, unknown>;
+  linkedBy?: PreviewEntryContext;
+};
+
+export type ResolvePreviewUrlOptions = {
+  /** The configured URL template. */
+  template: string;
+  entry: PreviewEntryContext;
+  environmentId: string;
+  /** Locale used to unwrap localized field values. */
+  defaultLocaleCode: string;
+  /** Locale substituted into `{locale}`. Falls back to the default locale. */
+  currentLocaleCode?: string;
+  /** Loads a linked entry by ID. Enables one hop of reference tokens. */
+  getEntry?: (entryId: string) => Promise<PreviewEntryContext | undefined>;
+  /** Loads the first entry linking to `entryId`. Enables `linkedBy` tokens. */
+  getIncomingLink?: (
+    entryId: string,
+  ) => Promise<PreviewEntryContext | undefined>;
+};
+
+export type ResolvedPreviewUrl = {
+  /** The template with every resolvable token substituted. */
+  url: string;
+  /** Token paths left in the URL because no value could be resolved. */
+  unresolvedTokens: string[];
+};
+
+type TokenContext = {
+  entry: PreviewEntryContext;
+  env_id: string;
+  /** Legacy aliases kept for parity with the web app's resolver. */
+  entry_id: string;
+  entry_field: Record<string, unknown>;
+};
+
+/**
+ * Inserts the locale into a field path, mirroring how the CMA nests localized
+ * values: `entry.fields.author.sys.id` becomes
+ * `entry.fields.author.<locale>.sys.id`. Paths that stop at the field itself
+ * (`entry.fields.slug`) are returned unchanged and unwrapped later.
+ */
+export function addLocale(path: string, locale: string): string {
+  const fieldsIndex = path.indexOf('fields');
+  if (fieldsIndex === -1) {
+    return path;
+  }
+
+  // Skip past `fields.` before looking for the separator after the field name.
+  const separatorIndex = path.indexOf('.', fieldsIndex + 'fields'.length + 1);
+  if (separatorIndex === -1) {
+    return path;
+  }
+
+  return `${path.slice(0, separatorIndex + 1)}${locale}.${path.slice(separatorIndex + 1)}`;
+}
+
+/**
+ * How many levels of incoming links the template needs. `{entry.linkedBy.sys.id}`
+ * needs one, `{entry.linkedBy.linkedBy.fields.slug}` needs two.
+ */
+export function countIncomingLinkHops(template: string): number {
+  const placeholders = template.match(PLACEHOLDER) ?? [];
+  if (placeholders.length === 0) {
+    return 0;
+  }
+
+  return Math.max(
+    ...placeholders.map(
+      (placeholder) => (placeholder.match(LINKED_BY) ?? []).length,
+    ),
+  );
+}
+
+function isEntryLink(value: unknown): value is { sys: { id: string } } {
+  const sys = (value as { sys?: { type?: string; linkType?: string } })?.sys;
+  return sys?.type === 'Link' && sys?.linkType === 'Entry';
+}
+
+function asTokenValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return undefined;
+}
+
+/**
+ * Unwraps a localized value (`{ 'en-US': 'slug' }`) and rejects anything that
+ * is not a scalar — embedding `[object Object]` in a preview link is never what
+ * the editor wants.
+ */
+function unwrapValue(
+  value: unknown,
+  defaultLocaleCode: string,
+): string | undefined {
+  if (value !== null && typeof value === 'object') {
+    return asTokenValue((value as Record<string, unknown>)[defaultLocaleCode]);
+  }
+
+  return asTokenValue(value);
+}
+
+async function readContextPath(
+  path: string,
+  context: TokenContext,
+  getEntry: ResolvePreviewUrlOptions['getEntry'],
+): Promise<unknown> {
+  if (getEntry && NESTED_REFERENCE.test(path)) {
+    const prefix = NESTED_REFERENCE_PREFIX.exec(path)?.[0];
+    // Drop the trailing dot to get the path of the reference field itself.
+    const referencePath = prefix?.slice(0, -1);
+
+    if (referencePath) {
+      const nestedPath = path.slice(referencePath.length + 1);
+
+      if (SECOND_REFERENCE_HOP.test(nestedPath)) {
+        return undefined;
+      }
+
+      const link: unknown = get(context, referencePath);
+      if (isEntryLink(link)) {
+        const nestedEntry = await getEntry(link.sys.id);
+        return nestedEntry ? get(nestedEntry, nestedPath) : undefined;
+      }
+    }
+  }
+
+  return get(context, path);
+}
+
+async function attachIncomingLinks(
+  entry: PreviewEntryContext,
+  template: string,
+  getIncomingLink: ResolvePreviewUrlOptions['getIncomingLink'],
+): Promise<void> {
+  const hops = countIncomingLinkHops(template);
+  if (hops === 0 || !getIncomingLink) {
+    return;
+  }
+
+  const seen = new Map<string, PreviewEntryContext | undefined>();
+  let current = entry;
+
+  for (let hop = 0; hop < hops; hop += 1) {
+    const entryId = current.sys.id;
+    if (!seen.has(entryId)) {
+      seen.set(entryId, await getIncomingLink(entryId));
+    }
+
+    const linkedBy = seen.get(entryId);
+    if (!linkedBy) {
+      return;
+    }
+
+    current.linkedBy = cloneDeep(linkedBy);
+    current = current.linkedBy;
+  }
+}
+
+/**
+ * Substitutes entry data into a Content Preview URL template.
+ *
+ * Supported tokens: `{locale}`, `{env_id}`, `{entry_id}`, `{entry_field.<field>}`,
+ * `{entry.sys.*}`, `{entry.fields.<field>}` (localized), one hop of reference
+ * traversal (`{entry.fields.parent.sys.id}`), and `{entry.linkedBy...}` incoming
+ * links. Timeline, release, variant, and custom-variable tokens are not
+ * resolved and are reported through `unresolvedTokens`.
+ */
+export async function resolvePreviewUrl(
+  options: ResolvePreviewUrlOptions,
+): Promise<ResolvedPreviewUrl> {
+  const {
+    template,
+    environmentId,
+    defaultLocaleCode,
+    currentLocaleCode,
+    getEntry,
+    getIncomingLink,
+  } = options;
+
+  const entry = cloneDeep(options.entry);
+  await attachIncomingLinks(entry, template, getIncomingLink);
+
+  const context: TokenContext = {
+    entry,
+    env_id: environmentId,
+    entry_id: entry.sys.id,
+    entry_field: entry.fields,
+  };
+
+  let url = template.replace(
+    LOCALE_TOKEN,
+    currentLocaleCode ?? defaultLocaleCode,
+  );
+
+  const unresolvedTokens: string[] = [];
+
+  for (const [token, rawPath] of [...url.matchAll(TOKEN)]) {
+    const path = rawPath?.trim() || token;
+    const raw = await readContextPath(
+      addLocale(path, defaultLocaleCode),
+      context,
+      getEntry,
+    );
+    const value = unwrapValue(raw, defaultLocaleCode);
+
+    if (value === undefined) {
+      if (!unresolvedTokens.includes(path)) {
+        unresolvedTokens.push(path);
+      }
+      continue;
+    }
+
+    // Replace via a function so `$&`-style sequences in field values are literal.
+    url = url.replace(token, () => value);
+  }
+
+  return { url, unresolvedTokens };
+}

--- a/packages/mcp-tools/src/tools/content-previews/register.test.ts
+++ b/packages/mcp-tools/src/tools/content-previews/register.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { createContentPreviewTools } from './register.js';
+import { ListContentPreviewsToolParams } from './listContentPreviews.js';
+import { GetEntryPreviewUrlToolParams } from './getEntryPreviewUrl.js';
+import { createMockConfig } from '../../test-helpers/mockConfig.js';
+
+describe('content preview tools collection', () => {
+  const mockConfig = createMockConfig();
+
+  it('should export createContentPreviewTools factory function', () => {
+    expect(createContentPreviewTools).toBeDefined();
+    expect(typeof createContentPreviewTools).toBe('function');
+  });
+
+  it('should create contentPreviewTools collection with correct structure', () => {
+    const tools = createContentPreviewTools(mockConfig);
+    expect(Object.keys(tools)).toHaveLength(2);
+  });
+
+  it('should have listContentPreviews tool with correct properties', () => {
+    const { listContentPreviews } = createContentPreviewTools(mockConfig);
+
+    expect(listContentPreviews.title).toBe('list_content_previews');
+    expect(listContentPreviews.inputParams).toStrictEqual(
+      ListContentPreviewsToolParams.shape,
+    );
+    expect(listContentPreviews.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+    expect(typeof listContentPreviews.tool).toBe('function');
+  });
+
+  it('should have getEntryPreviewUrl tool with correct properties', () => {
+    const { getEntryPreviewUrl } = createContentPreviewTools(mockConfig);
+
+    expect(getEntryPreviewUrl.title).toBe('get_entry_preview_url');
+    expect(getEntryPreviewUrl.inputParams).toStrictEqual(
+      GetEntryPreviewUrlToolParams.shape,
+    );
+    expect(getEntryPreviewUrl.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+    expect(typeof getEntryPreviewUrl.tool).toBe('function');
+  });
+});

--- a/packages/mcp-tools/src/tools/content-previews/register.ts
+++ b/packages/mcp-tools/src/tools/content-previews/register.ts
@@ -1,0 +1,41 @@
+import {
+  listContentPreviewsTool,
+  ListContentPreviewsToolParams,
+} from './listContentPreviews.js';
+import {
+  getEntryPreviewUrlTool,
+  GetEntryPreviewUrlToolParams,
+} from './getEntryPreviewUrl.js';
+import type { ContentfulConfig } from '../../config/types.js';
+
+export function createContentPreviewTools(config: ContentfulConfig) {
+  const listContentPreviews = listContentPreviewsTool(config);
+  const getEntryPreviewUrl = getEntryPreviewUrlTool(config);
+
+  return {
+    listContentPreviews: {
+      title: 'list_content_previews',
+      description:
+        'List the content previews (Settings → Content Preview) configured for a space, including the URL template for each content type. URL templates can contain secret tokens, so treat the output as sensitive.',
+      inputParams: ListContentPreviewsToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: listContentPreviews,
+    },
+    getEntryPreviewUrl: {
+      title: 'get_entry_preview_url',
+      description:
+        "Resolve the draft-preview URL for an entry by substituting the entry's data into the content preview URL template configured for its content type. Returns the same link an editor would get from the Content Preview dropdown in the entry editor, plus any tokens that could not be resolved.",
+      inputParams: GetEntryPreviewUrlToolParams.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      tool: getEntryPreviewUrl,
+    },
+  };
+}

--- a/packages/mcp-tools/src/tools/content-previews/types.test.ts
+++ b/packages/mcp-tools/src/tools/content-previews/types.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  configurationContentTypeId,
+  findEnabledConfiguration,
+} from './types.js';
+import { mockBlogPostPreview, mockLegacyPreview } from './mockClient.js';
+
+describe('configurationContentTypeId', () => {
+  it('prefers entityId for ContentType configurations', () => {
+    expect(
+      configurationContentTypeId({
+        url: '',
+        enabled: true,
+        entityType: 'ContentType',
+        entityId: 'blogPost',
+        contentType: 'stale',
+      }),
+    ).toBe('blogPost');
+  });
+
+  it('falls back to the deprecated contentType field', () => {
+    expect(
+      configurationContentTypeId({
+        url: '',
+        enabled: true,
+        contentType: 'blogPost',
+      }),
+    ).toBe('blogPost');
+  });
+
+  it('ignores non-content-type entities', () => {
+    expect(
+      configurationContentTypeId({
+        url: '',
+        enabled: true,
+        entityType: 'ExperienceTemplate',
+        entityId: 'layout',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('findEnabledConfiguration', () => {
+  it('returns the enabled configuration for a content type', () => {
+    expect(
+      findEnabledConfiguration(mockBlogPostPreview, 'blogPost')?.url,
+    ).toContain('/blog/');
+  });
+
+  it('skips disabled configurations', () => {
+    expect(
+      findEnabledConfiguration(mockBlogPostPreview, 'landingPage'),
+    ).toBeUndefined();
+  });
+
+  it('matches legacy configurations', () => {
+    expect(
+      findEnabledConfiguration(mockLegacyPreview, 'blogPost'),
+    ).toBeDefined();
+  });
+});

--- a/packages/mcp-tools/src/tools/content-previews/types.ts
+++ b/packages/mcp-tools/src/tools/content-previews/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Types and helpers for the Content Preview ("preview environment") CMA
+ * endpoints.
+ *
+ * `preview_environments` is a space-level endpoint that is not yet part of the
+ * official `contentful-management` client surface, so the response shapes are
+ * declared here and the endpoint is called through the plain client's `raw`
+ * methods. Keep these aligned with the CMA response if the endpoint changes.
+ */
+
+/** Entity kinds a preview configuration can be attached to. */
+export type PreviewEnvironmentEntityType =
+  | 'ContentType'
+  | 'ExperienceTemplate'
+  | 'Component'
+  | 'ExperienceTemplate:Definition'
+  | 'Component:Definition'
+  /** @deprecated superseded by `ExperienceTemplate` */
+  | 'Template'
+  /** @deprecated superseded by `Component` */
+  | 'ComponentType';
+
+export type PreviewEnvironmentConfiguration = {
+  /** URL template, e.g. `https://example.com/{locale}/{entry.fields.slug}?secret=abc`. */
+  url: string;
+  entityType?: PreviewEnvironmentEntityType;
+  entityId?: string;
+  /** @deprecated superseded by `entityType` + `entityId`; still returned by the CMA. */
+  contentType?: string | null;
+  enabled: boolean;
+  example?: boolean;
+};
+
+export type PreviewEnvironment = {
+  sys: {
+    id: string;
+    type: 'PreviewEnvironment';
+    version: number;
+    createdAt: string;
+    updatedAt: string;
+    space: { sys: { id: string; type: 'Link'; linkType: 'Space' } };
+  };
+  name: string;
+  description?: string;
+  configurations: PreviewEnvironmentConfiguration[];
+};
+
+/**
+ * Resolves the content type a configuration targets.
+ *
+ * Newer configurations use `entityType`/`entityId`; older ones only carry the
+ * deprecated `contentType`. Non-content-type entities (ExO templates and
+ * components) return `undefined` so callers can skip them.
+ */
+export function configurationContentTypeId(
+  configuration: PreviewEnvironmentConfiguration,
+): string | undefined {
+  if (configuration.entityType && configuration.entityType !== 'ContentType') {
+    return undefined;
+  }
+
+  return configuration.entityId ?? configuration.contentType ?? undefined;
+}
+
+/** Returns the enabled configuration for `contentTypeId`, if the preview has one. */
+export function findEnabledConfiguration(
+  previewEnvironment: PreviewEnvironment,
+  contentTypeId: string,
+): PreviewEnvironmentConfiguration | undefined {
+  return previewEnvironment.configurations.find(
+    (configuration) =>
+      configuration.enabled &&
+      configurationContentTypeId(configuration) === contentTypeId,
+  );
+}


### PR DESCRIPTION
[AIS-479](https://contentful.atlassian.net/browse/AIS-479)

## Summary

Chime has an internal Claude skill that sets up A/B experiments on chime.com through the Contentful MCP connector. The flow is automated end to end except the last step: handing the editor a working draft-preview link. Content Preview is configured per space (Settings → Content Preview), the URL template carries a secret token, and no tool exposed it — so the skill can neither read nor construct the link and has to tell the editor which dropdown to use instead. Chime has flagged this as a blocker.

Adds a `content-previews` tool group to `@contentful/mcp-tools`, both read-only:

- **`list_content_previews`** — reads `/spaces/{spaceId}/preview_environments` and returns each preview's URL template per content type. Optional `contentTypeId` filter.
- **`get_entry_preview_url`** — substitutes an entry's data into the matching template and returns the same link the entry editor produces, plus the preview it came from and any tokens it could not resolve.

### Notes for review

**`preview_environments` is an internal CMA endpoint.** It is not on the `contentful-management` client surface yet — the web app reaches it through `@contentful/experience-cma-utils` (`client.internal.contentPreview`), which carries a standing TODO to promote it once the endpoint is restructured ([discovery doc](https://contentful.atlassian.net/wiki/spaces/PROD/pages/4440785098/Space-+or+environment-scoped+Content+Preview+Technical+Discovery)). It is reachable with a standard CMA token, verified against a live space. The path is isolated in `client.ts` so there is one place to update if it moves.

**Token resolution is a port, not a dependency.** The web app resolves these templates via `@contentful/experience-content-preview`, but that package is UNLICENSED and published to GitHub Packages, while this one ships to public npm under MIT — depending on it would break external installs. `previewUrl.ts` ports the grammar instead, with tests covering each token form.

**One deliberate divergence from the web app:** it substitutes `<path>_NOT_FOUND` for tokens it cannot resolve. That would hand an agent a silently broken link, so unresolved tokens are left in place and reported through `unresolvedTokens` alongside a warning.

**Supported tokens:** `{locale}`, `{env_id}`, `{entry_id}`, `{entry_field.<field>}`, `{entry.sys.*}`, `{entry.fields.<field>}` (localized), one hop of reference traversal, and `{entry.linkedBy...}` incoming links. Not resolved (and reported): custom preview variables from `/live_preview/variables` (gated behind the `previewLocalization` entitlement), timeline/release/variant tokens, and ExO entity previews.

**Security surface:** both tools are read-only and add no capability beyond what the caller's CMA token already grants. Preview URL templates do embed secret tokens, which is called out in the `list_content_previews` description.

Remote server registration is a separate PR, held until this releases so its dependency can pin the published version.

## Test plan

- [x] `npm run test:run` — full suite green (134 files), 41 new tests across token resolution, both tools, type helpers, and registration
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings)
- [x] `npm run build` clean
- [x] Live-verified against a real space: `list_content_previews` returned both configured platforms with their templates; `get_entry_preview_url` resolved `https://colorful-experience-builder-…/en-US/blog/financial-tips-for-frequent-flyers?mode=preview`, matching the entry editor
- [x] Live-verified the error path: requesting a preview that has no configuration for the entry's content type reports which previews do
- [ ] Reviewer sanity-check: is reusing the internal `preview_environments` endpoint acceptable for a public OSS tool, or should this wait for official CMA support?

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-479]: https://contentful.atlassian.net/browse/AIS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds two read-only MCP tools for Content Preview: one lists preview configurations for a space, and the other builds an editor-equivalent draft-preview URL for a Contentful entry. It integrates the tools into the shared MCP tool registry and implements local token resolution so the public MIT package does not depend on the web application's internal preview package.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>The new listing tool exposes Content Preview URL templates, which may contain secret tokens, and explicitly marks the output as sensitive in the tool description; callers must therefore handle its read-only response as sensitive data in listContentPreviews.ts and register.ts.</li>

<li>The tools call the internal space-level /spaces/{spaceId}/preview_environments CMA endpoint through the client's raw API because contentful-management does not expose a typed client method for it; the endpoint path is isolated in client.ts for future replacement.</li>

<li>previewUrl.ts preserves unresolved placeholders instead of silently converting them to a broken fallback value, returns unresolvedTokens and a warning, and supports localized fields, legacy entry tokens, one-hop references, and linkedBy traversal while leaving unsupported release, timeline, variant, and custom-variable tokens unresolved.</li>

<li>The new test suite covers both tool workflows, configuration compatibility, pagination and filtering, URL token behavior, reference traversal, error handling, registration metadata, and server-wide tool collection registration.</li>

</ul>
</details>

</div>