### PR TITLE
fix: allow create_component to accept an optional ID

### DIFF
--- a/packages/mcp-tools/src/tools/exo/components/createComponent.test.ts
+++ b/packages/mcp-tools/src/tools/exo/components/createComponent.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mockComponentCreate, mockComponent } from './mockClient.js';
+import {
+  mockComponentCreate,
+  mockComponentUpsert,
+  mockComponent,
+} from './mockClient.js';
 import { createComponentTool } from './createComponent.js';
 import { formatResponse } from '../../../utils/formatters.js';
 import { createMockConfig } from '../../../test-helpers/mockConfig.js';
@@ -40,6 +44,45 @@ describe('createComponent', () => {
           type: 'text',
           text: formatResponse('Component created successfully', {
             component: mockComponent,
+          }),
+        },
+      ],
+    });
+  });
+
+  it('creates a component with a custom ID using upsert', async () => {
+    const testArgs = { ...args, componentId: 'custom-component-id' };
+    const mockComponentWithId = {
+      ...mockComponent,
+      sys: { ...mockComponent.sys, id: testArgs.componentId },
+    };
+    mockComponentUpsert.mockResolvedValue(mockComponentWithId);
+
+    const tool = createComponentTool(mockConfig);
+    const result = await tool(testArgs);
+
+    expect(mockComponentUpsert).toHaveBeenCalledWith(
+      {
+        spaceId: args.spaceId,
+        environmentId: args.environmentId,
+        componentId: testArgs.componentId,
+      },
+      {
+        sys: { id: testArgs.componentId, type: 'Component' },
+        name: 'Hero',
+        description: 'A hero section',
+        viewports: [],
+        contentProperties: [],
+        designProperties: [],
+      },
+    );
+    expect(mockComponentCreate).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: formatResponse('Component created successfully', {
+            component: mockComponentWithId,
           }),
         },
       ],

--- a/packages/mcp-tools/src/tools/exo/components/createComponent.ts
+++ b/packages/mcp-tools/src/tools/exo/components/createComponent.ts
@@ -19,6 +19,12 @@ import {
 import type { ContentfulConfig } from '../../../config/types.js';
 
 export const CreateComponentToolParams = BaseToolSchema.extend({
+  componentId: z
+    .string()
+    .optional()
+    .describe(
+      'Optional ID for the component. If provided, will use upsert (create via PUT) with this ID',
+    ),
   name: z.string().describe('The name of the component'),
   description: z.string().describe('Description of the component'),
   viewports: z
@@ -54,19 +60,35 @@ export function createComponentTool(config: ContentfulConfig) {
 
     const contentfulClient = createExoToolClient(config, args);
 
-    const component = await contentfulClient.component.create(
-      { spaceId: args.spaceId, environmentId: args.environmentId },
-      {
-        name: args.name,
-        description: args.description,
-        viewports: args.viewports,
-        contentProperties: args.contentProperties,
-        designProperties: args.designProperties,
-        ...(args.componentTree && { componentTree: args.componentTree }),
-        ...(args.slots && { slots: args.slots }),
-        ...(args.metadata && { metadata: args.metadata }),
-      },
-    );
+    const componentData = {
+      name: args.name,
+      description: args.description,
+      viewports: args.viewports,
+      contentProperties: args.contentProperties,
+      designProperties: args.designProperties,
+      ...(args.componentTree && { componentTree: args.componentTree }),
+      ...(args.slots && { slots: args.slots }),
+      ...(args.metadata && { metadata: args.metadata }),
+    };
+
+    // Create the component with or without an explicit ID. Providing an ID
+    // uses upsert (PUT) with no sys.version, which the CMA treats as a create.
+    const component = args.componentId
+      ? await contentfulClient.component.upsert(
+          {
+            spaceId: args.spaceId,
+            environmentId: args.environmentId,
+            componentId: args.componentId,
+          },
+          {
+            sys: { id: args.componentId, type: 'Component' },
+            ...componentData,
+          },
+        )
+      : await contentfulClient.component.create(
+          { spaceId: args.spaceId, environmentId: args.environmentId },
+          componentData,
+        );
 
     return createSuccessResponse('Component created successfully', {
       component,


### PR DESCRIPTION
## Summary
- Adds an optional `componentId` input to `create_component`, mirroring the existing `contentTypeId`/`id` pattern on `create_content_type` and `create_tag`.
- When `componentId` is provided, the tool calls `component.upsert` with `sys.id` set and no `sys.version`, which the CMA treats as a create-via-PUT. Without it, behavior is unchanged (`component.create`).

## Test plan
- [x] Added a test covering the `componentId` path (asserts `component.upsert` is called with the right params and `component.create` is not).
- [x] `npx vitest run packages/mcp-tools/src/tools/exo/components` — 54 tests passing.
- [x] `npx tsc --noEmit` on `packages/mcp-tools` — clean.